### PR TITLE
fix: batch docs corrections (#25, #26, #27, #28, #29)

### DIFF
--- a/content/docs/capabilities/memory.fr.mdx
+++ b/content/docs/capabilities/memory.fr.mdx
@@ -170,7 +170,7 @@ Sans relations, vous accumulez des mémoires contradictoires. Une mémoire feedb
 3. **Archivée** — remplacée via la relation `updates`, exclue des rappels par défaut
 4. **Supprimée** — suppression définitive, uniquement pour les données véritablement incorrectes
 
-Les mémoires archivées ne sont pas supprimées — elles sont conservées pour la piste d'audit. Si vous avez besoin de voir l'historique complet incluant les mémoires archivées, passez `includeArchived: true` à recall.
+Les mémoires archivées ne sont pas supprimées — elles sont conservées pour la piste d'audit.
 
 ## Pattern de démarrage de session
 

--- a/content/docs/capabilities/memory.mdx
+++ b/content/docs/capabilities/memory.mdx
@@ -170,7 +170,7 @@ Without relations, you accumulate conflicting memories. A feedback memory saying
 3. **Archived** — superseded via `updates` relation, excluded from recall by default
 4. **Deleted** — hard delete, only use for genuinely incorrect data
 
-Archived memories are not deleted — they are retained for audit trail. If you need to see the full history including archived memories, pass `includeArchived: true` to recall.
+Archived memories are not deleted — they are retained for audit trail.
 
 ## Session Start Pattern
 

--- a/content/docs/capabilities/messaging.fr.mdx
+++ b/content/docs/capabilities/messaging.fr.mdx
@@ -190,13 +190,13 @@ Retourne :
 ```json
 [
   {
-    "orchestratorId": "pi",
+    "id": "pi",
     "instanceId": "pi-chromebook",
     "summary": "Reviewing PR #47",
     "lastSeen": 1711670400000
   },
   {
-    "orchestratorId": "tau",
+    "id": "tau",
     "instanceId": "tau-main",
     "summary": "Migrating PricingSection to lit-ui",
     "lastSeen": 1711670350000

--- a/content/docs/capabilities/messaging.mdx
+++ b/content/docs/capabilities/messaging.mdx
@@ -190,13 +190,13 @@ Returns:
 ```json
 [
   {
-    "orchestratorId": "pi",
+    "id": "pi",
     "instanceId": "pi-chromebook",
     "summary": "Reviewing PR #47",
     "lastSeen": 1711670400000
   },
   {
-    "orchestratorId": "tau",
+    "id": "tau",
     "instanceId": "tau-main",
     "summary": "Migrating PricingSection to lit-ui",
     "lastSeen": 1711670350000

--- a/content/docs/core-concepts/architecture.mdx
+++ b/content/docs/core-concepts/architecture.mdx
@@ -140,7 +140,7 @@ Cron-based task templates:
 | `assignedTo` | string | Default assignee |
 | `lastTriggered` | number? | Last creation timestamp |
 
-### agentProfiles
+### profiles
 
 Static identity and dynamic state per orchestrator instance:
 
@@ -153,7 +153,7 @@ Static identity and dynamic state per orchestrator instance:
 | `lastSeen` | number | Timestamp of last activity |
 | `sessionCount` | number | Total sessions started |
 
-### diaryEntries
+### diary
 
 Daily session logs:
 
@@ -164,7 +164,7 @@ Daily session logs:
 | `content` | string | Diary narrative |
 | `highlights` | string[] | Key events of the day |
 
-### briefings
+### briefingNotes
 
 Structured meeting and decision records:
 

--- a/content/docs/infrastructure/issue-resolution.fr.mdx
+++ b/content/docs/infrastructure/issue-resolution.fr.mdx
@@ -1,11 +1,11 @@
 ---
 title: Protocole de résolution d'issues
-description: Résolution automatisée en 12 étapes avec intégration webhook GitHub et modèles de missions.
+description: Résolution automatisée en 14 étapes (T0-T13) avec intégration webhook GitHub et modèles de missions.
 ---
 
 # Protocole de résolution d'issues
 
-Quand une issue GitHub est ouverte sur un dépôt mappé, VantagePeers crée automatiquement une mission avec 12 tâches suivant le Protocole de Résolution d'Issues (IRP). L'orchestrateur assigné exécute chaque étape, avec des commentaires de progression postés automatiquement sur GitHub.
+Quand une issue GitHub est ouverte sur un dépôt mappé, VantagePeers crée automatiquement une mission avec 14 tâches suivant le Protocole de Résolution d'Issues (IRP). L'orchestrateur assigné exécute chaque étape, avec des commentaires de progression postés automatiquement sur GitHub.
 
 ## Fonctionnement
 
@@ -19,10 +19,10 @@ Le webhook reçoit l'événement
 Auto-commentaire : "Investigating - assigned to {orchestrator}"
        |
        v
-Mission créée avec 12 tâches (depuis le modèle)
+Mission créée avec 14 tâches (depuis le modèle)
        |
        v
-L'orchestrateur exécute les étapes T1-T12
+L'orchestrateur exécute les étapes T0-T13
        |
        v
 Auto-commentaires aux étapes T6, T8, T11
@@ -31,7 +31,7 @@ Auto-commentaires aux étapes T6, T8, T11
 Issue fermée avec le correctif déployé
 ```
 
-## Les 12 étapes
+## Les 14 étapes (T0-T13)
 
 | Étape | Titre | Description | Auto-commentaire |
 |-------|-------|-------------|------------------|

--- a/content/docs/infrastructure/issue-resolution.mdx
+++ b/content/docs/infrastructure/issue-resolution.mdx
@@ -1,11 +1,11 @@
 ---
 title: Issue Resolution Protocol
-description: Automated 12-step issue resolution with GitHub webhook integration and mission templates.
+description: Automated 14-step issue resolution with GitHub webhook integration and mission templates.
 ---
 
 # Issue Resolution Protocol
 
-When a GitHub issue is opened on a mapped repository, VantagePeers automatically creates a mission with 12 tasks following the Issue Resolution Protocol (IRP). The assigned orchestrator works through each step, with progress comments posted back to GitHub.
+When a GitHub issue is opened on a mapped repository, VantagePeers automatically creates a mission with 14 tasks following the Issue Resolution Protocol (IRP). The assigned orchestrator works through each step, with progress comments posted back to GitHub.
 
 ## How It Works
 
@@ -19,10 +19,10 @@ Webhook receives event
 Auto-comment: "Investigating - assigned to {orchestrator}"
        |
        v
-Mission created with 12 tasks (from template)
+Mission created with 14 tasks (from template)
        |
        v
-Orchestrator executes steps T1-T12
+Orchestrator executes steps T0-T13
        |
        v
 Auto-comments at T6, T8, T11
@@ -31,7 +31,7 @@ Auto-comments at T6, T8, T11
 Issue closed with fix deployed
 ```
 
-## The 12 Steps
+## The 14 Steps (T0-T13)
 
 | Step | Title | Description | Auto-Comment |
 |------|-------|-------------|--------------|

--- a/content/docs/infrastructure/issue-stats.fr.mdx
+++ b/content/docs/infrastructure/issue-stats.fr.mdx
@@ -46,8 +46,7 @@ Avant : médiane 4 jours. Après : médiane 28 minutes. Amélioration de 207x.
 
 ```json
 {
-  "repo": "myreeldream-ai/MyShortReel-beta",
-  "limit": 7
+  "project": "vantage-peers"
 }
 ```
 

--- a/content/docs/infrastructure/issue-stats.mdx
+++ b/content/docs/infrastructure/issue-stats.mdx
@@ -45,10 +45,8 @@ Before: median 4 days. After: median 28 minutes. 207x improvement.
 ## Querying Stats
 
 ```json
-// Get latest stats for a repo
 {
-  "repo": "myreeldream-ai/MyShortReel-beta",
-  "limit": 7
+  "project": "vantage-peers"
 }
 ```
 

--- a/content/docs/infrastructure/mission-templates.fr.mdx
+++ b/content/docs/infrastructure/mission-templates.fr.mdx
@@ -13,7 +13,7 @@ Les modèles de missions définissent des workflows standardisés qui créent au
 
 Le Protocole de Résolution d'Issues. Auto-créé quand une issue GitHub est ouverte sur un dépôt mappé.
 
-**13 étapes :** Acknowledge → KB Search → Verify Config → Identify Tests → Run Existing Tests → Evaluate Coverage → Write Missing Tests → Fix → Run ALL Tests → Code Review → Deploy + Push → Verification Preview → Update KB
+**14 étapes (T0-T13) :** Acknowledge → KB Search → Verify Config → Identify Tests → Run Existing Tests → Evaluate Coverage → Write Missing Tests → Fix → Run ALL Tests → Code Review → Deploy + Push → Verification Preview → Update KB → Close Issue
 
 Auto-commentaires postés sur GitHub aux étapes T1 (acknowledge), T6 (bug reproduit), T8 (fix prêt), T11 (déployé).
 

--- a/content/docs/infrastructure/mission-templates.mdx
+++ b/content/docs/infrastructure/mission-templates.mdx
@@ -13,7 +13,7 @@ Mission templates define standardized workflows that auto-create missions with p
 
 The Issue Resolution Protocol. Auto-created when a GitHub issue is opened on a mapped repo.
 
-**13 steps:** Acknowledge → KB Search → Verify Config → Identify Tests → Run Existing Tests → Evaluate Coverage → Write Missing Tests → Fix → Run ALL Tests → Code Review → Deploy + Push → Verification Preview → Update KB
+**14 steps (T0-T13):** Acknowledge → KB Search → Verify Config → Identify Tests → Run Existing Tests → Evaluate Coverage → Write Missing Tests → Fix → Run ALL Tests → Code Review → Deploy + Push → Verification Preview → Update KB → Close Issue
 
 Auto-comments posted to GitHub at steps T1 (acknowledge), T6 (bug reproduced), T8 (fix ready), T11 (deployed).
 


### PR DESCRIPTION
## Summary
- #25: list_peers response field orchestratorId changed to id (EN + FR)
- #26: Remove non-existent includeArchived param from recall docs (EN + FR)
- #27: Fix table names in architecture.mdx: agentProfiles to profiles, diaryEntries to diary, briefings to briefingNotes (EN only, FR was already correct)
- #28: Align IRP step count to 14 steps (T0-T13) in issue-resolution and mission-templates (EN + FR)
- #29: Fix issue_stats params to project only, remove repo and limit (EN + FR)

## Test plan
- [ ] Verify list_peers response example shows id field in messaging docs
- [ ] Verify no includeArchived reference remains in memory docs
- [ ] Verify architecture.mdx EN uses profiles, diary, briefingNotes table names
- [ ] Verify all IRP references say 14 steps (T0-T13)
- [ ] Verify issue_stats example uses project param only

Closes #25, closes #26, closes #27, closes #28, closes #29

Orchestrator: Sigma — VantageOS Team | 2026-04-08