### PR TITLE
fix: docs priority critical → urgent (#11)

### DIFF
--- a/content/docs/capabilities/tasks.fr.mdx
+++ b/content/docs/capabilities/tasks.fr.mdx
@@ -93,7 +93,7 @@ Quand le travail est fait mais nécessite une vérification avant clôture :
 | `low` | Souhaitable, pas de deadline, pas de dépendance bloquante |
 | `medium` | Travail standard, à faire ce sprint |
 | `high` | Une deadline ou une dépendance existe |
-| `critical` | Bloque la production, bloque d'autres agents ou bloque une release |
+| `urgent` | Bloque la production, bloque d'autres agents ou bloque une release |
 
 Choisissez toujours la priorité la plus haute applicable. Sous-prioriser mène à des tâches qui restent non exécutées pendant que du travail plus prioritaire s'accumule.
 

--- a/content/docs/capabilities/tasks.mdx
+++ b/content/docs/capabilities/tasks.mdx
@@ -93,7 +93,7 @@ When the work is done but needs verification before closing:
 | `low` | Nice to have, no deadline, no blocking dependency |
 | `medium` | Standard work, should be done this sprint |
 | `high` | Deadline or dependency exists |
-| `critical` | Blocking production, blocking other agents, or blocking a release |
+| `urgent` | Blocking production, blocking other agents, or blocking a release |
 
 Always pick the highest applicable priority. Under-prioritizing leads to tasks sitting unexecuted while higher-priority work accumulates.
 

--- a/content/docs/core-concepts/architecture.fr.mdx
+++ b/content/docs/core-concepts/architecture.fr.mdx
@@ -111,7 +111,7 @@ Table de coordination des tâches :
 | `title` | string | Titre de la tâche |
 | `assignedTo` | string | Orchestrateur responsable |
 | `status` | string | `todo`, `in_progress`, `review`, `blocked`, `done` |
-| `priority` | string | `low`, `medium`, `high`, `critical` |
+| `priority` | string | `low`, `medium`, `high`, `urgent` |
 | `missionId` | string? | Mission parente, si regroupée |
 | `dependsOn` | string[] | IDs des tâches qui doivent être terminées d'abord |
 | `blockedBy` | string | Description du bloqueur, si bloquée |

--- a/content/docs/core-concepts/architecture.mdx
+++ b/content/docs/core-concepts/architecture.mdx
@@ -111,7 +111,7 @@ Task coordination table:
 | `title` | string | Task title |
 | `assignedTo` | string | Orchestrator responsible |
 | `status` | string | `todo`, `in_progress`, `review`, `blocked`, `done` |
-| `priority` | string | `low`, `medium`, `high`, `critical` |
+| `priority` | string | `low`, `medium`, `high`, `urgent` |
 | `missionId` | string? | Parent mission, if grouped |
 | `dependsOn` | string[] | Task IDs that must complete first |
 | `blockedBy` | string | Blocker description, if blocked |

--- a/content/docs/tools.fr.mdx
+++ b/content/docs/tools.fr.mdx
@@ -192,7 +192,7 @@ Les tâches suivent le travail de la création à la complétion avec piste d'au
 ```json
 {
   "taskId": "task-abc123",
-  "priority": "critical",
+  "priority": "urgent",
   "blockedBy": "Waiting on API key"
 }
 ```

--- a/content/docs/tools.mdx
+++ b/content/docs/tools.mdx
@@ -204,7 +204,7 @@ Creates a new task and assigns it to an orchestrator.
 }
 ```
 
-Priority levels: `low`, `medium`, `high`, `critical`.
+Priority levels: `low`, `medium`, `high`, `urgent`.
 
 ### `list_tasks`
 


### PR DESCRIPTION
## Summary
- Replaced all priority `critical` references with `urgent` across EN and FR docs (6 files)
- Severity `critical` (in fix-patterns and memory docs) left untouched — it remains a valid severity level

## Files changed
- `content/docs/core-concepts/architecture.mdx` — priority enum list
- `content/docs/core-concepts/architecture.fr.mdx` — priority enum list
- `content/docs/tools.mdx` — priority levels description
- `content/docs/tools.fr.mdx` — priority JSON example
- `content/docs/capabilities/tasks.mdx` — priority table row
- `content/docs/capabilities/tasks.fr.mdx` — priority table row

## Test plan
- [ ] Verify no remaining `priority.*critical` in docs
- [ ] Verify severity `critical` still present in fix-patterns docs
- [ ] Site builds without errors

Closes #11

Orchestrator: Sigma — VantageOS Team | 2026-04-08