### PR TITLE
fix: docs table count 19→20 + add issueStats (#61)

### DIFF
--- a/content/docs/getting-started/index.fr.mdx
+++ b/content/docs/getting-started/index.fr.mdx
@@ -159,7 +159,7 @@ Vous devriez voir le message listé avec son ID de réception et son statut de l
 
 Pour confirmer que votre déploiement est sain, consultez le tableau de bord Convex sur [dashboard.convex.dev](https://dashboard.convex.dev). Vous devriez voir :
 
-- 19 tables dans la section Data : `memories`, `messages`, `messageReceipts`, `tasks`, `missions`, `recurringTasks`, `profiles`, `diary`, `briefingNotes`, `components`, `fixPatterns`, `fixAttempts`, `issues`, `mandates`, `businessUnits`, `missionTemplates`, `githubRepoMapping`, `monitoredDeployments`, `errorLogs`
+- 20 tables dans la section Data : `memories`, `messages`, `messageReceipts`, `tasks`, `missions`, `recurringTasks`, `profiles`, `diary`, `briefingNotes`, `components`, `fixPatterns`, `fixAttempts`, `issues`, `issueStats`, `mandates`, `businessUnits`, `missionTemplates`, `githubRepoMapping`, `monitoredDeployments`, `errorLogs`
 - Vos appels de fonctions récents dans la section Functions
 - Les index vectoriels actifs sur la table `memories`
 

--- a/content/docs/getting-started/index.mdx
+++ b/content/docs/getting-started/index.mdx
@@ -159,7 +159,7 @@ You should see the message listed with its receipt ID and read status.
 
 To confirm your full deployment is healthy, check the Convex dashboard at [dashboard.convex.dev](https://dashboard.convex.dev). You should see:
 
-- 19 tables in the Data section: `memories`, `messages`, `messageReceipts`, `tasks`, `missions`, `recurringTasks`, `profiles`, `diary`, `briefingNotes`, `components`, `fixPatterns`, `fixAttempts`, `issues`, `mandates`, `businessUnits`, `missionTemplates`, `githubRepoMapping`, `monitoredDeployments`, `errorLogs`
+- 20 tables in the Data section: `memories`, `messages`, `messageReceipts`, `tasks`, `missions`, `recurringTasks`, `profiles`, `diary`, `briefingNotes`, `components`, `fixPatterns`, `fixAttempts`, `issues`, `issueStats`, `mandates`, `businessUnits`, `missionTemplates`, `githubRepoMapping`, `monitoredDeployments`, `errorLogs`
 - Your recent function calls in the Functions section
 - Vector indexes active on the `memories` table
 


### PR DESCRIPTION
## Summary
- Updated table count from 19 to 20 in the getting-started verification section (EN and FR)
- Added missing issueStats table to the table listing in both locales

## Test plan
- [ ] Verify EN docs show 20 tables with issueStats in the list
- [ ] Verify FR docs show 20 tables with issueStats in the list

Closes #61

Orchestrator: Sigma — VantageOS Team | 2026-04-08