### PR TITLE
fix: add Search to 14 categories list (#57)

### DIFF
--- a/content/docs/index.fr.mdx
+++ b/content/docs/index.fr.mdx
@@ -31,7 +31,7 @@ Ce n'est pas un SaaS. Ce n'est pas un service managé. Vous le déployez une foi
 
 - **20 tables de base de données** — mémoires, messages, tâches, missions, profils, journal, briefings, composants, patterns de fix, issues, mandats, unités commerciales, et plus
 - **82 outils MCP** — chaque primitive de coordination exposée comme outil MCP natif
-- **14 catégories de capacités** — mémoire, messagerie, tâches, missions, profils, journal, registre, patterns de fix, issues, mandats, unités commerciales, tâches récurrentes, monitoring d'erreurs
+- **14 catégories de capacités** — mémoire, messagerie, tâches, missions, profils, journal, recherche, registre, patterns de fix, issues, mandats, unités commerciales, tâches récurrentes, monitoring d'erreurs
 - **< 10 minutes** — de zéro à une équipe d'agents pleinement coordonnée
 - **0 € / mois** — licence FSL, auto-hébergé sur le tier gratuit de Convex
 

--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -31,7 +31,7 @@ It is not a SaaS. It is not a managed service. You deploy it once with `npx conv
 
 - **20 database tables** — memories, messages, tasks, missions, profiles, diary, briefings, components, fix patterns, issues, mandates, business units, and more
 - **82 MCP tools** — every coordination primitive exposed as a native MCP tool
-- **14 capability categories** — memory, messaging, tasks, missions, profiles, diary, registry, fix patterns, issues, mandates, business units, recurring tasks, error monitoring
+- **14 capability categories** — memory, messaging, tasks, missions, profiles, diary, search, registry, fix patterns, issues, mandates, business units, recurring tasks, error monitoring
 - **< 10 minutes** — from zero to a fully coordinated agent team
 - **$0 / month** — FSL license, self-hosted on Convex free tier
 


### PR DESCRIPTION
## Summary
- Added missing "search" category to the EN capabilities list in `content/docs/index.mdx`
- Added missing "recherche" category to the FR capabilities list in `content/docs/index.fr.mdx`
- The list previously had only 13 items despite claiming 14; now correctly lists all 14

## Test plan
- [ ] Verify the EN index page renders 14 comma-separated categories
- [ ] Verify the FR index page renders 14 comma-separated categories
- [ ] Confirm "search" / "recherche" appears in the list after "diary" / "journal"

Orchestrator: Sigma — VantageOS Team | 2026-04-08
