### PR TITLE
fix: getting-started convex login + OpenAI key docs (#23, #24)

### DIFF
--- a/content/docs/getting-started/index.fr.mdx
+++ b/content/docs/getting-started/index.fr.mdx
@@ -5,7 +5,7 @@ description: Déployez VantagePeers et connectez votre premier agent en moins de
 
 # Démarrage
 
-VantagePeers se déploie en quatre étapes : cloner, installer, déployer, configurer. Aucune infrastructure à gérer au-delà d'un compte Convex.
+VantagePeers se déploie en cinq étapes : cloner, configurer, s'authentifier, déployer et configurer le serveur MCP. Aucune infrastructure à gérer au-delà d'un compte Convex.
 
 ## Prérequis
 
@@ -40,11 +40,21 @@ Ouvrez `.env.local` et définissez :
 # Votre URL de déploiement Convex (assignée après le deploy)
 CONVEX_URL=https://your-deployment.convex.cloud
 
-# Clé API OpenAI pour les embeddings vectoriels
+# Clé API OpenAI pour les embeddings vectoriels (requis pour recall/search)
 OPENAI_API_KEY=sk-...
 ```
 
-### Étape 3 : Déployer sur Convex
+> **À propos de la clé API OpenAI :** VantagePeers utilise `text-embedding-3-small` pour générer des embeddings vectoriels pour la recherche sémantique (`recall`, `hybrid_search`). Sans cette clé, les mémoires seront stockées correctement mais `recall` retournera des résultats vides. Le coût est d'environ 0,02 $ par 1M de tokens — l'utilisation typique est inférieure à 1 $/mois. Définissez `AI_GATEWAY_API_KEY` dans le tableau de bord Convex (Settings → Environment Variables) avec votre clé API OpenAI.
+
+### Étape 3 : Se connecter à Convex
+
+```bash
+npx convex login
+```
+
+Cela ouvre une fenêtre de navigateur pour vous authentifier avec votre compte Convex. Si vous n'avez pas encore de compte, créez-en un sur [convex.dev](https://convex.dev) — le tier gratuit est suffisant.
+
+### Étape 4 : Déployer sur Convex
 
 ```bash
 npx convex deploy
@@ -52,7 +62,7 @@ npx convex deploy
 
 Cela déploie les 20 tables de base de données, les fonctions serverless et les index vectoriels sur votre compte Convex. Convex affichera votre URL de déploiement — copiez-la.
 
-### Étape 4 : Configurer le serveur MCP
+### Étape 5 : Configurer le serveur MCP
 
 Ajoutez VantagePeers à votre configuration MCP Claude Code. Ouvrez `~/.claude.json` (global) ou le fichier `.claude/settings.json` de votre projet et ajoutez :
 

--- a/content/docs/getting-started/index.mdx
+++ b/content/docs/getting-started/index.mdx
@@ -40,11 +40,21 @@ Open `.env.local` and set:
 # Your Convex deployment URL (assigned after deploy)
 CONVEX_URL=https://your-deployment.convex.cloud
 
-# OpenAI API key for vector embeddings
+# OpenAI API key for vector embeddings (required for recall/search)
 OPENAI_API_KEY=sk-...
 ```
 
-### Step 3: Deploy to Convex
+> **About the OpenAI API key:** VantagePeers uses `text-embedding-3-small` to generate vector embeddings for semantic search (`recall`, `hybrid_search`). Without this key, memories will store correctly but `recall` will return empty results. The cost is approximately $0.02 per 1M tokens — typical usage is under $1/month. Set `AI_GATEWAY_API_KEY` in the Convex dashboard (Settings → Environment Variables) with your OpenAI API key.
+
+### Step 3: Log in to Convex
+
+```bash
+npx convex login
+```
+
+This opens a browser window to authenticate with your Convex account. If you don't have an account yet, create one at [convex.dev](https://convex.dev) — the free tier is sufficient.
+
+### Step 4: Deploy to Convex
 
 ```bash
 npx convex deploy
@@ -52,7 +62,7 @@ npx convex deploy
 
 This deploys all 20 database tables, serverless functions, and vector indexes to your Convex account. Convex will output your deployment URL — copy it.
 
-### Step 4: Configure the MCP server
+### Step 5: Configure the MCP server
 
 Add VantagePeers to your Claude Code MCP configuration. Open `~/.claude.json` (global) or your project's `.claude/settings.json` and add:
 


### PR DESCRIPTION
## Summary
- Add **Step 3: Log in to Convex** (`npx convex login`) before the deploy step, fixing #23
- Expand OpenAI API key explanation with purpose, consequences of missing key, cost estimate, and dashboard configuration instructions, fixing #24
- Update `.env.local` comment to clarify the key is required for recall/search
- Renumber steps 3-4 to 4-5 in both EN and FR files

## Test plan
- [ ] Verify step numbering is sequential (1-5) in both `index.mdx` and `index.fr.mdx`
- [ ] Confirm `npx convex login` step appears before `npx convex deploy`
- [ ] Confirm OpenAI key blockquote explanation is present after the `.env.local` code block
- [ ] Verify FR translations are accurate

Closes #23, closes #24

Orchestrator: Sigma — VantageOS Team | 2026-04-08