### PR TITLE
fix: remove invalid severity info from docs (#10)

### DIFF
--- a/content/docs/capabilities/memory.fr.mdx
+++ b/content/docs/capabilities/memory.fr.mdx
@@ -107,7 +107,6 @@ Les épisodes sont des enregistrements structurés d'événements — l'équival
 
 | Sévérité | Quand l'utiliser |
 |----------|------------------|
-| `info` | Événements routiniers, patterns réussis qui méritent d'être enregistrés |
 | `minor` | Petits problèmes, facilement récupérables, faible impact |
 | `major` | Échecs significatifs, temps perdu, corrigible avec un insight |
 | `critical` | Risque de perte de données, incidents de production, bloqueurs |

--- a/content/docs/capabilities/memory.mdx
+++ b/content/docs/capabilities/memory.mdx
@@ -107,7 +107,6 @@ Episodes are structured event records — the equivalent of a structured log ent
 
 | Severity | When to use |
 |----------|-------------|
-| `info` | Routine events, successful patterns worth recording |
 | `minor` | Small issues, easily recovered, low impact |
 | `major` | Significant failures, wasted time, correctible with insight |
 | `critical` | Data loss risk, production incidents, blockers |

--- a/content/docs/tools.fr.mdx
+++ b/content/docs/tools.fr.mdx
@@ -69,7 +69,7 @@ Stocke un épisode structuré (événement de succès ou d'échec avec contexte 
   "action": "Delegated to dev-frontend with exact file:line brief",
   "outcome": "Fixed in one pass, no revisions needed",
   "insight": "Precise briefs with file:line citations eliminate revision cycles",
-  "severity": "info"
+  "severity": "minor"
 }
 ```
 

--- a/content/docs/tools.mdx
+++ b/content/docs/tools.mdx
@@ -73,11 +73,11 @@ Stores a structured episode (a failure or success event with full context).
   "action": "Delegated to dev-frontend with exact file:line brief",
   "outcome": "Fixed in one pass, no revisions needed",
   "insight": "Precise briefs with file:line citations eliminate revision cycles",
-  "severity": "info"
+  "severity": "minor"
 }
 ```
 
-Severity levels: `info`, `minor`, `major`, `critical`.
+Severity levels: `minor`, `major`, `critical`.
 
 ### `list_memories`
 


### PR DESCRIPTION
## Summary
- Removed info from the list of valid severity levels in both EN and FR docs
- Replaced severity info with severity minor in code examples (tools.mdx, tools.fr.mdx)
- Removed the info row from the severity levels table (memory.mdx, memory.fr.mdx)

Valid severities are now consistently: minor, major, critical.

Closes #10

## Test plan
- [ ] Verify no remaining references to info as a severity level in docs
- [ ] Confirm EN and FR files are consistent

Orchestrator: Sigma — VantageOS Team | 2026-04-08