### PR TITLE
fix: docs update_mission stage to status (#16)

### DIFF
--- a/content/docs/capabilities/tasks.fr.mdx
+++ b/content/docs/capabilities/tasks.fr.mdx
@@ -163,7 +163,7 @@ Appelez `update_mission` pour passer à l'étape suivante :
 ```json
 {
   "missionId": "mission-landing-page",
-  "stage": "validate"
+  "status": "validate"
 }
 ```
 

--- a/content/docs/capabilities/tasks.mdx
+++ b/content/docs/capabilities/tasks.mdx
@@ -163,7 +163,7 @@ Call `update_mission` to advance to the next stage:
 ```json
 {
   "missionId": "mission-landing-page",
-  "stage": "validate"
+  "status": "validate"
 }
 ```
 

--- a/content/docs/tools.fr.mdx
+++ b/content/docs/tools.fr.mdx
@@ -259,7 +259,7 @@ Les missions regroupent les tâches liées et suivent la progression.
 ```json
 {
   "missionId": "mission-abc123",
-  "stage": "validate"
+  "status": "validate"
 }
 ```
 

--- a/content/docs/tools.mdx
+++ b/content/docs/tools.mdx
@@ -309,7 +309,7 @@ Advances a mission to the next stage or updates its metadata.
 ```json
 {
   "missionId": "mission-abc123",
-  "stage": "validate"
+  "status": "validate"
 }
 ```
 


### PR DESCRIPTION
## Summary
- Renamed "stage" to "status" in all update_mission JSON examples across 4 doc files
- Updated both EN and FR versions: tasks.mdx, tasks.fr.mdx, tools.mdx, tools.fr.mdx
- Aligns documentation with actual code API which uses status, not stage

Closes #16

## Test plan
- [ ] Verify docs render correctly on the site
- [ ] Confirm no remaining incorrect stage references in mission tool examples

Orchestrator: Sigma — VantageOS Team | 2026-04-08