### PR TITLE
fix: batch tool/category counts + settle_mandate param (#51, #52, #53)

### DIFF
--- a/content/docs/capabilities/mandates.fr.mdx
+++ b/content/docs/capabilities/mandates.fr.mdx
@@ -65,7 +65,8 @@ Utilisez `validate_mandate_spending` pour vérifier si une transaction est dans 
 ```json
 {
   "mandateId": "mandate-id-here",
-  "finalCost": 85000
+  "finalCost": 85000,
+  "callerOrchestrator": "tau"
 }
 ```
 

--- a/content/docs/capabilities/mandates.mdx
+++ b/content/docs/capabilities/mandates.mdx
@@ -65,7 +65,8 @@ Use `validate_mandate_spending` to check if a transaction is within limits befor
 ```json
 {
   "mandateId": "mandate-id-here",
-  "finalCost": 85000
+  "finalCost": 85000,
+  "callerOrchestrator": "tau"
 }
 ```
 

--- a/content/docs/core-concepts/architecture.fr.mdx
+++ b/content/docs/core-concepts/architecture.fr.mdx
@@ -22,7 +22,7 @@ VantagePeers est un serveur MCP adossé à Convex. Convex fournit la base de don
 │              Serveur MCP VantagePeers                    │
 │        (processus Node.js, tourne localement par agent)  │
 │                                                          │
-│  75 outils répartis en 13 catégories                     │
+│  82 outils répartis en 14 catégories                     │
 └──────────────────────────┬──────────────────────────────┘
                            │  SDK Convex
                            ▼
@@ -195,4 +195,4 @@ VantagePeers expose toutes les capacités comme des outils MCP. Le serveur MCP t
 3. Convex exécute la fonction contre la base de données (avec recherche vectorielle si applicable)
 4. Le résultat est retourné à Claude Code comme réponse de l'outil
 
-Les 75 outils sont sans état du point de vue du serveur MCP — l'état vit dans Convex. Cela signifie que vous pouvez redémarrer le processus du serveur MCP à tout moment sans perdre de données.
+Les 82 outils sont sans état du point de vue du serveur MCP — l'état vit dans Convex. Cela signifie que vous pouvez redémarrer le processus du serveur MCP à tout moment sans perdre de données.

--- a/content/docs/core-concepts/architecture.mdx
+++ b/content/docs/core-concepts/architecture.mdx
@@ -22,7 +22,7 @@ VantagePeers is a Convex-backed MCP server. Convex provides the database, server
 │              VantagePeers MCP Server                     │
 │         (Node.js process, runs locally per agent)        │
 │                                                          │
-│  75 tools across 13 categories                           │
+│  82 tools across 14 categories                           │
 └──────────────────────────┬──────────────────────────────┘
                            │  Convex SDK
                            ▼
@@ -195,4 +195,4 @@ VantagePeers exposes all capabilities as MCP tools. The MCP server runs as a loc
 3. Convex executes the function against the database (with vector search if applicable)
 4. The result is returned to Claude Code as the tool response
 
-All 75 tools are stateless from the MCP server's perspective — state lives in Convex. This means you can restart the MCP server process at any time without losing data.
+All 82 tools are stateless from the MCP server's perspective — state lives in Convex. This means you can restart the MCP server process at any time without losing data.

--- a/content/docs/getting-started/quickstart.fr.mdx
+++ b/content/docs/getting-started/quickstart.fr.mdx
@@ -132,4 +132,4 @@ Terminé. Deux agents, mémoire partagée, messagerie réelle, accusés de réce
 - Ajoutez des [tâches](/docs/capabilities/tasks) pour que les agents puissent s'assigner du travail mutuellement
 - Configurez des [tâches récurrentes](/docs/capabilities/recurring-tasks) pour l'automatisation basée sur cron
 - Lisez l'[architecture](/docs/core-concepts/architecture) complète pour comprendre les orchestrateurs, instances et namespaces
-- Parcourez les [75 outils MCP](/docs/tools)
+- Parcourez les [82 outils MCP](/docs/tools)

--- a/content/docs/getting-started/quickstart.mdx
+++ b/content/docs/getting-started/quickstart.mdx
@@ -132,4 +132,4 @@ Done. Two agents, shared memory, real messaging, read receipts. No file hacks. N
 - Add [tasks](/docs/capabilities/tasks) so agents can assign work to each other
 - Set up [recurring tasks](/docs/capabilities/recurring-tasks) for cron-based automation
 - Read the full [architecture](/docs/core-concepts/architecture) to understand orchestrators, instances, and namespaces
-- Browse all [75 MCP tools](/docs/tools)
+- Browse all [82 MCP tools](/docs/tools)

--- a/content/docs/getting-started/supported-tools.fr.mdx
+++ b/content/docs/getting-started/supported-tools.fr.mdx
@@ -9,7 +9,7 @@ VantagePeers est un serveur MCP. Il fonctionne avec tout outil qui supporte le [
 
 ## Support MCP complet
 
-Ces outils ont un support natif du client MCP — ajoutez VantagePeers comme serveur et les 75 outils sont immédiatement disponibles.
+Ces outils ont un support natif du client MCP — ajoutez VantagePeers comme serveur et les 82 outils sont immédiatement disponibles.
 
 ### Claude Code
 
@@ -127,4 +127,4 @@ Toutes les configurations nécessitent une seule variable d'environnement :
 |----------|--------|-------------|
 | `CONVEX_URL` | `https://your-deployment.convex.cloud` | URL de votre déploiement Convex (depuis `npx convex deploy`) |
 
-Le serveur MCP la résout au démarrage. Aucune autre configuration n'est nécessaire — le serveur se connecte à votre backend Convex et expose automatiquement les 75 outils.
+Le serveur MCP la résout au démarrage. Aucune autre configuration n'est nécessaire — le serveur se connecte à votre backend Convex et expose automatiquement les 82 outils.

--- a/content/docs/getting-started/supported-tools.mdx
+++ b/content/docs/getting-started/supported-tools.mdx
@@ -9,7 +9,7 @@ VantagePeers is an MCP server. It works with any tool that supports the [Model C
 
 ## Full MCP Support
 
-These tools have native MCP client support — add VantagePeers as a server and all 75 tools are immediately available.
+These tools have native MCP client support — add VantagePeers as a server and all 82 tools are immediately available.
 
 ### Claude Code
 
@@ -241,4 +241,4 @@ All configurations require one environment variable:
 |----------|-------|-------------|
 | `CONVEX_URL` | `https://your-deployment.convex.cloud` | Your Convex deployment URL (from `npx convex deploy`) |
 
-The MCP server resolves this at startup. No other configuration is needed — the server connects to your Convex backend and exposes all 75 tools automatically.
+The MCP server resolves this at startup. No other configuration is needed — the server connects to your Convex backend and exposes all 82 tools automatically.

--- a/content/docs/index.fr.mdx
+++ b/content/docs/index.fr.mdx
@@ -1,6 +1,6 @@
 ---
 title: Documentation VantagePeers
-description: Le système d'exploitation open-source pour les équipes d'agents IA. 20 tables, 75 outils MCP, gratuit pour toujours.
+description: Le système d'exploitation open-source pour les équipes d'agents IA. 20 tables, 82 outils MCP, gratuit pour toujours.
 ---
 
 # Bienvenue sur VantagePeers
@@ -11,7 +11,7 @@ VantagePeers est le backend open-source qui donne à vos agents IA une mémoire 
 
 Quand vous exécutez plusieurs agents Claude Code sur différentes machines et sessions, ils font face à un problème de coordination : chaque agent démarre sans connaître ce que les autres ont fait, sans moyen d'envoyer des messages entre machines, et sans tableau de bord partagé. Vous finissez par bricoler des plugins mémoire, des hacks basés sur des fichiers et une coordination manuelle — et ça casse à l'échelle.
 
-VantagePeers résout ce problème en fournissant un backend auto-hébergé unique avec 20 tables de base de données et 75 outils MCP couvrant chaque primitive de coordination dont votre équipe d'agents a besoin. Les agents stockent des mémoires typées avec recherche sémantique, envoient des messages avec accusés de réception, assignent des tâches avec priorités et dépendances, planifient des missions avec des étapes de cycle de vie, écrivent des journaux de session et maintiennent un registre partagé de composants. Tout persiste dans le cloud Convex et est accessible à tout agent sur n'importe quelle machine.
+VantagePeers résout ce problème en fournissant un backend auto-hébergé unique avec 20 tables de base de données et 82 outils MCP couvrant chaque primitive de coordination dont votre équipe d'agents a besoin. Les agents stockent des mémoires typées avec recherche sémantique, envoient des messages avec accusés de réception, assignent des tâches avec priorités et dépendances, planifient des missions avec des étapes de cycle de vie, écrivent des journaux de session et maintiennent un registre partagé de composants. Tout persiste dans le cloud Convex et est accessible à tout agent sur n'importe quelle machine.
 
 Ce n'est pas un SaaS. Ce n'est pas un service managé. Vous le déployez une fois avec `npx convex deploy`, vous l'ajoutez comme serveur MCP dans votre config Claude Code, et toute votre équipe d'agents est coordonnée. Licence FSL. Gratuit pour toujours.
 
@@ -22,7 +22,7 @@ Ce n'est pas un SaaS. Ce n'est pas un service managé. Vous le déployez une foi
 | [Démarrage](/docs/getting-started) | Installer, déployer et connecter en moins de 10 minutes |
 | [Quickstart](/docs/getting-started/quickstart) | Deux agents qui échangent des messages en 5 minutes |
 | [Architecture](/docs/core-concepts/architecture) | Concepts clés, schéma de base de données et intégration MCP |
-| [Référence des outils](/docs/tools) | Les 13 catégories et 75 outils |
+| [Référence des outils](/docs/tools) | Les 14 catégories et 82 outils |
 | [Mémoire](/docs/capabilities/memory) | Mémoire sémantique, namespaces et recherche vectorielle |
 | [Messagerie](/docs/capabilities/messaging) | Messagerie inter-machines avec accusés de réception |
 | [Tâches](/docs/capabilities/tasks) | Cycle de vie des tâches, priorités, missions et cron |
@@ -30,8 +30,8 @@ Ce n'est pas un SaaS. Ce n'est pas un service managé. Vous le déployez une foi
 ## Chiffres clés
 
 - **20 tables de base de données** — mémoires, messages, tâches, missions, profils, journal, briefings, composants, patterns de fix, issues, mandats, unités commerciales, et plus
-- **75 outils MCP** — chaque primitive de coordination exposée comme outil MCP natif
-- **13 catégories de capacités** — mémoire, messagerie, tâches, missions, profils, journal, registre, patterns de fix, issues, mandats, unités commerciales, tâches récurrentes, monitoring d'erreurs
+- **82 outils MCP** — chaque primitive de coordination exposée comme outil MCP natif
+- **14 catégories de capacités** — mémoire, messagerie, tâches, missions, profils, journal, registre, patterns de fix, issues, mandats, unités commerciales, tâches récurrentes, monitoring d'erreurs
 - **< 10 minutes** — de zéro à une équipe d'agents pleinement coordonnée
 - **0 € / mois** — licence FSL, auto-hébergé sur le tier gratuit de Convex
 

--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: VantagePeers Documentation
-description: The open-source operating system for AI agent teams. 20 database tables, 75 MCP tools, free forever.
+description: The open-source operating system for AI agent teams. 20 database tables, 82 MCP tools, free forever.
 ---
 
 # Welcome to VantagePeers
@@ -11,7 +11,7 @@ VantagePeers is the open-source backend that gives your AI agents shared memory,
 
 When you run multiple Claude Code agents across machines and sessions, they face a coordination problem: each agent starts fresh with no knowledge of what others have done, no way to send messages across machines, and no shared task board. You end up duct-taping together memory plugins, file-based hacks, and manual coordination — and it breaks at scale.
 
-VantagePeers solves this by providing a single self-hosted backend with 20 database tables and 75 MCP tools covering every coordination primitive your agent team needs. Agents store typed memories with semantic search, send messages with read receipts, assign tasks with priorities and dependencies, plan missions with lifecycle stages, write session diaries, and maintain a shared component registry. All of it persists in Convex cloud and is available to any agent on any machine.
+VantagePeers solves this by providing a single self-hosted backend with 20 database tables and 82 MCP tools covering every coordination primitive your agent team needs. Agents store typed memories with semantic search, send messages with read receipts, assign tasks with priorities and dependencies, plan missions with lifecycle stages, write session diaries, and maintain a shared component registry. All of it persists in Convex cloud and is available to any agent on any machine.
 
 It is not a SaaS. It is not a managed service. You deploy it once with `npx convex deploy`, add it as an MCP server in your Claude Code config, and your entire agent team is coordinated. FSL license. Free forever.
 
@@ -22,7 +22,7 @@ It is not a SaaS. It is not a managed service. You deploy it once with `npx conv
 | [Getting Started](/docs/getting-started) | Install, deploy, and connect in under 10 minutes |
 | [Quickstart](/docs/getting-started/quickstart) | Two agents exchanging messages in 5 minutes |
 | [Architecture](/docs/core-concepts/architecture) | Core concepts, database schema, and MCP integration |
-| [Tools Reference](/docs/tools) | All 13 tool categories and 75 tools |
+| [Tools Reference](/docs/tools) | All 14 tool categories and 82 tools |
 | [Memory](/docs/capabilities/memory) | Semantic memory, namespaces, and vector search |
 | [Messaging](/docs/capabilities/messaging) | Cross-machine messaging with read receipts |
 | [Tasks](/docs/capabilities/tasks) | Task lifecycle, priorities, missions, and cron |
@@ -30,8 +30,8 @@ It is not a SaaS. It is not a managed service. You deploy it once with `npx conv
 ## Key Numbers
 
 - **20 database tables** — memories, messages, tasks, missions, profiles, diary, briefings, components, fix patterns, issues, mandates, business units, and more
-- **75 MCP tools** — every coordination primitive exposed as a native MCP tool
-- **13 capability categories** — memory, messaging, tasks, missions, profiles, diary, registry, fix patterns, issues, mandates, business units, recurring tasks, error monitoring
+- **82 MCP tools** — every coordination primitive exposed as a native MCP tool
+- **14 capability categories** — memory, messaging, tasks, missions, profiles, diary, registry, fix patterns, issues, mandates, business units, recurring tasks, error monitoring
 - **< 10 minutes** — from zero to a fully coordinated agent team
 - **$0 / month** — FSL license, self-hosted on Convex free tier
 

--- a/content/docs/tools.fr.mdx
+++ b/content/docs/tools.fr.mdx
@@ -14,15 +14,15 @@ VantagePeers expose 82 outils MCP organisés en 14 catégories de capacités. Ch
 | [Mémoire](#outils-mémoire) | 6 | Stocker, rappeler et gérer les mémoires typées avec recherche vectorielle |
 | [Recherche](#outils-recherche) | 2 | Recherche plein texte et hybride sur les mémoires |
 | [Messagerie](#outils-messagerie) | 7 | Envoyer des messages inter-machines avec accusés de réception |
-| [Tâches](#outils-tâches) | 11 | Créer et gérer des tâches avec suivi complet du cycle de vie |
+| [Tâches](#outils-tâches) | 10 | Créer et gérer des tâches avec suivi complet du cycle de vie |
 | [Missions](#outils-missions) | 5 | Regrouper les tâches en missions avec suivi d'étapes |
 | [Profils et sessions](#outils-profils-et-sessions) | 8 | Identité d'agent, état de session, journal et briefings |
-| [Tâches récurrentes](#outils-tâches-récurrentes) | 7 | Automatisation basée sur cron |
-| [Registre](#outils-registre) | 3 | Sauvegarde et inventaire de composants |
+| [Tâches récurrentes](#outils-tâches-récurrentes) | 6 | Automatisation basée sur cron |
+| [Registre](#outils-registre) | 6 | Sauvegarde et inventaire de composants |
 | [Mandats](#outils-mandats) | 6 | Demandes de services inter-agents avec budgets |
 | [Unités commerciales](#outils-unités-commerciales) | 5 | Stratégie, tarification et KPIs des UC |
 | [Issues GitHub](#outils-issues-github) | 10 | Suivi d'issues avec synchronisation webhook |
-| [Fix Patterns](#outils-fix-patterns) | 5 | Base de connaissances de correctifs avec recherche sémantique |
+| [Fix Patterns](#outils-fix-patterns) | 6 | Base de connaissances de correctifs avec recherche sémantique |
 | [Modèles de missions](#outils-modèles-de-missions) | 2 | Modèles de missions configurables |
 | [Monitoring d'erreurs](#outils-monitoring-derreurs) | 4 | Détection proactive d'erreurs de déploiement |
 

--- a/content/docs/tools.mdx
+++ b/content/docs/tools.mdx
@@ -14,15 +14,15 @@ VantagePeers exposes 82 MCP tools organized into 14 capability categories. Every
 | [Memory](#memory-tools) | 6 | Store, recall, and manage typed memories with vector search |
 | [Search](#search-tools) | 2 | Full-text and hybrid search over memories |
 | [Messaging](#messaging-tools) | 7 | Send messages across machines with read receipts |
-| [Tasks](#task-tools) | 11 | Create and manage tasks with full lifecycle tracking |
+| [Tasks](#task-tools) | 10 | Create and manage tasks with full lifecycle tracking |
 | [Missions](#mission-tools) | 5 | Group tasks into missions with stage tracking |
 | [Profiles & Sessions](#profile-and-session-tools) | 8 | Agent identity, session state, diary, and briefings |
-| [Recurring Tasks](#recurring-task-tools) | 7 | Cron-based automation |
-| [Registry](#registry-tools) | 3 | Component backup and inventory |
+| [Recurring Tasks](#recurring-task-tools) | 6 | Cron-based automation |
+| [Registry](#registry-tools) | 6 | Component backup and inventory |
 | [Mandates](#mandate-tools) | 6 | Cross-agent service requests with budgets |
 | [Business Units](#business-unit-tools) | 5 | BU strategy, pricing, and KPIs |
 | [GitHub Issues](#github-issue-tools) | 10 | Issue tracking with webhook sync |
-| [Fix Patterns](#fix-pattern-tools) | 5 | Bug fix knowledge base with semantic search |
+| [Fix Patterns](#fix-pattern-tools) | 6 | Bug fix knowledge base with semantic search |
 | [Mission Templates](#mission-template-tools) | 2 | Configurable mission templates |
 | [Error Monitoring](#error-monitoring-tools) | 4 | Proactive deployment error detection |
 

--- a/content/new-positioning-copy.md
+++ b/content/new-positioning-copy.md
@@ -150,7 +150,7 @@ VantagePeers replaces the stack you were going to build. One backend. One deploy
 | Session diary | Custom logging | Not available | Included |
 | Briefing notes | Google Docs / Notion | Not available | Included |
 | Component registry | File system + README | Not available | Included |
-| MCP native | Custom tool wrappers | Partial (mem0 only) | 75 tools, 13 categories |
+| MCP native | Custom tool wrappers | Partial (mem0 only) | 82 tools, 14 categories |
 | Self-hosted | Your responsibility | Cloud-only or abandoned | Convex (free tier) |
 | Open source | N/A | Partial or closed | FSL License |
 | **Setup time** | Weeks | Hours + $$$ | < 10 minutes |
@@ -241,7 +241,7 @@ A: Convex is a real-time backend platform — database, serverless functions, ve
 - Angle: the only integrated backend for multi-agent orchestration — and it is free
 
 ### Key Messages (priority order)
-1. **Complete, not partial.** 20 tables, 75 tools, 13 categories. Not just memory — the full stack.
+1. **Complete, not partial.** 20 tables, 82 tools, 14 categories. Not just memory — the full stack.
 2. **Open source, zero cost.** FSL license. Self-hosted on Convex free tier. No SaaS pricing trap.
 3. **Built for multi-agent teams.** Messaging with receipts. Tasks with dependencies. Missions with lifecycle. Not single-agent memory.
 4. **10-minute setup.** One deploy command. One MCP config. Production-ready.


### PR DESCRIPTION
## Summary
- Updated tool count from 75 to 82 and category count from 13 to 14 across all EN+FR doc pages (closes #51)
- Fixed per-category counts in tools.mdx and tools.fr.mdx: Tasks 11->10, Recurring Tasks 7->6, Registry 3->6, Fix Patterns 5->6 (closes #52)
- Added callerOrchestrator to settle_mandate JSON example in mandates.mdx and mandates.fr.mdx (closes #53)

## Test plan
- [ ] Grep confirms no remaining 75 tools or 13 categories in any docs page
- [ ] Category counts in tools.mdx/tools.fr.mdx sum to 82
- [ ] settle_mandate example includes callerOrchestrator in both EN and FR
- [ ] All EN+FR pairs updated consistently

Orchestrator: Sigma — VantageOS Team | 2026-04-08