### PR TITLE
fix: standardize install paths to npx (#17)

### DIFF
--- a/content/docs/getting-started/index.fr.mdx
+++ b/content/docs/getting-started/index.fr.mdx
@@ -60,11 +60,10 @@ Ajoutez VantagePeers à votre configuration MCP Claude Code. Ouvrez `~/.claude.j
 {
   "mcpServers": {
     "vantage-peers": {
-      "command": "node",
-      "args": ["/path/to/vantage-peers/mcp-server/index.js"],
+      "command": "npx",
+      "args": ["-y", "vantage-peers-mcp"],
       "env": {
-        "CONVEX_URL": "https://your-deployment.convex.cloud",
-        "OPENAI_API_KEY": "sk-..."
+        "CONVEX_URL": "https://your-deployment.convex.cloud"
       }
     }
   }

--- a/content/docs/getting-started/index.mdx
+++ b/content/docs/getting-started/index.mdx
@@ -60,11 +60,10 @@ Add VantagePeers to your Claude Code MCP configuration. Open `~/.claude.json` (g
 {
   "mcpServers": {
     "vantage-peers": {
-      "command": "node",
-      "args": ["/path/to/vantage-peers/mcp-server/index.js"],
+      "command": "npx",
+      "args": ["-y", "vantage-peers-mcp"],
       "env": {
-        "CONVEX_URL": "https://your-deployment.convex.cloud",
-        "OPENAI_API_KEY": "sk-..."
+        "CONVEX_URL": "https://your-deployment.convex.cloud"
       }
     }
   }

--- a/content/docs/getting-started/quickstart.fr.mdx
+++ b/content/docs/getting-started/quickstart.fr.mdx
@@ -32,8 +32,8 @@ Ouvrez les paramètres Claude Code (`~/.claude.json` ou le fichier `.claude/sett
 {
   "mcpServers": {
     "vantage-peers": {
-      "command": "node",
-      "args": ["/path/to/vantage-peers/mcp-server/dist/server.js"],
+      "command": "npx",
+      "args": ["-y", "vantage-peers-mcp"],
       "env": {
         "CONVEX_URL": "https://your-deployment.convex.cloud"
       }

--- a/content/docs/getting-started/quickstart.mdx
+++ b/content/docs/getting-started/quickstart.mdx
@@ -32,8 +32,8 @@ Open Claude Code settings (`~/.claude.json` or your project's `.claude/settings.
 {
   "mcpServers": {
     "vantage-peers": {
-      "command": "node",
-      "args": ["/path/to/vantage-peers/mcp-server/dist/server.js"],
+      "command": "npx",
+      "args": ["-y", "vantage-peers-mcp"],
       "env": {
         "CONVEX_URL": "https://your-deployment.convex.cloud"
       }


### PR DESCRIPTION
## Summary
- Replace `node /path/to/mcp-server/index.js` in `index.mdx` (EN + FR) with `npx -y vantage-peers-mcp`
- Replace `node /path/to/mcp-server/dist/server.js` in `quickstart.mdx` (EN + FR) with `npx -y vantage-peers-mcp`
- Remove stale `OPENAI_API_KEY` env var from index config example
- All six getting-started pages now use the same install command

## Test plan
- [ ] Verify `index.mdx` MCP config uses `npx -y vantage-peers-mcp`
- [ ] Verify `quickstart.mdx` MCP config uses `npx -y vantage-peers-mcp`
- [ ] Verify `supported-tools.mdx` already correct (no change needed)
- [ ] Verify FR counterparts match EN versions
- [ ] Grep for `node /path` returns zero results

Closes #17

Orchestrator: Sigma — VantageOS Team | 2026-04-08