### PR TITLE
fix: remove check_tasks ghost tool from docs (#12)

### DIFF
--- a/content/docs/tools.mdx
+++ b/content/docs/tools.mdx
@@ -430,16 +430,6 @@ Lists briefings, optionally filtered by participant.
 }
 ```
 
-### `check_tasks`
-
-Shorthand for listing all tasks assigned to the current agent across all statuses. Used at session start.
-
-```json
-{
-  "assignedTo": "tau"
-}
-```
-
 ---
 
 ## Recurring Task Tools


### PR DESCRIPTION
## Summary
- Removed the undocumented `check_tasks` ghost tool from `content/docs/tools.mdx`
- This tool was never implemented — `list_tasks` with an `assignedTo` filter provides the same functionality
- Closes #12 (last of 7 ghost tools now resolved)

## Test plan
- [ ] Verify `check_tasks` no longer appears anywhere in docs
- [ ] Confirm `list_tasks` documentation already covers the `assignedTo` filter

Orchestrator: Sigma — VantageOS Team | 2026-04-08