### PR TITLE
fix: add 'Add an Orchestrator' guide (#22)

### DIFF
--- a/content/docs/getting-started/add-orchestrator.fr.mdx
+++ b/content/docs/getting-started/add-orchestrator.fr.mdx
@@ -1,0 +1,86 @@
+---
+title: Ajouter un orchestrateur
+description: Comment ajouter un nouvel agent orchestrateur à votre déploiement VantagePeers.
+---
+
+# Ajouter un orchestrateur
+
+Ajouter un nouvel orchestrateur à VantagePeers ne nécessite aucune modification de code. Les noms d'orchestrateurs sont des chaînes libres — utilisez le nom de votre choix.
+
+## Étape 1 : Choisir un nom
+
+Choisissez un identifiant court en minuscules pour votre orchestrateur. Exemples : `delta`, `gamma`, `atlas`, `nova`.
+
+Convention : les lettres grecques (`pi`, `tau`, `phi`, `sigma`, `omega`, `zeta`, `eta`) sont utilisées par l'équipe VantageOS, mais toute chaîne de caractères fonctionne.
+
+## Étape 2 : Configurer le serveur MCP
+
+Sur la machine du nouvel orchestrateur, ajoutez VantagePeers à Claude Code avec la même `CONVEX_URL` :
+
+```json
+{
+  "mcpServers": {
+    "vantage-peers": {
+      "command": "npx",
+      "args": ["-y", "vantage-peers-mcp"],
+      "env": {
+        "CONVEX_URL": "https://your-deployment.convex.cloud"
+      }
+    }
+  }
+}
+```
+
+Tous les orchestrateurs partagent un seul backend Convex. Aucun déploiement par agent n'est nécessaire.
+
+## Étape 3 : Créer un profil
+
+Depuis la session Claude Code du nouvel orchestrateur :
+
+```
+update_profile(
+  orchestratorId: "delta",
+  name: "Delta",
+  static: {
+    role: "Spécialiste des pipelines de données",
+    workspace: "/home/user/projects",
+    capabilities: ["etl", "sql", "python"]
+  },
+  dynamic: {
+    currentTask: "Configuration initiale",
+    lastSeen: Date.now(),
+    sessionCount: 1
+  }
+)
+```
+
+## Étape 4 : Vérifier la connectivité
+
+Testez que le nouvel orchestrateur peut communiquer :
+
+```
+send_message(
+  from: "delta",
+  channel: "broadcast",
+  content: "Delta en ligne — connecté à VantagePeers."
+)
+```
+
+Les autres orchestrateurs recevront ce message lors de leur prochain `check_messages`.
+
+## Liste de diffusion
+
+Le canal `broadcast` envoie à une liste codée en dur : pi, tau, phi, sigma, omega, zeta, eta. Les nouveaux orchestrateurs ne reçoivent les diffusions que s'ils sont ajoutés à cette liste dans `convex/messages.ts`. Pour la messagerie directe, utilisez le nom de l'orchestrateur comme canal — aucune modification de code n'est nécessaire.
+
+## Identifiants d'instance
+
+Si vous exécutez plusieurs instances du même orchestrateur (par ex. `delta-laptop` et `delta-server`), utilisez `fromInstanceId` et `recipientInstanceId` pour cibler des instances spécifiques :
+
+```
+send_message(
+  from: "delta",
+  fromInstanceId: "delta-laptop",
+  channel: "delta",
+  content: "Message à toute instance delta"
+)
+```

--- a/content/docs/getting-started/add-orchestrator.mdx
+++ b/content/docs/getting-started/add-orchestrator.mdx
@@ -1,0 +1,86 @@
+---
+title: Add an Orchestrator
+description: How to add a new orchestrator agent to your VantagePeers deployment.
+---
+
+# Add an Orchestrator
+
+Adding a new orchestrator to VantagePeers requires no code changes. Orchestrator names are open strings — use any name you want.
+
+## Step 1: Choose a name
+
+Pick a short, lowercase identifier for your orchestrator. Examples: `delta`, `gamma`, `atlas`, `nova`.
+
+Convention: Greek letters (`pi`, `tau`, `phi`, `sigma`, `omega`, `zeta`, `eta`) are used by the VantageOS team, but any string works.
+
+## Step 2: Configure the MCP server
+
+On the new orchestrator's machine, add VantagePeers to Claude Code with the same `CONVEX_URL`:
+
+```json
+{
+  "mcpServers": {
+    "vantage-peers": {
+      "command": "npx",
+      "args": ["-y", "vantage-peers-mcp"],
+      "env": {
+        "CONVEX_URL": "https://your-deployment.convex.cloud"
+      }
+    }
+  }
+}
+```
+
+All orchestrators share one Convex backend. No per-agent deployment needed.
+
+## Step 3: Create a profile
+
+From the new orchestrator's Claude Code session:
+
+```
+update_profile(
+  orchestratorId: "delta",
+  name: "Delta",
+  static: {
+    role: "Data pipeline specialist",
+    workspace: "/home/user/projects",
+    capabilities: ["etl", "sql", "python"]
+  },
+  dynamic: {
+    currentTask: "Initial setup",
+    lastSeen: Date.now(),
+    sessionCount: 1
+  }
+)
+```
+
+## Step 4: Verify connectivity
+
+Test that the new orchestrator can communicate:
+
+```
+send_message(
+  from: "delta",
+  channel: "broadcast",
+  content: "Delta online — connected to VantagePeers."
+)
+```
+
+Other orchestrators will receive this on their next `check_messages`.
+
+## Broadcast list
+
+The `broadcast` channel sends to a hardcoded list: pi, tau, phi, sigma, omega, zeta, eta. New orchestrators receive broadcasts only if added to this list in `convex/messages.ts`. For direct messaging, use the orchestrator name as the channel — no code changes needed.
+
+## Instance IDs
+
+If you run multiple instances of the same orchestrator (e.g., `delta-laptop` and `delta-server`), use `fromInstanceId` and `recipientInstanceId` to target specific instances:
+
+```
+send_message(
+  from: "delta",
+  fromInstanceId: "delta-laptop",
+  channel: "delta",
+  content: "Message to any delta instance"
+)
+```

--- a/content/docs/getting-started/meta.fr.json
+++ b/content/docs/getting-started/meta.fr.json
@@ -1,5 +1,5 @@
 {
   "title": "Démarrage",
   "defaultOpen": true,
-  "pages": ["index", "quickstart", "supported-tools"]
+  "pages": ["index", "quickstart", "add-orchestrator", "supported-tools"]
 }

--- a/content/docs/getting-started/meta.json
+++ b/content/docs/getting-started/meta.json
@@ -1,5 +1,5 @@
 {
   "title": "Getting Started",
   "defaultOpen": true,
-  "pages": ["index", "quickstart", "supported-tools"]
+  "pages": ["index", "quickstart", "add-orchestrator", "supported-tools"]
 }


### PR DESCRIPTION
## Summary
- Add "Add an Orchestrator" guide page in EN and FR
- Update navigation meta files to include the new page
- Covers: naming conventions, MCP server config, profile creation, connectivity verification, broadcast list note, and instance IDs

## Test plan
- [ ] Verify EN page renders at /docs/getting-started/add-orchestrator
- [ ] Verify FR page renders at /fr/docs/getting-started/add-orchestrator
- [ ] Confirm navigation sidebar shows the new entry in both languages
- [ ] Check all code blocks render correctly

Closes #22

Orchestrator: Sigma — VantageOS Team | 2026-04-08
