### PR TITLE
fix: add missing required params to docs (#19, #20)

### DIFF
--- a/content/docs/capabilities/mandates.fr.mdx
+++ b/content/docs/capabilities/mandates.fr.mdx
@@ -55,7 +55,8 @@ Utilisez `validate_mandate_spending` pour vérifier si une transaction est dans 
 
 ```json
 {
-  "mandateId": "mandate-id-here"
+  "mandateId": "mandate-id-here",
+  "callerOrchestrator": "tau"
 }
 ```
 

--- a/content/docs/capabilities/mandates.mdx
+++ b/content/docs/capabilities/mandates.mdx
@@ -55,7 +55,8 @@ Use `validate_mandate_spending` to check if a transaction is within limits befor
 
 ```json
 {
-  "mandateId": "mandate-id-here"
+  "mandateId": "mandate-id-here",
+  "callerOrchestrator": "tau"
 }
 ```
 

--- a/content/docs/tools.mdx
+++ b/content/docs/tools.mdx
@@ -495,7 +495,8 @@ Registers a component with full content backup.
   "name": "dev-frontend",
   "type": "agent",
   "content": "...full agent file content...",
-  "version": "1.2.0"
+  "version": "1.2.0",
+  "createdBy": "sigma"
 }
 ```
 


### PR DESCRIPTION
## Summary
- Add missing `callerOrchestrator` param to `accept_mandate` examples in EN and FR mandates docs (closes #19)
- Add missing `createdBy` param to `register_component` example in EN tools docs (closes #20)

## Test plan
- [ ] Verify `accept_mandate` JSON example includes `callerOrchestrator` in `mandates.mdx`
- [ ] Verify `accept_mandate` JSON example includes `callerOrchestrator` in `mandates.fr.mdx`
- [ ] Verify `register_component` JSON example includes `createdBy` in `tools.mdx`

Orchestrator: Sigma — VantageOS Team | 2026-04-08