### PR TITLE
fix: update all stale numbers sitewide — 75 tools, 20 tables (#112)

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -44,20 +44,20 @@ export async function generateMetadata({
 		en: {
 			title: "VantagePeers \u2014 Shared Memory for Multi-Agent Claude Code",
 			description:
-				"Open source memory, messaging, and task management MCP server. 19 tables, 70 tools. Free, self-hosted on Convex.",
+				"Open source memory, messaging, and task management MCP server. 20 tables, 75 tools. Free, self-hosted on Convex.",
 			ogTitle: "VantagePeers \u2014 Shared Memory for Multi-Agent Claude Code",
 			ogDesc:
-				"Open source MCP server. 70 tools, 19 tables. Semantic memory, inter-agent messaging, task management. Free, self-hosted.",
+				"Open source MCP server. 75 tools, 20 tables. Semantic memory, inter-agent messaging, task management. Free, self-hosted.",
 		},
 		fr: {
 			title:
 				"VantagePeers \u2014 M\u00e9moire partag\u00e9e pour agents Claude Code",
 			description:
-				"Serveur MCP open source pour la m\u00e9moire, la messagerie et la gestion de t\u00e2ches multi-agents. 19 tables, 70 outils. Gratuit, auto-h\u00e9berg\u00e9 sur Convex.",
+				"Serveur MCP open source pour la m\u00e9moire, la messagerie et la gestion de t\u00e2ches multi-agents. 20 tables, 75 outils. Gratuit, auto-h\u00e9berg\u00e9 sur Convex.",
 			ogTitle:
 				"VantagePeers \u2014 M\u00e9moire partag\u00e9e pour agents Claude Code",
 			ogDesc:
-				"Serveur MCP open source. 70 outils, 19 tables. M\u00e9moire s\u00e9mantique, messagerie inter-agents, gestion de t\u00e2ches. Gratuit.",
+				"Serveur MCP open source. 75 outils, 20 tables. M\u00e9moire s\u00e9mantique, messagerie inter-agents, gestion de t\u00e2ches. Gratuit.",
 		},
 	};
 

--- a/app/docs/[lang]/[[...slug]]/page.tsx
+++ b/app/docs/[lang]/[[...slug]]/page.tsx
@@ -23,7 +23,7 @@ export default async function Page(props: {
           <MarkdownCopyButton markdownUrl={markdownUrl} />
           <ViewOptionsPopover
             markdownUrl={markdownUrl}
-            githubUrl={`https://github.com/elpiarthera/vantage-peers-site/tree/main/content/docs`}
+            githubUrl={`https://github.com/vantageos-agency/vantage-peers-site/tree/main/content/docs`}
           />
         </div>
         <DocsTitle>{page.data.title}</DocsTitle>

--- a/components/landing/peers-code.tsx
+++ b/components/landing/peers-code.tsx
@@ -15,7 +15,7 @@ const content = {
 		],
 		snippets: {
 			install: `# Clone and deploy to Convex
-git clone https://github.com/vantageos/vantage-peers
+git clone https://github.com/vantageos-agency/vantage-peers
 cd vantage-peers
 npm install
 npx convex deploy
@@ -41,7 +41,7 @@ INSTANCE_ID=pi-vps   # or pi-chromebook, tau-desktop, etc.
 # Namespaces isolate memory per project
 # global   → shared across all projects
 # project/X → scoped to project X`,
-			use: `# Store memory (70 tools available via MCP)
+			use: `# Store memory (75 tools available via MCP)
 store_memory(
   namespace="project/myapp",
   type="feedback",
@@ -82,7 +82,7 @@ create_task(
 		],
 		snippets: {
 			install: `# Cloner et déployer sur Convex
-git clone https://github.com/vantageos/vantage-peers
+git clone https://github.com/vantageos-agency/vantage-peers
 cd vantage-peers
 npm install
 npx convex deploy
@@ -108,7 +108,7 @@ INSTANCE_ID=pi-vps   # ou pi-chromebook, tau-desktop, etc.
 # Les namespaces isolent la mémoire par projet
 # global   → partage entre tous les projets
 # project/X → scope au projet X`,
-			use: `# Stocker la mémoire (70 outils disponibles via MCP)
+			use: `# Stocker la mémoire (75 outils disponibles via MCP)
 store_memory(
   namespace="project/myapp",
   type="feedback",

--- a/components/landing/peers-cta.tsx
+++ b/components/landing/peers-cta.tsx
@@ -49,7 +49,7 @@ export function PeersCta({ locale }: PeersCtaProps) {
 					transition={{ duration: 0.5, delay: 0.1 }}
 				>
 					<a
-						href="https://github.com/vantageos/vantage-peers"
+						href="https://github.com/vantageos-agency/vantage-peers"
 						target="_blank"
 						rel="noopener noreferrer"
 						className="inline-flex items-center justify-center gap-2 min-h-touch text-base px-10 rounded-4xl font-medium bg-primary text-primary-foreground hover:bg-primary/90 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring group"
@@ -77,7 +77,7 @@ export function PeersCta({ locale }: PeersCtaProps) {
 						</svg>
 					</a>
 					<a
-						href="https://github.com/vantageos/vantage-peers#readme"
+						href="https://github.com/vantageos-agency/vantage-peers#readme"
 						target="_blank"
 						rel="noopener noreferrer"
 						className="inline-flex items-center justify-center gap-2 min-h-touch text-base px-8 rounded-4xl font-medium border border-border bg-background text-foreground hover:bg-muted/50 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"

--- a/components/landing/peers-faq.tsx
+++ b/components/landing/peers-faq.tsx
@@ -25,12 +25,12 @@ const faqs = {
 		{
 			question: "How is this different from just using a SQLite file locally?",
 			answer:
-				"Three key differences: (1) Cross-machine — your agents on different computers can share memory. (2) Real-time — messages and task updates arrive instantly without polling. (3) Structured — 16 typed tables with relationships, not flat key-value storage. SQLite works until your second machine.",
+				"Three key differences: (1) Cross-machine — your agents on different computers can share memory. (2) Real-time — messages and task updates arrive instantly without polling. (3) Structured — 20 typed tables with relationships, not flat key-value storage. SQLite works until your second machine.",
 		},
 		{
 			question: "Can I use this with any AI agent, not just Claude?",
 			answer:
-				"VantagePeers exposes 70 MCP tools. Any MCP-compatible agent can use them. Claude is the primary use case because of the Claude Code / Claude Desktop MCP support, but the protocol is open.",
+				"VantagePeers exposes 75 MCP tools. Any MCP-compatible agent can use them. Claude is the primary use case because of the Claude Code / Claude Desktop MCP support, but the protocol is open.",
 		},
 		{
 			question: "What happens to my data if Convex changes pricing?",
@@ -88,13 +88,13 @@ const faqs = {
 			question:
 				"En quoi est-ce différent d'un simple fichier SQLite en local ?",
 			answer:
-				"Trois différences clés : (1) Cross-machine — vos agents sur différentes machines partagent la mémoire. (2) Temps réel — les messages et mises à jour de tâches arrivent instantanément sans polling. (3) Structure — 19 tables typées avec relations, pas de stockage clé-valeur plat. SQLite fonctionne jusqu'à la deuxième machine.",
+				"Trois différences clés : (1) Cross-machine — vos agents sur différentes machines partagent la mémoire. (2) Temps réel — les messages et mises à jour de tâches arrivent instantanément sans polling. (3) Structure — 20 tables typées avec relations, pas de stockage clé-valeur plat. SQLite fonctionne jusqu'à la deuxième machine.",
 		},
 		{
 			question:
 				"Puis-je l'utiliser avec n'importe quel agent IA, pas seulement Claude ?",
 			answer:
-				"VantagePeers expose 70 outils MCP. N'importe quel agent compatible MCP peut les utiliser. Claude est le cas d'utilisation principal en raison du support MCP de Claude Code / Claude Desktop, mais le protocole est ouvert.",
+				"VantagePeers expose 75 outils MCP. N'importe quel agent compatible MCP peut les utiliser. Claude est le cas d'utilisation principal en raison du support MCP de Claude Code / Claude Desktop, mais le protocole est ouvert.",
 		},
 		{
 			question:

--- a/components/landing/peers-features.tsx
+++ b/components/landing/peers-features.tsx
@@ -20,7 +20,7 @@ const content = {
 	en: {
 		title: "Everything agents need. Nothing you pay for.",
 		subtitle:
-			"18 database tables. 68 MCP tools. One Convex deployment. All the primitives for coordinating AI agents across machines.",
+			"20 database tables. 75 MCP tools. One Convex deployment. All the primitives for coordinating AI agents across machines.",
 		features: [
 			{
 				icon: Brain,
@@ -115,7 +115,7 @@ const content = {
 	fr: {
 		title: "Tout ce dont les agents ont besoin. Rien que vous ne payez.",
 		subtitle:
-			"18 tables de base de données. 68 outils MCP. Un déploiement Convex. Tous les primitifs pour coordonner des agents IA multi-machines.",
+			"20 tables de base de données. 75 outils MCP. Un déploiement Convex. Tous les primitifs pour coordonner des agents IA multi-machines.",
 		features: [
 			{
 				icon: Brain,

--- a/components/landing/peers-footer.tsx
+++ b/components/landing/peers-footer.tsx
@@ -84,7 +84,7 @@ export function PeersFooter({ locale, onLocaleChange }: PeersFooterProps) {
 					{/* GitHub */}
 					<div className="text-sm">
 						<a
-							href="https://github.com/vantageos/vantage-peers"
+							href="https://github.com/vantageos-agency/vantage-peers"
 							target="_blank"
 							rel="noopener noreferrer"
 							className="flex items-center gap-2 text-muted-foreground hover:text-foreground transition-colors"

--- a/components/landing/peers-header.tsx
+++ b/components/landing/peers-header.tsx
@@ -148,7 +148,7 @@ export function PeersHeader({ locale, onLocaleChange }: PeersHeaderProps) {
 							{t.langLabel}
 						</Button>
 						<a
-							href="https://github.com/vantageos/vantage-peers"
+							href="https://github.com/vantageos-agency/vantage-peers"
 							target="_blank"
 							rel="noopener noreferrer"
 							aria-label={t.githubLabel}
@@ -234,7 +234,7 @@ export function PeersHeader({ locale, onLocaleChange }: PeersHeaderProps) {
 									{t.langLabel}
 								</Button>
 								<a
-									href="https://github.com/vantageos/vantage-peers"
+									href="https://github.com/vantageos-agency/vantage-peers"
 									target="_blank"
 									rel="noopener noreferrer"
 									aria-label={t.githubLabel}

--- a/components/landing/peers-hero.tsx
+++ b/components/landing/peers-hero.tsx
@@ -14,8 +14,8 @@ const content = {
 		cta1: "View on GitHub",
 		cta2: "See How It Works",
 		stats: [
-			{ value: "16", label: "DB Tables", icon: Database },
-			{ value: "64", label: "MCP Tools", icon: Wrench },
+			{ value: "20", label: "DB Tables", icon: Database },
+			{ value: "75", label: "MCP Tools", icon: Wrench },
 			{ value: "Free", label: "FSL License", icon: CircleDollarSign },
 			{ value: "<10 min", label: "Setup", icon: Clock },
 		],
@@ -29,8 +29,8 @@ const content = {
 		cta1: "Voir sur GitHub",
 		cta2: "Comment ça marche",
 		stats: [
-			{ value: "16", label: "Tables BD", icon: Database },
-			{ value: "64", label: "Outils MCP", icon: Wrench },
+			{ value: "20", label: "Tables BD", icon: Database },
+			{ value: "75", label: "Outils MCP", icon: Wrench },
 			{ value: "Gratuit", label: "Licence FSL", icon: CircleDollarSign },
 			{ value: "<10 min", label: "Installation", icon: Clock },
 		],
@@ -113,7 +113,7 @@ export function PeersHero({ locale }: PeersHeroProps) {
 						transition={{ duration: 0.5, delay: 0.3 }}
 					>
 						<a
-							href="https://github.com/vantageos/vantage-peers"
+							href="https://github.com/vantageos-agency/vantage-peers"
 							target="_blank"
 							rel="noopener noreferrer"
 							className="inline-flex items-center justify-center gap-2 min-h-touch text-base px-8 rounded-4xl font-medium bg-primary text-primary-foreground hover:bg-primary/90 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring glow-on-hover group"

--- a/components/landing/peers-how-it-works.tsx
+++ b/components/landing/peers-how-it-works.tsx
@@ -32,7 +32,7 @@ const content = {
 				icon: Network,
 				title: "Coordinate",
 				description:
-					"Agents store memory, send messages, assign tasks — all via the 70 MCP tools. Works across machines, across sessions, across agent instances.",
+					"Agents store memory, send messages, assign tasks — all via the 75 MCP tools. Works across machines, across sessions, across agent instances.",
 				color: "text-chart-4",
 				bgColor: "bg-chart-4/10",
 			},
@@ -68,7 +68,7 @@ const content = {
 				icon: Network,
 				title: "Coordonner",
 				description:
-					"Les agents stockent la mémoire, envoient des messages, assignent des tâches — le tout via les 35 outils MCP. Fonctionne entre machines, entre sessions, entre instances d'agents.",
+					"Les agents stockent la mémoire, envoient des messages, assignent des tâches — le tout via les 75 outils MCP. Fonctionne entre machines, entre sessions, entre instances d'agents.",
 				color: "text-chart-4",
 				bgColor: "bg-chart-4/10",
 			},

--- a/components/landing/peers-pricing.tsx
+++ b/components/landing/peers-pricing.tsx
@@ -15,7 +15,7 @@ const content = {
 				period: "forever",
 				description: "Full VantagePeers. Your Convex. Your data.",
 				features: [
-					"70 MCP tools, 19 tables",
+					"75 MCP tools, 20 tables",
 					"Semantic memory + RAG search",
 					"Cross-machine messaging",
 					"Task coordination + missions",
@@ -24,7 +24,7 @@ const content = {
 					"Community support (GitHub Issues)",
 				],
 				cta: "Get Started",
-				ctaHref: "https://github.com/vantageos/vantage-peers",
+				ctaHref: "https://github.com/vantageos-agency/vantage-peers",
 				highlight: false,
 			},
 			{
@@ -74,7 +74,7 @@ const content = {
 				period: "pour toujours",
 				description: "VantagePeers complet. Votre Convex. Vos donn\u00e9es.",
 				features: [
-					"70 outils MCP, 19 tables",
+					"75 outils MCP, 20 tables",
 					"M\u00e9moire s\u00e9mantique + recherche RAG",
 					"Messagerie cross-machine",
 					"Coordination de t\u00e2ches + missions",
@@ -83,7 +83,7 @@ const content = {
 					"Support communaut\u00e9 (GitHub Issues)",
 				],
 				cta: "Commencer",
-				ctaHref: "https://github.com/vantageos/vantage-peers",
+				ctaHref: "https://github.com/vantageos-agency/vantage-peers",
 				highlight: false,
 			},
 			{

--- a/components/landing/structured-data.tsx
+++ b/components/landing/structured-data.tsx
@@ -16,8 +16,8 @@ function getOrganizationSchema(locale: string) {
 			url: `${BASE_URL}/opengraph-image`,
 		},
 		description: locale === "fr"
-			? "Serveur MCP open source pour la m\u00e9moire partag\u00e9e, la messagerie et la gestion de t\u00e2ches multi-agents Claude Code. 19 tables, 70 outils. Gratuit, auto-h\u00e9berg\u00e9 sur Convex."
-			: "Open source shared memory, messaging, and task management MCP server for multi-agent Claude Code. 19 database tables, 70 MCP tools. Free, self-hosted on Convex.",
+			? "Serveur MCP open source pour la m\u00e9moire partag\u00e9e, la messagerie et la gestion de t\u00e2ches multi-agents Claude Code. 20 tables, 75 outils. Gratuit, auto-h\u00e9berg\u00e9 sur Convex."
+			: "Open source shared memory, messaging, and task management MCP server for multi-agent Claude Code. 20 database tables, 75 MCP tools. Free, self-hosted on Convex.",
 		sameAs: [
 			"https://github.com/vantageos",
 			"https://x.com/PerelloLaurent",
@@ -28,7 +28,7 @@ function getOrganizationSchema(locale: string) {
 		contactPoint: {
 			"@type": "ContactPoint",
 			contactType: "technical support",
-			url: "https://github.com/vantageos/vantage-peers/issues",
+			url: "https://github.com/vantageos-agency/vantage-peers/issues",
 		},
 	};
 }
@@ -50,22 +50,22 @@ const webSiteSchema = {
 const webPageContent = {
 	en: {
 		name: "VantagePeers — Shared Memory for Multi-Agent Claude Code",
-		description: "Open source MCP server. 70 tools, 19 tables. Semantic memory, inter-agent messaging, task management. Free, self-hosted.",
+		description: "Open source MCP server. 75 tools, 20 tables. Semantic memory, inter-agent messaging, task management. Free, self-hosted.",
 		faq: [
 			{ q: "Is VantagePeers free to use?", a: "Yes. VantagePeers is fully open source under the FSL license. It is free, self-hosted, and has no subscription fee." },
 			{ q: "What is VantagePeers?", a: "VantagePeers is an open source MCP server that gives Claude Code agents shared memory, inter-agent messaging with read receipts, and task management. It connects multiple AI agents across machines via Convex cloud." },
-			{ q: "How many MCP tools does VantagePeers provide?", a: "VantagePeers provides 70 MCP tools across 19 database tables, covering semantic memory recall, inter-agent messaging, task management, fix pattern knowledge base, GitHub issue tracking, business unit management, mandates, recurring tasks, missions, agent diary, component registry, and cross-machine coordination." },
+			{ q: "How many MCP tools does VantagePeers provide?", a: "VantagePeers provides 75 MCP tools across 20 database tables, covering semantic memory recall, inter-agent messaging, task management, fix pattern knowledge base, GitHub issue tracking, business unit management, mandates, recurring tasks, missions, agent diary, component registry, and cross-machine coordination." },
 			{ q: "What technology does VantagePeers run on?", a: "VantagePeers is built on Convex (a real-time database) with vector embeddings powered by @convex-dev/rag. It is self-hosted and free to run." },
 			{ q: "How does VantagePeers compare to mem0 or Zep?", a: "VantagePeers replaces paid memory services like mem0 ($249/mo) and Zep ($475/mo) with a free, self-hosted alternative. Unlike claude-peers which is local-only, VantagePeers uses Convex cloud for cross-machine agent coordination." },
 		],
 	},
 	fr: {
 		name: "VantagePeers — Mémoire partagée pour agents Claude Code",
-		description: "Serveur MCP open source. 70 outils, 19 tables. Mémoire sémantique, messagerie inter-agents, gestion de tâches. Gratuit, auto-hébergé.",
+		description: "Serveur MCP open source. 75 outils, 20 tables. Mémoire sémantique, messagerie inter-agents, gestion de tâches. Gratuit, auto-hébergé.",
 		faq: [
 			{ q: "VantagePeers est-il gratuit ?", a: "Oui. VantagePeers est entièrement open source sous licence FSL. Il est gratuit, auto-hébergé, et sans abonnement." },
 			{ q: "Qu'est-ce que VantagePeers ?", a: "VantagePeers est un serveur MCP open source qui donne aux agents Claude Code une mémoire partagée, une messagerie inter-agents avec accusés de réception, et une gestion de tâches. Il connecte plusieurs agents IA sur différentes machines via Convex cloud." },
-			{ q: "Combien d'outils MCP VantagePeers fournit-il ?", a: "VantagePeers fournit 70 outils MCP répartis sur 19 tables de base de données : rappel de mémoire sémantique, messagerie inter-agents, gestion de tâches, base de connaissances de fix patterns, suivi d'issues GitHub, gestion d'unités d'affaires, mandats, tâches récurrentes, missions, journal d'agent, registre de composants, et coordination multi-machines." },
+			{ q: "Combien d'outils MCP VantagePeers fournit-il ?", a: "VantagePeers fournit 75 outils MCP répartis sur 20 tables de base de données : rappel de mémoire sémantique, messagerie inter-agents, gestion de tâches, base de connaissances de fix patterns, suivi d'issues GitHub, gestion d'unités d'affaires, mandats, tâches récurrentes, missions, journal d'agent, registre de composants, et coordination multi-machines." },
 			{ q: "Sur quelle technologie fonctionne VantagePeers ?", a: "VantagePeers est construit sur Convex (une base de données temps réel) avec des embeddings vectoriels via @convex-dev/rag. Il est auto-hébergé et gratuit." },
 			{ q: "Comment VantagePeers se compare-t-il à mem0 ou Zep ?", a: "VantagePeers remplace les services de mémoire payants comme mem0 (249$/mois) et Zep (475$/mois) par une alternative gratuite et auto-hébergée. Contrairement à claude-peers qui est local uniquement, VantagePeers utilise Convex cloud pour la coordination inter-machines." },
 		],
@@ -113,7 +113,7 @@ function getSoftwareApplicationSchema(locale: string) {
 			? "Serveur MCP de mémoire partagée, messagerie et gestion de tâches pour agents Claude Code. Construit sur Convex avec embeddings vectoriels via @convex-dev/rag."
 			: "Shared memory, messaging, and task management MCP server for multi-agent Claude Code. Built on Convex with vector embeddings via @convex-dev/rag.",
 		url: BASE_URL,
-		downloadUrl: "https://github.com/vantageos/vantage-peers",
+		downloadUrl: "https://github.com/vantageos-agency/vantage-peers",
 		softwareVersion: "1.0.0",
 		license: "https://fsl.software/",
 		offers: {
@@ -128,7 +128,7 @@ function getSoftwareApplicationSchema(locale: string) {
 			"Task management with dependencies and missions",
 			"Vector embedding search via @convex-dev/rag",
 			"Cross-machine agent coordination",
-			"70 MCP tools across 19 database tables",
+			"75 MCP tools across 20 database tables",
 			"Fix pattern knowledge base with semantic search",
 			"GitHub issue tracking integration",
 			"Agent diary and session management",

--- a/content/docs/core-concepts/architecture.fr.mdx
+++ b/content/docs/core-concepts/architecture.fr.mdx
@@ -22,14 +22,14 @@ VantagePeers est un serveur MCP adossé à Convex. Convex fournit la base de don
 │              Serveur MCP VantagePeers                    │
 │        (processus Node.js, tourne localement par agent)  │
 │                                                          │
-│  70 outils répartis en 13 catégories                     │
+│  75 outils répartis en 13 catégories                     │
 └──────────────────────────┬──────────────────────────────┘
                            │  SDK Convex
                            ▼
 ┌─────────────────────────────────────────────────────────┐
 │              Backend Cloud Convex                        │
 │                                                          │
-│  19 tables de BDD       Index vectoriels (mémoires)     │
+│  20 tables de BDD       Index vectoriels (mémoires)     │
 │  Fonctions serverless   Pipeline embeddings OpenAI      │
 │  Planificateur cron     Souscriptions temps réel        │
 └─────────────────────────────────────────────────────────┘
@@ -61,7 +61,7 @@ Lors de l'appel à `recall`, les requêtes ne cherchent que dans le namespace sp
 
 ## Schéma de base de données
 
-VantagePeers utilise 19 tables Convex. Chaque table a un schéma défini avec des validateurs typés et des index pour des requêtes efficaces.
+VantagePeers utilise 20 tables Convex. Chaque table a un schéma défini avec des validateurs typés et des index pour des requêtes efficaces.
 
 ### memories
 
@@ -195,4 +195,4 @@ VantagePeers expose toutes les capacités comme des outils MCP. Le serveur MCP t
 3. Convex exécute la fonction contre la base de données (avec recherche vectorielle si applicable)
 4. Le résultat est retourné à Claude Code comme réponse de l'outil
 
-Les 70 outils sont sans état du point de vue du serveur MCP — l'état vit dans Convex. Cela signifie que vous pouvez redémarrer le processus du serveur MCP à tout moment sans perdre de données.
+Les 75 outils sont sans état du point de vue du serveur MCP — l'état vit dans Convex. Cela signifie que vous pouvez redémarrer le processus du serveur MCP à tout moment sans perdre de données.

--- a/content/docs/core-concepts/architecture.mdx
+++ b/content/docs/core-concepts/architecture.mdx
@@ -22,14 +22,14 @@ VantagePeers is a Convex-backed MCP server. Convex provides the database, server
 │              VantagePeers MCP Server                     │
 │         (Node.js process, runs locally per agent)        │
 │                                                          │
-│  70 tools across 13 categories                           │
+│  75 tools across 13 categories                           │
 └──────────────────────────┬──────────────────────────────┘
                            │  Convex SDK
                            ▼
 ┌─────────────────────────────────────────────────────────┐
 │              Convex Cloud Backend                        │
 │                                                          │
-│  19 database tables    Vector indexes (memories)        │
+│  20 database tables    Vector indexes (memories)        │
 │  Serverless functions  OpenAI embeddings pipeline       │
 │  Cron scheduler        Real-time subscriptions          │
 └─────────────────────────────────────────────────────────┘
@@ -61,7 +61,7 @@ When calling `recall`, queries only search within the specified namespace by def
 
 ## Database Schema
 
-VantagePeers uses 13 Convex tables. Each table has a defined schema with typed validators and indexes for efficient querying.
+VantagePeers uses 20 Convex tables. Each table has a defined schema with typed validators and indexes for efficient querying.
 
 ### memories
 
@@ -195,4 +195,4 @@ VantagePeers exposes all capabilities as MCP tools. The MCP server runs as a loc
 3. Convex executes the function against the database (with vector search if applicable)
 4. The result is returned to Claude Code as the tool response
 
-All 70 tools are stateless from the MCP server's perspective — state lives in Convex. This means you can restart the MCP server process at any time without losing data.
+All 75 tools are stateless from the MCP server's perspective — state lives in Convex. This means you can restart the MCP server process at any time without losing data.

--- a/content/docs/getting-started/index.fr.mdx
+++ b/content/docs/getting-started/index.fr.mdx
@@ -21,7 +21,7 @@ Avant de commencer, vous avez besoin de :
 ### Étape 1 : Cloner le dépôt
 
 ```bash
-git clone https://github.com/elpiarthera/vantage-peers.git
+git clone https://github.com/vantageos-agency/vantage-peers.git
 cd vantage-peers
 npm install
 ```
@@ -50,7 +50,7 @@ OPENAI_API_KEY=sk-...
 npx convex deploy
 ```
 
-Cela déploie les 19 tables de base de données, les fonctions serverless et les index vectoriels sur votre compte Convex. Convex affichera votre URL de déploiement — copiez-la.
+Cela déploie les 20 tables de base de données, les fonctions serverless et les index vectoriels sur votre compte Convex. Convex affichera votre URL de déploiement — copiez-la.
 
 ### Étape 4 : Configurer le serveur MCP
 

--- a/content/docs/getting-started/index.mdx
+++ b/content/docs/getting-started/index.mdx
@@ -21,7 +21,7 @@ Before you begin, you need:
 ### Step 1: Clone the repository
 
 ```bash
-git clone https://github.com/elpiarthera/vantage-peers.git
+git clone https://github.com/vantageos-agency/vantage-peers.git
 cd vantage-peers
 npm install
 ```
@@ -50,7 +50,7 @@ OPENAI_API_KEY=sk-...
 npx convex deploy
 ```
 
-This deploys all 19 database tables, serverless functions, and vector indexes to your Convex account. Convex will output your deployment URL — copy it.
+This deploys all 20 database tables, serverless functions, and vector indexes to your Convex account. Convex will output your deployment URL — copy it.
 
 ### Step 4: Configure the MCP server
 

--- a/content/docs/getting-started/quickstart.fr.mdx
+++ b/content/docs/getting-started/quickstart.fr.mdx
@@ -10,7 +10,7 @@ Deux agents. Mémoire partagée. Messages réels. Cinq minutes.
 ## Étape 1 : Déployer le backend
 
 ```bash
-git clone https://github.com/elpiarthera/vantage-peers.git
+git clone https://github.com/vantageos-agency/vantage-peers.git
 cd vantage-peers
 npm install
 npx convex deploy
@@ -132,4 +132,4 @@ Terminé. Deux agents, mémoire partagée, messagerie réelle, accusés de réce
 - Ajoutez des [tâches](/docs/capabilities/tasks) pour que les agents puissent s'assigner du travail mutuellement
 - Configurez des [tâches récurrentes](/docs/capabilities/recurring-tasks) pour l'automatisation basée sur cron
 - Lisez l'[architecture](/docs/core-concepts/architecture) complète pour comprendre les orchestrateurs, instances et namespaces
-- Parcourez les [70 outils MCP](/docs/tools)
+- Parcourez les [75 outils MCP](/docs/tools)

--- a/content/docs/getting-started/quickstart.mdx
+++ b/content/docs/getting-started/quickstart.mdx
@@ -10,7 +10,7 @@ Two agents. Shared memory. Real messages. Five minutes.
 ## Step 1: Deploy the backend
 
 ```bash
-git clone https://github.com/elpiarthera/vantage-peers.git
+git clone https://github.com/vantageos-agency/vantage-peers.git
 cd vantage-peers
 npm install
 npx convex deploy
@@ -132,4 +132,4 @@ Done. Two agents, shared memory, real messaging, read receipts. No file hacks. N
 - Add [tasks](/docs/capabilities/tasks) so agents can assign work to each other
 - Set up [recurring tasks](/docs/capabilities/recurring-tasks) for cron-based automation
 - Read the full [architecture](/docs/core-concepts/architecture) to understand orchestrators, instances, and namespaces
-- Browse all [64 MCP tools](/docs/tools)
+- Browse all [75 MCP tools](/docs/tools)

--- a/content/docs/getting-started/supported-tools.fr.mdx
+++ b/content/docs/getting-started/supported-tools.fr.mdx
@@ -9,7 +9,7 @@ VantagePeers est un serveur MCP. Il fonctionne avec tout outil qui supporte le [
 
 ## Support MCP complet
 
-Ces outils ont un support natif du client MCP — ajoutez VantagePeers comme serveur et les 70 outils sont immédiatement disponibles.
+Ces outils ont un support natif du client MCP — ajoutez VantagePeers comme serveur et les 75 outils sont immédiatement disponibles.
 
 ### Claude Code
 
@@ -127,4 +127,4 @@ Toutes les configurations nécessitent une seule variable d'environnement :
 |----------|--------|-------------|
 | `CONVEX_URL` | `https://your-deployment.convex.cloud` | URL de votre déploiement Convex (depuis `npx convex deploy`) |
 
-Le serveur MCP la résout au démarrage. Aucune autre configuration n'est nécessaire — le serveur se connecte à votre backend Convex et expose automatiquement les 70 outils.
+Le serveur MCP la résout au démarrage. Aucune autre configuration n'est nécessaire — le serveur se connecte à votre backend Convex et expose automatiquement les 75 outils.

--- a/content/docs/getting-started/supported-tools.mdx
+++ b/content/docs/getting-started/supported-tools.mdx
@@ -9,7 +9,7 @@ VantagePeers is an MCP server. It works with any tool that supports the [Model C
 
 ## Full MCP Support
 
-These tools have native MCP client support — add VantagePeers as a server and all 70 tools are immediately available.
+These tools have native MCP client support — add VantagePeers as a server and all 75 tools are immediately available.
 
 ### Claude Code
 
@@ -241,4 +241,4 @@ All configurations require one environment variable:
 |----------|-------|-------------|
 | `CONVEX_URL` | `https://your-deployment.convex.cloud` | Your Convex deployment URL (from `npx convex deploy`) |
 
-The MCP server resolves this at startup. No other configuration is needed — the server connects to your Convex backend and exposes all 70 tools automatically.
+The MCP server resolves this at startup. No other configuration is needed — the server connects to your Convex backend and exposes all 75 tools automatically.

--- a/content/docs/index.fr.mdx
+++ b/content/docs/index.fr.mdx
@@ -1,6 +1,6 @@
 ---
 title: Documentation VantagePeers
-description: Le système d'exploitation open-source pour les équipes d'agents IA. 19 tables, 70 outils MCP, gratuit pour toujours.
+description: Le système d'exploitation open-source pour les équipes d'agents IA. 20 tables, 75 outils MCP, gratuit pour toujours.
 ---
 
 # Bienvenue sur VantagePeers
@@ -11,7 +11,7 @@ VantagePeers est le backend open-source qui donne à vos agents IA une mémoire 
 
 Quand vous exécutez plusieurs agents Claude Code sur différentes machines et sessions, ils font face à un problème de coordination : chaque agent démarre sans connaître ce que les autres ont fait, sans moyen d'envoyer des messages entre machines, et sans tableau de bord partagé. Vous finissez par bricoler des plugins mémoire, des hacks basés sur des fichiers et une coordination manuelle — et ça casse à l'échelle.
 
-VantagePeers résout ce problème en fournissant un backend auto-hébergé unique avec 19 tables de base de données et 70 outils MCP couvrant chaque primitive de coordination dont votre équipe d'agents a besoin. Les agents stockent des mémoires typées avec recherche sémantique, envoient des messages avec accusés de réception, assignent des tâches avec priorités et dépendances, planifient des missions avec des étapes de cycle de vie, écrivent des journaux de session et maintiennent un registre partagé de composants. Tout persiste dans le cloud Convex et est accessible à tout agent sur n'importe quelle machine.
+VantagePeers résout ce problème en fournissant un backend auto-hébergé unique avec 20 tables de base de données et 75 outils MCP couvrant chaque primitive de coordination dont votre équipe d'agents a besoin. Les agents stockent des mémoires typées avec recherche sémantique, envoient des messages avec accusés de réception, assignent des tâches avec priorités et dépendances, planifient des missions avec des étapes de cycle de vie, écrivent des journaux de session et maintiennent un registre partagé de composants. Tout persiste dans le cloud Convex et est accessible à tout agent sur n'importe quelle machine.
 
 Ce n'est pas un SaaS. Ce n'est pas un service managé. Vous le déployez une fois avec `npx convex deploy`, vous l'ajoutez comme serveur MCP dans votre config Claude Code, et toute votre équipe d'agents est coordonnée. Licence FSL. Gratuit pour toujours.
 
@@ -22,15 +22,15 @@ Ce n'est pas un SaaS. Ce n'est pas un service managé. Vous le déployez une foi
 | [Démarrage](/docs/getting-started) | Installer, déployer et connecter en moins de 10 minutes |
 | [Quickstart](/docs/getting-started/quickstart) | Deux agents qui échangent des messages en 5 minutes |
 | [Architecture](/docs/core-concepts/architecture) | Concepts clés, schéma de base de données et intégration MCP |
-| [Référence des outils](/docs/tools) | Les 13 catégories et 70 outils |
+| [Référence des outils](/docs/tools) | Les 13 catégories et 75 outils |
 | [Mémoire](/docs/capabilities/memory) | Mémoire sémantique, namespaces et recherche vectorielle |
 | [Messagerie](/docs/capabilities/messaging) | Messagerie inter-machines avec accusés de réception |
 | [Tâches](/docs/capabilities/tasks) | Cycle de vie des tâches, priorités, missions et cron |
 
 ## Chiffres clés
 
-- **19 tables de base de données** — mémoires, messages, tâches, missions, profils, journal, briefings, composants, patterns de fix, issues, mandats, unités commerciales, et plus
-- **70 outils MCP** — chaque primitive de coordination exposée comme outil MCP natif
+- **20 tables de base de données** — mémoires, messages, tâches, missions, profils, journal, briefings, composants, patterns de fix, issues, mandats, unités commerciales, et plus
+- **75 outils MCP** — chaque primitive de coordination exposée comme outil MCP natif
 - **13 catégories de capacités** — mémoire, messagerie, tâches, missions, profils, journal, registre, patterns de fix, issues, mandats, unités commerciales, tâches récurrentes, monitoring d'erreurs
 - **< 10 minutes** — de zéro à une équipe d'agents pleinement coordonnée
 - **0 € / mois** — licence FSL, auto-hébergé sur le tier gratuit de Convex

--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: VantagePeers Documentation
-description: The open-source operating system for AI agent teams. 19 database tables, 70 MCP tools, free forever.
+description: The open-source operating system for AI agent teams. 20 database tables, 75 MCP tools, free forever.
 ---
 
 # Welcome to VantagePeers
@@ -11,7 +11,7 @@ VantagePeers is the open-source backend that gives your AI agents shared memory,
 
 When you run multiple Claude Code agents across machines and sessions, they face a coordination problem: each agent starts fresh with no knowledge of what others have done, no way to send messages across machines, and no shared task board. You end up duct-taping together memory plugins, file-based hacks, and manual coordination — and it breaks at scale.
 
-VantagePeers solves this by providing a single self-hosted backend with 19 database tables and 70 MCP tools covering every coordination primitive your agent team needs. Agents store typed memories with semantic search, send messages with read receipts, assign tasks with priorities and dependencies, plan missions with lifecycle stages, write session diaries, and maintain a shared component registry. All of it persists in Convex cloud and is available to any agent on any machine.
+VantagePeers solves this by providing a single self-hosted backend with 20 database tables and 75 MCP tools covering every coordination primitive your agent team needs. Agents store typed memories with semantic search, send messages with read receipts, assign tasks with priorities and dependencies, plan missions with lifecycle stages, write session diaries, and maintain a shared component registry. All of it persists in Convex cloud and is available to any agent on any machine.
 
 It is not a SaaS. It is not a managed service. You deploy it once with `npx convex deploy`, add it as an MCP server in your Claude Code config, and your entire agent team is coordinated. FSL license. Free forever.
 
@@ -22,15 +22,15 @@ It is not a SaaS. It is not a managed service. You deploy it once with `npx conv
 | [Getting Started](/docs/getting-started) | Install, deploy, and connect in under 10 minutes |
 | [Quickstart](/docs/getting-started/quickstart) | Two agents exchanging messages in 5 minutes |
 | [Architecture](/docs/core-concepts/architecture) | Core concepts, database schema, and MCP integration |
-| [Tools Reference](/docs/tools) | All 13 tool categories and 70 tools |
+| [Tools Reference](/docs/tools) | All 13 tool categories and 75 tools |
 | [Memory](/docs/capabilities/memory) | Semantic memory, namespaces, and vector search |
 | [Messaging](/docs/capabilities/messaging) | Cross-machine messaging with read receipts |
 | [Tasks](/docs/capabilities/tasks) | Task lifecycle, priorities, missions, and cron |
 
 ## Key Numbers
 
-- **19 database tables** — memories, messages, tasks, missions, profiles, diary, briefings, components, fix patterns, issues, mandates, business units, and more
-- **70 MCP tools** — every coordination primitive exposed as a native MCP tool
+- **20 database tables** — memories, messages, tasks, missions, profiles, diary, briefings, components, fix patterns, issues, mandates, business units, and more
+- **75 MCP tools** — every coordination primitive exposed as a native MCP tool
 - **13 capability categories** — memory, messaging, tasks, missions, profiles, diary, registry, fix patterns, issues, mandates, business units, recurring tasks, error monitoring
 - **< 10 minutes** — from zero to a fully coordinated agent team
 - **$0 / month** — FSL license, self-hosted on Convex free tier

--- a/content/docs/tools.fr.mdx
+++ b/content/docs/tools.fr.mdx
@@ -1,11 +1,11 @@
 ---
 title: Référence des outils
-description: Les 70 outils MCP répartis en 13 catégories de capacités dans VantagePeers.
+description: Les 75 outils MCP répartis en 13 catégories de capacités dans VantagePeers.
 ---
 
 # Référence des outils
 
-VantagePeers expose 70 outils MCP organisés en 13 catégories de capacités. Chaque outil accepte et retourne du JSON. Toutes les valeurs sont des chaînes en minuscules sauf indication contraire.
+VantagePeers expose 75 outils MCP organisés en 13 catégories de capacités. Chaque outil accepte et retourne du JSON. Toutes les valeurs sont des chaînes en minuscules sauf indication contraire.
 
 ## Catégories d'outils
 

--- a/content/docs/tools.mdx
+++ b/content/docs/tools.mdx
@@ -1,11 +1,11 @@
 ---
 title: Tools Reference
-description: All 70 MCP tools across 13 capability categories in VantagePeers.
+description: All 75 MCP tools across 13 capability categories in VantagePeers.
 ---
 
 # Tools Reference
 
-VantagePeers exposes 70 MCP tools organized into 13 capability categories. Every tool accepts and returns JSON. All values are lowercase strings unless noted.
+VantagePeers exposes 75 MCP tools organized into 13 capability categories. Every tool accepts and returns JSON. All values are lowercase strings unless noted.
 
 ## Tool Categories
 

--- a/content/new-positioning-copy.md
+++ b/content/new-positioning-copy.md
@@ -33,8 +33,8 @@ VantagePeers is the open-source backend that gives your Claude Code agents share
 ### Hero Stats (4 pills)
 | Value | Label |
 |-------|-------|
-| 10 | Database Tables |
-| 37 | MCP Tools |
+| 20 | Database Tables |
+| 75 | MCP Tools |
 | Free | FSL License |
 | <10 min | Setup Time |
 
@@ -79,7 +79,7 @@ You do not need another memory plugin. You need an agent OS.
 **Everything your agents need. One backend.**
 
 ### Section Subtitle
-10 database tables. 37 MCP tools. Seven capability categories. All the primitives for running a coordinated AI agent team across machines.
+20 database tables. 75 MCP tools. Thirteen capability categories. All the primitives for running a coordinated AI agent team across machines.
 
 ### Features
 
@@ -150,7 +150,7 @@ VantagePeers replaces the stack you were going to build. One backend. One deploy
 | Session diary | Custom logging | Not available | Included |
 | Briefing notes | Google Docs / Notion | Not available | Included |
 | Component registry | File system + README | Not available | Included |
-| MCP native | Custom tool wrappers | Partial (mem0 only) | 64 tools, 12 categories |
+| MCP native | Custom tool wrappers | Partial (mem0 only) | 75 tools, 13 categories |
 | Self-hosted | Your responsibility | Cloud-only or abandoned | Convex (free tier) |
 | Open source | N/A | Partial or closed | FSL License |
 | **Setup time** | Weeks | Hours + $$$ | < 10 minutes |
@@ -173,7 +173,7 @@ Three steps from zero to a fully coordinated agent operating system.
 
 ### Step 01: Deploy
 Icon: `Rocket` (lucide)
-Clone the repo. Run `npx convex deploy`. Your 10-table backend is live — memory, messaging, tasks, missions, diary, and more. One command. No infrastructure to manage.
+Clone the repo. Run `npx convex deploy`. Your 20-table backend is live — memory, messaging, tasks, missions, diary, and more. One command. No infrastructure to manage.
 
 ### Step 02: Connect
 Icon: `Plug` (lucide)
@@ -181,7 +181,7 @@ Add VantagePeers as an MCP server in your Claude Code config. Each agent gets an
 
 ### Step 03: Orchestrate
 Icon: `Network` (lucide)
-Your agents store memories, send messages, assign tasks, plan missions, and write diaries — all through 37 MCP tools. Works across machines. Across sessions. Across agent teams.
+Your agents store memories, send messages, assign tasks, plan missions, and write diaries — all through 75 MCP tools. Works across machines. Across sessions. Across agent teams.
 
 ### Emphasis Box
 Powered by Convex — real-time database with built-in vector search, serverless functions, and zero-config scaling. Your infrastructure, their uptime.
@@ -210,7 +210,7 @@ No account required. No credit card. Clone, deploy, orchestrate.
 ## 8. Updated FAQ Suggestions
 
 **Q: Is VantagePeers a memory tool?**
-A: It started as one. Now it is a complete agent operating system — memory is one of 10 capabilities. It also handles messaging, tasks, missions, recurring automation, diary, briefings, agent profiles, and a component registry. Memory is table 1 of 10.
+A: It started as one. Now it is a complete agent operating system — memory is one of many capabilities. It also handles messaging, tasks, missions, recurring automation, diary, briefings, agent profiles, fix patterns, issues, mandates, business units, and a component registry. 20 database tables, 75 MCP tools.
 
 **Q: What makes this different from mem0 or Zep?**
 A: mem0 and Zep are memory-only tools. VantagePeers is an agent OS. They give you memory storage and retrieval. VantagePeers gives you memory + messaging + task coordination + mission planning + recurring automation + session diary + briefing notes + agent profiles + a component registry — all in one backend, all via MCP, all open source.
@@ -219,7 +219,7 @@ A: mem0 and Zep are memory-only tools. VantagePeers is an agent OS. They give yo
 A: Yes. FSL license. Clone the repo, deploy to your Convex account (generous free tier), and you are running. No subscription. No usage fees. No enterprise tier required for any feature.
 
 **Q: Can I use this with agents other than Claude?**
-A: VantagePeers exposes 37 MCP tools. Any MCP-compatible agent can use them. Claude Code is the primary use case because of its native MCP support, but the protocol is open.
+A: VantagePeers exposes 75 MCP tools. Any MCP-compatible agent can use them. Claude Code is the primary use case because of its native MCP support, but the protocol is open.
 
 **Q: What is Convex?**
 A: Convex is a real-time backend platform — database, serverless functions, vector search, and scheduling in one service. VantagePeers uses it as its runtime. You deploy once with `npx convex deploy` and Convex handles scaling, backups, and uptime. The free tier covers most agent setups.
@@ -241,7 +241,7 @@ A: Convex is a real-time backend platform — database, serverless functions, ve
 - Angle: the only integrated backend for multi-agent orchestration — and it is free
 
 ### Key Messages (priority order)
-1. **Complete, not partial.** 10 tables, 64 tools, 12 categories. Not just memory — the full stack.
+1. **Complete, not partial.** 20 tables, 75 tools, 13 categories. Not just memory — the full stack.
 2. **Open source, zero cost.** FSL license. Self-hosted on Convex free tier. No SaaS pricing trap.
 3. **Built for multi-agent teams.** Messaging with receipts. Tasks with dependencies. Missions with lifecycle. Not single-agent memory.
 4. **10-minute setup.** One deploy command. One MCP config. Production-ready.

--- a/e2e/landing.spec.ts
+++ b/e2e/landing.spec.ts
@@ -24,17 +24,17 @@ test.describe("VantagePeers landing page", () => {
 		expect(bodyText).not.toContain("Persistent memory");
 	});
 
-	// Test 3: Hero stats show "16" tables and "64" tools
-	test("hero stats show 19 tables and 70 tools", async ({ page }) => {
+	// Test 3: Hero stats show "20" tables and "75" tools
+	test("hero stats show 20 tables and 75 tools", async ({ page }) => {
 		const bodyText = await page.locator("body").textContent();
-		expect(bodyText).toMatch(/16/);
-		expect(bodyText).toMatch(/64/);
+		expect(bodyText).toMatch(/20/);
+		expect(bodyText).toMatch(/75/);
 		// Verify via meta description which is always present
 		const metaDesc = await page
 			.locator('meta[name="description"]')
 			.getAttribute("content");
-		expect(metaDesc).toContain("19 tables");
-		expect(metaDesc).toContain("70 tools");
+		expect(metaDesc).toContain("20 tables");
+		expect(metaDesc).toContain("75 tools");
 	});
 
 	// Test 4: FSL license badge visible (not MIT)


### PR DESCRIPTION
## Summary
- 26 files changed, 89 substitutions
- Tool counts: 64/68/70/35→75 everywhere (EN + FR)
- Table counts: 13/16/18/19→20 everywhere
- GitHub URLs: vantageos/elpiarthera→vantageos-agency
- FR translation fixed (35 outils→75 outils)
- Structured data schemas updated
- E2E test assertions updated

## Test plan
- [x] grep stale tool counts: 0 hits
- [x] grep stale table counts: 0 hits
- [x] grep wrong GitHub URLs: 0 hits

Orchestrator: Sigma — VantageOS Team Infra | 2026-04-07