### PR TITLE
fix: docs webhook events add Pull request reviews (#4)

### DIFF
--- a/content/docs/infrastructure/issue-resolution.fr.mdx
+++ b/content/docs/infrastructure/issue-resolution.fr.mdx
@@ -91,7 +91,7 @@ Vous pouvez ajouter, supprimer ou réordonner les étapes. Les modifications pre
 Dans les paramètres de votre dépôt, ajoutez un webhook :
 - **URL** : `https://your-deployment.convex.site/github/webhook`
 - **Content type** : `application/json`
-- **Événements** : Issues, Issue comments
+- **Événements** : Issues, Issue comments, Pull requests, Pull request reviews
 - **Secret** : Doit correspondre à votre variable d'environnement `GITHUB_WEBHOOK_SECRET`
 
 ### 2. Mapper le dépôt à un orchestrateur

--- a/content/docs/infrastructure/issue-resolution.mdx
+++ b/content/docs/infrastructure/issue-resolution.mdx
@@ -91,7 +91,7 @@ You can add, remove, or reorder steps. Changes take effect on the next issue ope
 In your repo settings, add a webhook:
 - **URL**: `https://your-deployment.convex.site/github/webhook`
 - **Content type**: `application/json`
-- **Events**: Issues, Issue comments
+- **Events**: Issues, Issue comments, Pull requests, Pull request reviews
 - **Secret**: Match your `GITHUB_WEBHOOK_SECRET` env var
 
 ### 2. Map repo to orchestrator


### PR DESCRIPTION
## Summary
- Added Pull requests and Pull request reviews to the webhook events list in the GitHub webhook setup docs
- Updated both EN and FR versions of issue-resolution.mdx
- Closes #4

## Test plan
- [ ] Verify the EN doc lists all four events: Issues, Issue comments, Pull requests, Pull request reviews
- [ ] Verify the FR doc lists all four events

Generated with Claude Code

Orchestrator: Sigma — VantageOS Team | 2026-04-08