### PR TITLE
fix: add Claude Code Web setup docs (#21)

### DIFF
--- a/content/docs/getting-started/index.fr.mdx
+++ b/content/docs/getting-started/index.fr.mdx
@@ -72,6 +72,22 @@ Ajoutez VantagePeers à votre configuration MCP Claude Code. Ouvrez `~/.claude.j
 
 Redémarrez Claude Code. Les outils VantagePeers apparaîtront dans la liste des outils.
 
+### Claude Code Web
+
+VantagePeers fonctionne également avec [Claude Code Web](https://claude.ai/code) (anciennement claude.ai). Pour configurer :
+
+1. Ouvrez Claude Code Web sur [claude.ai/code](https://claude.ai/code)
+2. Allez dans **Settings → MCP Servers**
+3. Cliquez sur **Add Server**
+4. Entrez les informations suivantes :
+   - **Name :** `vantage-peers`
+   - **Command :** `npx`
+   - **Arguments :** `-y vantage-peers-mcp`
+   - **Environment Variables :** `CONVEX_URL=https://your-deployment.convex.cloud`
+5. Enregistrez et vérifiez que les outils apparaissent dans la liste des outils
+
+Le même serveur MCP fonctionne dans Claude Code CLI, Claude Code Web et les extensions VS Code / JetBrains.
+
 ## Démarrage rapide
 
 Une fois connecté, vérifiez que tout fonctionne en exécutant ces deux opérations depuis Claude Code.

--- a/content/docs/getting-started/index.mdx
+++ b/content/docs/getting-started/index.mdx
@@ -72,6 +72,22 @@ Add VantagePeers to your Claude Code MCP configuration. Open `~/.claude.json` (g
 
 Restart Claude Code. VantagePeers tools will appear in the tool list.
 
+### Claude Code Web
+
+VantagePeers also works with [Claude Code Web](https://claude.ai/code) (formerly claude.ai). To configure:
+
+1. Open Claude Code Web at [claude.ai/code](https://claude.ai/code)
+2. Go to **Settings → MCP Servers**
+3. Click **Add Server**
+4. Enter the following:
+   - **Name:** `vantage-peers`
+   - **Command:** `npx`
+   - **Arguments:** `-y vantage-peers-mcp`
+   - **Environment Variables:** `CONVEX_URL=https://your-deployment.convex.cloud`
+5. Save and verify tools appear in the tool list
+
+The same MCP server works in Claude Code CLI, Claude Code Web, and the VS Code / JetBrains extensions.
+
 ## Quick Start
 
 Once connected, verify everything works by running these two operations from within Claude Code.


### PR DESCRIPTION
## Summary
- Added Claude Code Web setup instructions to the getting-started page (EN + FR)
- Documents how to configure VantagePeers MCP server via claude.ai/code Settings -> MCP Servers
- Notes compatibility across Claude Code CLI, Web, and VS Code / JetBrains extensions

## Test plan
- [ ] Verify EN getting-started page renders correctly with the new Claude Code Web section
- [ ] Verify FR getting-started page renders correctly with the translated section
- [ ] Confirm instructions match the current Claude Code Web MCP configuration UI

Closes #21

Orchestrator: Sigma — VantageOS Team | 2026-04-08