### PR TITLE
fix: docs create_mission title to name (#137)

### DIFF
--- a/content/docs/capabilities/missions.fr.mdx
+++ b/content/docs/capabilities/missions.fr.mdx
@@ -21,7 +21,7 @@ Les missions regroupent des tâches liées et suivent la progression à travers 
 
 ```json
 {
-  "title": "Fix #282 — credit race condition",
+  "name": "Fix #282 — credit race condition",
   "project": "myreeldream",
   "pilot": "omega",
   "priority": "high",

--- a/content/docs/capabilities/missions.mdx
+++ b/content/docs/capabilities/missions.mdx
@@ -21,7 +21,7 @@ Missions group related tasks and track progress through lifecycle stages. They c
 
 ```json
 {
-  "title": "Fix #282 — credit race condition",
+  "name": "Fix #282 — credit race condition",
   "project": "myreeldream",
   "pilot": "omega",
   "priority": "high",

--- a/content/docs/capabilities/tasks.fr.mdx
+++ b/content/docs/capabilities/tasks.fr.mdx
@@ -134,7 +134,7 @@ Les missions regroupent des tâches liées et suivent la progression globale à 
 
 ```json
 {
-  "title": "Landing Page Migration — Phase 1",
+  "name": "Landing Page Migration — Phase 1",
   "pilot": "tau",
   "targetDate": 1712275200000
 }

--- a/content/docs/capabilities/tasks.mdx
+++ b/content/docs/capabilities/tasks.mdx
@@ -134,7 +134,7 @@ Missions group related tasks and track overall progress through lifecycle stages
 
 ```json
 {
-  "title": "Landing Page Migration — Phase 1",
+  "name": "Landing Page Migration — Phase 1",
   "pilot": "tau",
   "targetDate": 1712275200000
 }

--- a/content/docs/tools.fr.mdx
+++ b/content/docs/tools.fr.mdx
@@ -240,7 +240,7 @@ Les missions regroupent les tâches liées et suivent la progression.
 
 ```json
 {
-  "title": "Landing Page Migration — Phase 1",
+  "name": "Landing Page Migration — Phase 1",
   "pilot": "tau",
   "targetDate": 1712275200000
 }

--- a/content/docs/tools.mdx
+++ b/content/docs/tools.mdx
@@ -284,7 +284,7 @@ Creates a new mission and assigns a pilot.
 
 ```json
 {
-  "title": "Landing Page Migration — Phase 1",
+  "name": "Landing Page Migration — Phase 1",
   "pilot": "tau",
   "targetDate": 1712275200000
 }
@@ -292,15 +292,15 @@ Creates a new mission and assigns a pilot.
 
 ### `list_missions`
 
-Lists all missions, optionally filtered by stage or pilot.
+Lists all missions, optionally filtered by status or pilot.
 
 ```json
 {
-  "stage": "execute"
+  "status": "execute"
 }
 ```
 
-Stage values: `brainstorm`, `plan`, `execute`, `validate`, `complete`.
+Status values: `brainstorm`, `plan`, `execute`, `validate`, `complete`.
 
 ### `update_mission`
 


### PR DESCRIPTION
## Summary
- Replace "title" with "name" in all create_mission code examples across EN and FR docs
- Fix "stage" to "status" in list_missions example in tools.mdx

## Test plan
- [ ] Verify docs build without errors
- [ ] Spot-check each changed page renders correctly

Closes vantageos-agency/vantage-peers#137

Orchestrator: Sigma — VantageOS Team | 2026-04-08