### PR TITLE
fix: add 13 undocumented tools to tools reference (#18)

### DIFF
--- a/content/docs/tools.fr.mdx
+++ b/content/docs/tools.fr.mdx
@@ -1,22 +1,23 @@
 ---
 title: Référence des outils
-description: Les 75 outils MCP répartis en 13 catégories de capacités dans VantagePeers.
+description: Les 88 outils MCP répartis en 14 catégories de capacités dans VantagePeers.
 ---
 
 # Référence des outils
 
-VantagePeers expose 75 outils MCP organisés en 13 catégories de capacités. Chaque outil accepte et retourne du JSON. Toutes les valeurs sont des chaînes en minuscules sauf indication contraire.
+VantagePeers expose 88 outils MCP organisés en 14 catégories de capacités. Chaque outil accepte et retourne du JSON. Toutes les valeurs sont des chaînes en minuscules sauf indication contraire.
 
 ## Catégories d'outils
 
 | Catégorie | Nombre | Description |
 |-----------|--------|-------------|
-| [Mémoire](#outils-mémoire) | 4 | Stocker, rappeler et gérer les mémoires typées avec recherche vectorielle |
-| [Messagerie](#outils-messagerie) | 6 | Envoyer des messages inter-machines avec accusés de réception |
-| [Tâches](#outils-tâches) | 8 | Créer et gérer des tâches avec suivi complet du cycle de vie |
-| [Missions](#outils-missions) | 4 | Regrouper les tâches en missions avec suivi d'étapes |
+| [Mémoire](#outils-mémoire) | 6 | Stocker, rappeler et gérer les mémoires typées avec recherche vectorielle |
+| [Recherche](#outils-recherche) | 2 | Recherche plein texte et hybride sur les mémoires |
+| [Messagerie](#outils-messagerie) | 7 | Envoyer des messages inter-machines avec accusés de réception |
+| [Tâches](#outils-tâches) | 11 | Créer et gérer des tâches avec suivi complet du cycle de vie |
+| [Missions](#outils-missions) | 5 | Regrouper les tâches en missions avec suivi d'étapes |
 | [Profils et sessions](#outils-profils-et-sessions) | 8 | Identité d'agent, état de session, journal et briefings |
-| [Tâches récurrentes](#outils-tâches-récurrentes) | 5 | Automatisation basée sur cron |
+| [Tâches récurrentes](#outils-tâches-récurrentes) | 7 | Automatisation basée sur cron |
 | [Registre](#outils-registre) | 3 | Sauvegarde et inventaire de composants |
 | [Mandats](#outils-mandats) | 6 | Demandes de services inter-agents avec budgets |
 | [Unités commerciales](#outils-unités-commerciales) | 5 | Stratégie, tarification et KPIs des UC |
@@ -82,6 +83,56 @@ Liste les mémoires d'un namespace, avec filtre optionnel par type.
   "namespace": "project/vantage-starter",
   "type": "project",
   "limit": 20
+}
+```
+
+### `soft_delete_memory`
+
+Suppression douce d'une mémoire pour qu'elle n'apparaisse plus dans les résultats de rappel.
+
+```json
+{
+  "memoryId": "memory-abc123"
+}
+```
+
+### `get_memory`
+
+Récupérer une mémoire unique par son ID.
+
+```json
+{
+  "memoryId": "memory-abc123"
+}
+```
+
+---
+
+## Outils recherche
+
+Recherche plein texte et hybride sur le magasin de mémoires.
+
+### `text_search`
+
+Recherche par mots-clés BM25 plein texte sur les mémoires.
+
+```json
+{
+  "query": "deployment error",
+  "namespace": "global",
+  "limit": 10
+}
+```
+
+### `hybrid_search`
+
+Recherche combinée vectorielle + BM25 avec fusion RRF.
+
+```json
+{
+  "query": "deployment error",
+  "namespace": "global",
+  "limit": 10
 }
 ```
 
@@ -153,6 +204,16 @@ Retourne toutes les instances d'agents connues et leur statut actuel.
 {}
 ```
 
+### `list_broadcast_status`
+
+Afficher qui a lu un message de diffusion et qui ne l'a pas lu.
+
+```json
+{
+  "messageId": "msg-abc123"
+}
+```
+
 ---
 
 ## Outils tâches
@@ -180,6 +241,8 @@ Les tâches suivent le travail de la création à la complétion avec piste d'au
 ```
 
 ### `list_tasks_by_mission`
+
+Lister toutes les tâches liées à une mission spécifique.
 
 ```json
 {
@@ -216,17 +279,23 @@ Les tâches suivent le travail de la création à la complétion avec piste d'au
 
 ### `checkout_task`
 
+Réclamer atomiquement une tâche (sans conflit pour les instances multiples).
+
 ```json
 {
-  "taskId": "task-abc123"
+  "taskId": "task-abc123",
+  "callerOrchestrator": "tau"
 }
 ```
 
 ### `delete_task`
 
+Supprimer définitivement une tâche (créateur ou système uniquement).
+
 ```json
 {
-  "taskId": "task-abc123"
+  "taskId": "task-abc123",
+  "callerOrchestrator": "sigma"
 }
 ```
 
@@ -265,10 +334,12 @@ Les missions regroupent les tâches liées et suivent la progression.
 
 ### `update_mission_status`
 
+Changer le statut du cycle de vie d'une mission.
+
 ```json
 {
   "missionId": "mission-abc123",
-  "status": "complete"
+  "status": "validate"
 }
 ```
 
@@ -289,12 +360,17 @@ Les profils d'agents stockent l'identité statique et l'état dynamique. Le jour
 
 ### `update_profile`
 
+Créer ou mettre à jour un profil d'orchestrateur (mises à jour partielles supportées).
+
 ```json
 {
   "orchestratorId": "tau",
-  "instanceId": "tau-main",
-  "role": "frontend specialist",
-  "status": "active"
+  "name": "Tau",
+  "dynamic": {
+    "currentTask": "Building dashboard",
+    "lastSeen": 1712275200000,
+    "sessionCount": 42
+  }
 }
 ```
 
@@ -366,8 +442,26 @@ Automatisation basée sur cron. Voir [Tâches récurrentes](/docs/capabilities/r
 | `create_recurring_task` | Créer un nouveau modèle de tâche récurrente |
 | `list_recurring_tasks` | Lister tous les modèles de tâches récurrentes |
 | `delete_recurring_task` | Supprimer un modèle |
-| `pause_recurring_task` | Mettre en pause |
-| `resume_recurring_task` | Reprendre une tâche en pause |
+
+### `pause_recurring_task`
+
+Mettre en pause une tâche récurrente.
+
+```json
+{
+  "recurringTaskId": "rt-abc123"
+}
+```
+
+### `resume_recurring_task`
+
+Reprendre une tâche récurrente en pause.
+
+```json
+{
+  "recurringTaskId": "rt-abc123"
+}
+```
 
 ---
 
@@ -428,6 +522,17 @@ Suivi d'issues avec synchronisation webhook et auto-liaison. Voir [Issues GitHub
 | `verify_issue` | Marquer une issue comme vérifiée |
 | `issue_stats` | Obtenir les statistiques de comptage des issues |
 | `link_issue_to_pattern` | Lier une issue à un fix pattern |
+
+### `link_issue_to_pattern`
+
+Lier une issue VantagePeers à un fix pattern.
+
+```json
+{
+  "issueId": "issue-abc123",
+  "patternId": "pattern-abc123"
+}
+```
 
 ---
 

--- a/content/docs/tools.mdx
+++ b/content/docs/tools.mdx
@@ -1,22 +1,23 @@
 ---
 title: Tools Reference
-description: All 75 MCP tools across 13 capability categories in VantagePeers.
+description: All 88 MCP tools across 14 capability categories in VantagePeers.
 ---
 
 # Tools Reference
 
-VantagePeers exposes 75 MCP tools organized into 13 capability categories. Every tool accepts and returns JSON. All values are lowercase strings unless noted.
+VantagePeers exposes 88 MCP tools organized into 14 capability categories. Every tool accepts and returns JSON. All values are lowercase strings unless noted.
 
 ## Tool Categories
 
 | Category | Tool Count | Description |
 |----------|-----------|-------------|
-| [Memory](#memory-tools) | 4 | Store, recall, and manage typed memories with vector search |
-| [Messaging](#messaging-tools) | 6 | Send messages across machines with read receipts |
-| [Tasks](#task-tools) | 8 | Create and manage tasks with full lifecycle tracking |
-| [Missions](#mission-tools) | 4 | Group tasks into missions with stage tracking |
+| [Memory](#memory-tools) | 6 | Store, recall, and manage typed memories with vector search |
+| [Search](#search-tools) | 2 | Full-text and hybrid search over memories |
+| [Messaging](#messaging-tools) | 7 | Send messages across machines with read receipts |
+| [Tasks](#task-tools) | 11 | Create and manage tasks with full lifecycle tracking |
+| [Missions](#mission-tools) | 5 | Group tasks into missions with stage tracking |
 | [Profiles & Sessions](#profile-and-session-tools) | 8 | Agent identity, session state, diary, and briefings |
-| [Recurring Tasks](#recurring-task-tools) | 5 | Cron-based automation |
+| [Recurring Tasks](#recurring-task-tools) | 7 | Cron-based automation |
 | [Registry](#registry-tools) | 3 | Component backup and inventory |
 | [Mandates](#mandate-tools) | 6 | Cross-agent service requests with budgets |
 | [Business Units](#business-unit-tools) | 5 | BU strategy, pricing, and KPIs |
@@ -88,6 +89,56 @@ Lists memories in a namespace, optionally filtered by type.
   "namespace": "project/vantage-starter",
   "type": "project",
   "limit": 20
+}
+```
+
+### `soft_delete_memory`
+
+Soft-delete a memory so it stops appearing in recall results.
+
+```json
+{
+  "memoryId": "memory-abc123"
+}
+```
+
+### `get_memory`
+
+Fetch a single memory by its ID.
+
+```json
+{
+  "memoryId": "memory-abc123"
+}
+```
+
+---
+
+## Search Tools
+
+Full-text and hybrid search over the memory store.
+
+### `text_search`
+
+BM25 full-text keyword search over memories.
+
+```json
+{
+  "query": "deployment error",
+  "namespace": "global",
+  "limit": 10
+}
+```
+
+### `hybrid_search`
+
+Combined vector + BM25 search using RRF fusion.
+
+```json
+{
+  "query": "deployment error",
+  "namespace": "global",
+  "limit": 10
 }
 ```
 
@@ -184,6 +235,16 @@ Returns all known agent instances and their current status.
 
 Returns orchestrator IDs, instance IDs, last seen timestamps, and current tasks.
 
+### `list_broadcast_status`
+
+Show who read a broadcast message and who didn't.
+
+```json
+{
+  "messageId": "msg-abc123"
+}
+```
+
 ---
 
 ## Task Tools
@@ -272,6 +333,38 @@ Links two tasks so one cannot start before the other completes.
 }
 ```
 
+### `checkout_task`
+
+Atomically claim a task (conflict-safe for multi-instance).
+
+```json
+{
+  "taskId": "task-abc123",
+  "callerOrchestrator": "tau"
+}
+```
+
+### `delete_task`
+
+Permanently delete a task (creator or system only).
+
+```json
+{
+  "taskId": "task-abc123",
+  "callerOrchestrator": "sigma"
+}
+```
+
+### `list_tasks_by_mission`
+
+List all tasks linked to a specific mission.
+
+```json
+{
+  "missionId": "mission-abc123"
+}
+```
+
 ---
 
 ## Mission Tools
@@ -320,6 +413,17 @@ Returns a mission with all its linked tasks and current status.
 ```json
 {
   "missionId": "mission-abc123"
+}
+```
+
+### `update_mission_status`
+
+Change a mission's lifecycle status.
+
+```json
+{
+  "missionId": "mission-abc123",
+  "status": "validate"
 }
 ```
 
@@ -393,14 +497,17 @@ List diary entries for an orchestrator, optionally filtered by date range.
 
 ### `update_profile`
 
-Update an orchestrator profile (role, capabilities, status).
+Create or update an orchestrator profile (partial updates supported).
 
 ```json
 {
   "orchestratorId": "tau",
-  "instanceId": "tau-main",
-  "role": "frontend specialist",
-  "status": "active"
+  "name": "Tau",
+  "dynamic": {
+    "currentTask": "Building dashboard",
+    "lastSeen": 1712275200000,
+    "sessionCount": 42
+  }
 }
 ```
 
@@ -473,6 +580,26 @@ Updates a recurring task template.
 ### `delete_recurring_task`
 
 Removes a recurring task template. Does not delete already-created instances.
+
+```json
+{
+  "recurringTaskId": "rt-abc123"
+}
+```
+
+### `pause_recurring_task`
+
+Pause a recurring task.
+
+```json
+{
+  "recurringTaskId": "rt-abc123"
+}
+```
+
+### `resume_recurring_task`
+
+Resume a paused recurring task.
 
 ```json
 {
@@ -614,6 +741,17 @@ Bug fix knowledge base with semantic search. See [Fix Patterns KB](/docs/capabil
 | `validate_fix` | Set the validated fix |
 | `search_fix_patterns` | Semantic search over patterns |
 | `list_fix_patterns` | List patterns by project |
+
+### `link_issue_to_pattern`
+
+Link a VantagePeers issue to a fix pattern.
+
+```json
+{
+  "issueId": "issue-abc123",
+  "patternId": "pattern-abc123"
+}
+```
 
 ---
 


### PR DESCRIPTION
## Summary
- Added 13 missing MCP tools to `tools.mdx` and `tools.fr.mdx` across 8 sections: Memory, Search (new), Messaging, Tasks, Missions, Profiles, Recurring Tasks, and Fix Patterns
- Each tool includes a description and JSON example with consistent placeholder IDs
- Updated tool counts from 75/13 to 88/14 in both files

## Test plan
- [ ] Verify all 13 tool names render correctly in both EN and FR pages
- [ ] Confirm JSON examples are valid and use consistent placeholder IDs
- [ ] Check that the new Search section anchor links work in the summary table

Closes #18

Orchestrator: Sigma — VantageOS Team | 2026-04-08