### PR TITLE
fix: remove ghost external-tracking tools from docs (#13)

### DIFF
--- a/content/docs/infrastructure/external-tracking.fr.mdx
+++ b/content/docs/infrastructure/external-tracking.fr.mdx
@@ -52,13 +52,9 @@ Un cron s'exécute toutes les heures et vérifie toutes les issues externes avec
 
 Aucune vérification manuelle nécessaire — Pi reçoit un message quand une PR change d'état.
 
-## Outils MCP
+## Outils
 
-| Outil | Description |
-|-------|-------------|
-| `createExternal` | Créer une issue externe dans VantagePeers |
-| `updatePrStatus` | Mettre à jour l'URL et le statut de la PR |
-| `listExternalOpen` | Lister toutes les issues externes avec des PRs ouvertes |
+Le suivi d'issues externes utilise les outils VantagePeers standard : `create_task`, `update_task`, et `list_tasks` avec les tags appropriés. Il n'y a pas d'outils MCP dédiés au suivi externe — le skill `/track-external-issue` ci-dessous gère le workflow complet.
 
 ## Skill : /track-external-issue
 

--- a/content/docs/infrastructure/external-tracking.mdx
+++ b/content/docs/infrastructure/external-tracking.mdx
@@ -52,13 +52,9 @@ A cron runs every hour and checks all external issues with `prStatus = open` or 
 
 No manual checking needed — Pi gets a message when any PR changes state.
 
-## MCP Tools
+## Tools
 
-| Tool | Description |
-|------|-------------|
-| `createExternal` | Create an external issue in VantagePeers |
-| `updatePrStatus` | Update PR URL and status |
-| `listExternalOpen` | List all external issues with open PRs |
+External issue tracking uses the standard VantagePeers tools: `create_task`, `update_task`, and `list_tasks` with appropriate tags. There are no dedicated external-tracking MCP tools — the `/track-external-issue` skill below handles the full workflow.
 
 ## Skill: /track-external-issue
 


### PR DESCRIPTION
## Summary
- Removed fabricated MCP Tools section (`createExternal`, `updatePrStatus`, `listExternalOpen`) from external-tracking docs
- Replaced with accurate description: external tracking uses standard `create_task`, `update_task`, and `list_tasks` tools
- Updated both EN and FR versions

## Test plan
- [ ] Verify no fabricated tool names remain in either file
- [ ] Confirm EN and FR docs render correctly
- [ ] Confirm the `/track-external-issue` skill reference is accurate

Closes #13

Orchestrator: Sigma — VantageOS Team | 2026-04-08