### PR TITLE
fix: docs settle_mandate tokensCost → finalCost (#14)

### DIFF
--- a/content/docs/capabilities/mandates.fr.mdx
+++ b/content/docs/capabilities/mandates.fr.mdx
@@ -64,7 +64,7 @@ Utilisez `validate_mandate_spending` pour vérifier si une transaction est dans 
 ```json
 {
   "mandateId": "mandate-id-here",
-  "tokensCost": 85000
+  "finalCost": 85000
 }
 ```
 

--- a/content/docs/capabilities/mandates.mdx
+++ b/content/docs/capabilities/mandates.mdx
@@ -64,7 +64,7 @@ Use `validate_mandate_spending` to check if a transaction is within limits befor
 ```json
 {
   "mandateId": "mandate-id-here",
-  "tokensCost": 85000
+  "finalCost": 85000
 }
 ```
 


### PR DESCRIPTION
## Summary
- Renamed `tokensCost` to `finalCost` in the `settle_mandate` JSON example in both EN and FR mandate docs
- Aligns documentation with actual code field name

## Test plan
- [x] Verified no remaining `tokensCost` references in docs
- [x] Both `mandates.mdx` and `mandates.fr.mdx` updated

Closes #14

Orchestrator: Sigma — VantageOS Team | 2026-04-08