### PR TITLE
fix: tools.mdx tool count 88→82 (#47)

### DIFF
--- a/content/docs/tools.fr.mdx
+++ b/content/docs/tools.fr.mdx
@@ -1,11 +1,11 @@
 ---
 title: Référence des outils
-description: Les 88 outils MCP répartis en 14 catégories de capacités dans VantagePeers.
+description: Les 82 outils MCP répartis en 14 catégories de capacités dans VantagePeers.
 ---
 
 # Référence des outils
 
-VantagePeers expose 88 outils MCP organisés en 14 catégories de capacités. Chaque outil accepte et retourne du JSON. Toutes les valeurs sont des chaînes en minuscules sauf indication contraire.
+VantagePeers expose 82 outils MCP organisés en 14 catégories de capacités. Chaque outil accepte et retourne du JSON. Toutes les valeurs sont des chaînes en minuscules sauf indication contraire.
 
 ## Catégories d'outils
 

--- a/content/docs/tools.mdx
+++ b/content/docs/tools.mdx
@@ -1,11 +1,11 @@
 ---
 title: Tools Reference
-description: All 88 MCP tools across 14 capability categories in VantagePeers.
+description: All 82 MCP tools across 14 capability categories in VantagePeers.
 ---
 
 # Tools Reference
 
-VantagePeers exposes 88 MCP tools organized into 14 capability categories. Every tool accepts and returns JSON. All values are lowercase strings unless noted.
+VantagePeers exposes 82 MCP tools organized into 14 capability categories. Every tool accepts and returns JSON. All values are lowercase strings unless noted.
 
 ## Tool Categories
 


### PR DESCRIPTION
## Summary
- Corrected tool count from 88 to 82 in both tools.mdx and tools.fr.mdx to match the actual number of tools registered in server.ts
- Updated frontmatter description and intro paragraph in both EN and FR versions
- Category count (14) verified correct -- no change needed

## Test plan
- [ ] Verify tools.mdx shows 82 tools in title/description/intro
- [ ] Verify tools.fr.mdx shows 82 tools in title/description/intro
- [ ] Confirm no remaining references to 88 tools

Closes #47

Orchestrator: Sigma — VantageOS Team | 2026-04-08