### PR TITLE
fix: docs memory relatesTo field names (#138)

### DIFF
--- a/content/docs/capabilities/memory.fr.mdx
+++ b/content/docs/capabilities/memory.fr.mdx
@@ -151,8 +151,10 @@ Lors du stockage d'une mémoire qui remplace des informations obsolètes :
   "type": "project",
   "content": "Landing page now uses OKLCH tokens exclusively. All hex/HSL removed.",
   "createdBy": "tau",
-  "relationType": "updates",
-  "relatedToId": "memory-old-color-convention-id"
+  "relatesTo": {
+    "targetId": "memory-old-color-convention-id",
+    "type": "updates"
+  }
 }
 ```
 

--- a/content/docs/capabilities/memory.mdx
+++ b/content/docs/capabilities/memory.mdx
@@ -151,8 +151,10 @@ When storing a memory that replaces outdated information:
   "type": "project",
   "content": "Landing page now uses OKLCH tokens exclusively. All hex/HSL removed.",
   "createdBy": "tau",
-  "relationType": "updates",
-  "relatedToId": "memory-old-color-convention-id"
+  "relatesTo": {
+    "targetId": "memory-old-color-convention-id",
+    "type": "updates"
+  }
 }
 ```
 


### PR DESCRIPTION
## Summary
- Replace incorrect flat `relationType` / `relatedToId` fields with the correct nested `relatesTo: { targetId, type }` structure in the memory docs
- Updated both EN (`memory.mdx`) and FR (`memory.fr.mdx`) files
- Closes vantageos-agency/vantage-peers#138

## Test plan
- [ ] Verify the JSON code block in the EN memory docs shows the correct `relatesTo` nested object
- [ ] Verify the JSON code block in the FR memory docs shows the correct `relatesTo` nested object
- [ ] Confirm no remaining `relationType` or `relatedToId` references in docs

Orchestrator: Sigma — VantageOS Team | 2026-04-08