### PR TITLE
fix: replace alpha/beta with pi/tau in quickstart (#135)

### DIFF
--- a/content/docs/getting-started/quickstart.fr.mdx
+++ b/content/docs/getting-started/quickstart.fr.mdx
@@ -24,7 +24,7 @@ Définissez la clé OpenAI pour les embeddings vectoriels :
 npx convex env set OPENAI_API_KEY sk-your-key-here
 ```
 
-## Étape 2 : Configurer l'Agent A
+## Étape 2 : Configurer l'Agent A (Pi)
 
 Ouvrez les paramètres Claude Code (`~/.claude.json` ou le fichier `.claude/settings.json` de votre projet) et ajoutez :
 
@@ -44,44 +44,44 @@ Ouvrez les paramètres Claude Code (`~/.claude.json` ou le fichier `.claude/sett
 
 Redémarrez Claude Code. Vous devriez voir les outils VantagePeers dans la liste des outils.
 
-## Étape 3 : L'Agent A stocke une mémoire
+## Étape 3 : L'Agent A (Pi) stocke une mémoire
 
-Depuis la session Claude Code de l'Agent A :
+Depuis la session Claude Code de l'Agent A (Pi) :
 
 ```
 store_memory(
   namespace: "global",
   type: "project",
   content: "Project kickoff: building a REST API with FastAPI. Target: MVP by Friday.",
-  createdBy: "alpha"
+  createdBy: "pi"
 )
 ```
 
 Réponse : `{ memoryId: "k17..." }`
 
-## Étape 4 : L'Agent A envoie un message
+## Étape 4 : L'Agent A (Pi) envoie un message
 
 ```
 send_message(
-  from: "alpha",
-  channel: "beta",
-  content: "Hey Beta — I stored the project brief in global memory. Start on the database schema."
+  from: "pi",
+  channel: "tau",
+  content: "Hey Tau — I stored the project brief in global memory. Start on the database schema."
 )
 ```
 
 Réponse : `{ messageId: "jn7..." }`
 
-## Étape 5 : Configurer l'Agent B
+## Étape 5 : Configurer l'Agent B (Tau)
 
 Sur une seconde machine (ou une seconde session Claude Code), ajoutez la même config MCP de l'Étape 2. Même `CONVEX_URL` — les deux agents partagent un seul backend.
 
-## Étape 6 : L'Agent B vérifie ses messages
+## Étape 6 : L'Agent B (Tau) vérifie ses messages
 
-Depuis la session Claude Code de l'Agent B :
+Depuis la session Claude Code de l'Agent B (Tau) :
 
 ```
 check_messages(
-  recipient: "beta"
+  recipient: "tau"
 )
 ```
 
@@ -90,14 +90,14 @@ Réponse :
 ```json
 [
   {
-    "from": "alpha",
-    "content": "Hey Beta — I stored the project brief in global memory. Start on the database schema.",
+    "from": "pi",
+    "content": "Hey Tau — I stored the project brief in global memory. Start on the database schema.",
     "receiptId": "k97..."
   }
 ]
 ```
 
-## Étape 7 : L'Agent B rappelle la mémoire
+## Étape 7 : L'Agent B (Tau) rappelle la mémoire
 
 ```
 recall(
@@ -107,9 +107,9 @@ recall(
 )
 ```
 
-La réponse inclut la mémoire stockée par l'Agent A — avec un classement par recherche sémantique.
+La réponse inclut la mémoire stockée par l'Agent A (Pi) — avec un classement par recherche sémantique.
 
-## Étape 8 : L'Agent B marque le message comme lu
+## Étape 8 : L'Agent B (Tau) marque le message comme lu
 
 ```
 mark_as_read(
@@ -123,9 +123,9 @@ Terminé. Deux agents, mémoire partagée, messagerie réelle, accusés de réce
 
 1. **Un seul déploiement Convex** sert de backend partagé pour les deux agents
 2. **store_memory** a persisté une mémoire avec embedding vectoriel que tout agent peut rappeler
-3. **send_message** a délivré un message d'Alpha à Beta avec un accusé de réception
+3. **send_message** a délivré un message de Pi à Tau avec un accusé de réception
 4. **recall** a utilisé la recherche sémantique pour trouver les mémoires pertinentes — pas une recherche par mot-clé
-5. **mark_as_read** a confirmé que Beta a traité le message
+5. **mark_as_read** a confirmé que Tau a traité le message
 
 ## Étapes suivantes
 

--- a/content/docs/getting-started/quickstart.mdx
+++ b/content/docs/getting-started/quickstart.mdx
@@ -24,7 +24,7 @@ Set the OpenAI key for vector embeddings:
 npx convex env set OPENAI_API_KEY sk-your-key-here
 ```
 
-## Step 2: Configure Agent A
+## Step 2: Configure Agent A (Pi)
 
 Open Claude Code settings (`~/.claude.json` or your project's `.claude/settings.json`) and add:
 
@@ -44,44 +44,44 @@ Open Claude Code settings (`~/.claude.json` or your project's `.claude/settings.
 
 Restart Claude Code. You should see VantagePeers tools in the tool list.
 
-## Step 3: Agent A stores a memory
+## Step 3: Agent A (Pi) stores a memory
 
-From Agent A's Claude Code session:
+From Agent A (Pi)'s Claude Code session:
 
 ```
 store_memory(
   namespace: "global",
   type: "project",
   content: "Project kickoff: building a REST API with FastAPI. Target: MVP by Friday.",
-  createdBy: "alpha"
+  createdBy: "pi"
 )
 ```
 
 Response: `{ memoryId: "k17..." }`
 
-## Step 4: Agent A sends a message
+## Step 4: Agent A (Pi) sends a message
 
 ```
 send_message(
-  from: "alpha",
-  channel: "beta",
-  content: "Hey Beta — I stored the project brief in global memory. Start on the database schema."
+  from: "pi",
+  channel: "tau",
+  content: "Hey Tau — I stored the project brief in global memory. Start on the database schema."
 )
 ```
 
 Response: `{ messageId: "jn7..." }`
 
-## Step 5: Configure Agent B
+## Step 5: Configure Agent B (Tau)
 
 On a second machine (or second Claude Code session), add the same MCP config from Step 2. Same `CONVEX_URL` — both agents share one backend.
 
-## Step 6: Agent B checks messages
+## Step 6: Agent B (Tau) checks messages
 
-From Agent B's Claude Code session:
+From Agent B (Tau)'s Claude Code session:
 
 ```
 check_messages(
-  recipient: "beta"
+  recipient: "tau"
 )
 ```
 
@@ -90,14 +90,14 @@ Response:
 ```json
 [
   {
-    "from": "alpha",
-    "content": "Hey Beta — I stored the project brief in global memory. Start on the database schema.",
+    "from": "pi",
+    "content": "Hey Tau — I stored the project brief in global memory. Start on the database schema.",
     "receiptId": "k97..."
   }
 ]
 ```
 
-## Step 7: Agent B recalls the memory
+## Step 7: Agent B (Tau) recalls the memory
 
 ```
 recall(
@@ -107,9 +107,9 @@ recall(
 )
 ```
 
-Response includes the memory Agent A stored — with semantic search ranking.
+Response includes the memory Agent A (Pi) stored — with semantic search ranking.
 
-## Step 8: Agent B marks the message as read
+## Step 8: Agent B (Tau) marks the message as read
 
 ```
 mark_as_read(
@@ -123,9 +123,9 @@ Done. Two agents, shared memory, real messaging, read receipts. No file hacks. N
 
 1. **One Convex deployment** serves as the shared backend for both agents
 2. **store_memory** persisted a vector-embedded memory that any agent can recall
-3. **send_message** delivered a message from Alpha to Beta with a receipt
+3. **send_message** delivered a message from Pi to Tau with a receipt
 4. **recall** used semantic search to find relevant memories — not keyword matching
-5. **mark_as_read** confirmed Beta processed the message
+5. **mark_as_read** confirmed Tau processed the message
 
 ## Next steps
 


### PR DESCRIPTION
## Summary
- Replaced orchestrator names alpha/beta with realistic names pi/tau in quickstart code examples and prose
- Updated both EN (quickstart.mdx) and FR (quickstart.fr.mdx) files consistently
- Headings now show Agent A (Pi) and Agent B (Tau) for clarity

## Test plan
- [ ] Verify EN quickstart renders correctly with new names
- [ ] Verify FR quickstart renders correctly with new names
- [ ] Confirm no remaining alpha/beta orchestrator references in either file

Closes vantageos-agency/vantage-peers#135

Orchestrator: Sigma — VantageOS Team | 2026-04-08