### PR TITLE
fix: docs OPENAI_API_KEY → AI_GATEWAY_API_KEY (#60)

### DIFF
--- a/content/docs/getting-started/index.fr.mdx
+++ b/content/docs/getting-started/index.fr.mdx
@@ -40,8 +40,8 @@ Ouvrez `.env.local` et définissez :
 # Votre URL de déploiement Convex (assignée après le deploy)
 CONVEX_URL=https://your-deployment.convex.cloud
 
-# Clé API OpenAI pour les embeddings vectoriels (requis pour recall/search)
-OPENAI_API_KEY=sk-...
+# Clé API pour les embeddings vectoriels (requis pour recall/search)
+AI_GATEWAY_API_KEY=sk-...
 ```
 
 > **À propos de la clé API OpenAI :** VantagePeers utilise `text-embedding-3-small` pour générer des embeddings vectoriels pour la recherche sémantique (`recall`, `hybrid_search`). Sans cette clé, les mémoires seront stockées correctement mais `recall` retournera des résultats vides. Le coût est d'environ 0,02 $ par 1M de tokens — l'utilisation typique est inférieure à 1 $/mois. Définissez `AI_GATEWAY_API_KEY` dans le tableau de bord Convex (Settings → Environment Variables) avec votre clé API OpenAI.
@@ -159,7 +159,7 @@ Vous devriez voir le message listé avec son ID de réception et son statut de l
 
 Pour confirmer que votre déploiement est sain, consultez le tableau de bord Convex sur [dashboard.convex.dev](https://dashboard.convex.dev). Vous devriez voir :
 
-- 19 tables dans la section Data : `memories`, `messages`, `messageReceipts`, `tasks`, `missions`, `recurringTasks`, `profiles`, `diary`, `briefingNotes`, `components`, `fixPatterns`, `fixAttempts`, `issues`, `mandates`, `businessUnits`, `missionTemplates`, `githubRepoMapping`, `monitoredDeployments`, `errorLogs`
+- 20 tables dans la section Data : `memories`, `messages`, `messageReceipts`, `tasks`, `missions`, `recurringTasks`, `profiles`, `diary`, `briefingNotes`, `components`, `fixPatterns`, `fixAttempts`, `issues`, `issueStats`, `mandates`, `businessUnits`, `missionTemplates`, `githubRepoMapping`, `monitoredDeployments`, `errorLogs`
 - Vos appels de fonctions récents dans la section Functions
 - Les index vectoriels actifs sur la table `memories`
 

--- a/content/docs/getting-started/index.mdx
+++ b/content/docs/getting-started/index.mdx
@@ -40,8 +40,8 @@ Open `.env.local` and set:
 # Your Convex deployment URL (assigned after deploy)
 CONVEX_URL=https://your-deployment.convex.cloud
 
-# OpenAI API key for vector embeddings (required for recall/search)
-OPENAI_API_KEY=sk-...
+# API key for vector embeddings (required for recall/search)
+AI_GATEWAY_API_KEY=sk-...
 ```
 
 > **About the OpenAI API key:** VantagePeers uses `text-embedding-3-small` to generate vector embeddings for semantic search (`recall`, `hybrid_search`). Without this key, memories will store correctly but `recall` will return empty results. The cost is approximately $0.02 per 1M tokens — typical usage is under $1/month. Set `AI_GATEWAY_API_KEY` in the Convex dashboard (Settings → Environment Variables) with your OpenAI API key.
@@ -159,7 +159,7 @@ You should see the message listed with its receipt ID and read status.
 
 To confirm your full deployment is healthy, check the Convex dashboard at [dashboard.convex.dev](https://dashboard.convex.dev). You should see:
 
-- 19 tables in the Data section: `memories`, `messages`, `messageReceipts`, `tasks`, `missions`, `recurringTasks`, `profiles`, `diary`, `briefingNotes`, `components`, `fixPatterns`, `fixAttempts`, `issues`, `mandates`, `businessUnits`, `missionTemplates`, `githubRepoMapping`, `monitoredDeployments`, `errorLogs`
+- 20 tables in the Data section: `memories`, `messages`, `messageReceipts`, `tasks`, `missions`, `recurringTasks`, `profiles`, `diary`, `briefingNotes`, `components`, `fixPatterns`, `fixAttempts`, `issues`, `issueStats`, `mandates`, `businessUnits`, `missionTemplates`, `githubRepoMapping`, `monitoredDeployments`, `errorLogs`
 - Your recent function calls in the Functions section
 - Vector indexes active on the `memories` table
 

--- a/content/docs/getting-started/quickstart.fr.mdx
+++ b/content/docs/getting-started/quickstart.fr.mdx
@@ -21,7 +21,7 @@ Convex affiche votre URL de déploiement. Copiez-la — vous en aurez besoin ens
 Définissez la clé OpenAI pour les embeddings vectoriels :
 
 ```bash
-npx convex env set OPENAI_API_KEY sk-your-key-here
+npx convex env set AI_GATEWAY_API_KEY sk-your-key-here
 ```
 
 ## Étape 2 : Configurer l'Agent A (Pi)

--- a/content/docs/getting-started/quickstart.mdx
+++ b/content/docs/getting-started/quickstart.mdx
@@ -21,7 +21,7 @@ Convex outputs your deployment URL. Copy it — you'll need it next.
 Set the OpenAI key for vector embeddings:
 
 ```bash
-npx convex env set OPENAI_API_KEY sk-your-key-here
+npx convex env set AI_GATEWAY_API_KEY sk-your-key-here
 ```
 
 ## Step 2: Configure Agent A (Pi)


### PR DESCRIPTION
## Summary
- Renamed all occurrences of `OPENAI_API_KEY` to `AI_GATEWAY_API_KEY` in docs to match the actual env var read by the Convex backend
- Updated both EN and FR versions of getting-started and quickstart pages (4 files total)

Closes #60

## Test plan
- [ ] Verify no remaining `OPENAI_API_KEY` references in docs (`grep -r OPENAI_API_KEY content/`)
- [ ] Confirm quickstart instructions work with `AI_GATEWAY_API_KEY`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Orchestrator: Sigma — VantageOS Team | 2026-04-08