### PR TITLE
fix: quickstart valid JSON + second terminal wording (#64, #65)

### DIFF
--- a/content/docs/getting-started/quickstart.fr.mdx
+++ b/content/docs/getting-started/quickstart.fr.mdx
@@ -24,7 +24,7 @@ Définissez la clé OpenAI pour les embeddings vectoriels :
 npx convex env set AI_GATEWAY_API_KEY sk-your-key-here
 ```
 
-## Étape 2 : Configurer l'Agent A (Pi)
+## Étape 2 : Configurer l'Agent A (Alice)
 
 Ouvrez les paramètres Claude Code (`~/.claude.json` ou le fichier `.claude/settings.json` de votre projet) et ajoutez :
 
@@ -44,45 +44,47 @@ Ouvrez les paramètres Claude Code (`~/.claude.json` ou le fichier `.claude/sett
 
 Redémarrez Claude Code. Vous devriez voir les outils VantagePeers dans la liste des outils.
 
-## Étape 3 : L'Agent A (Pi) stocke une mémoire
+## Étape 3 : L'Agent A (Alice) stocke une mémoire
 
-Depuis la session Claude Code de l'Agent A (Pi) :
+Depuis la session Claude Code de l'Agent A (Alice) :
 
-```
-store_memory(
-  namespace: "global",
-  type: "project",
-  content: "Project kickoff: building a REST API with FastAPI. Target: MVP by Friday.",
-  createdBy: "pi"
-)
-```
-
-Réponse : `{ memoryId: "k17..." }`
-
-## Étape 4 : L'Agent A (Pi) envoie un message
-
-```
-send_message(
-  from: "pi",
-  channel: "tau",
-  content: "Hey Tau — I stored the project brief in global memory. Start on the database schema."
-)
+```json
+{
+  "namespace": "global",
+  "type": "project",
+  "content": "Project kickoff: building a REST API with FastAPI. Target: MVP by Friday.",
+  "createdBy": "alice"
+}
 ```
 
-Réponse : `{ messageId: "jn7..." }`
+Réponse : `{ "memoryId": "k17..." }`
 
-## Étape 5 : Configurer l'Agent B (Tau)
+## Étape 4 : L'Agent A (Alice) envoie un message
 
-Sur une seconde machine (ou une seconde session Claude Code), ajoutez la même config MCP de l'Étape 2. Même `CONVEX_URL` — les deux agents partagent un seul backend.
-
-## Étape 6 : L'Agent B (Tau) vérifie ses messages
-
-Depuis la session Claude Code de l'Agent B (Tau) :
-
+```json
+{
+  "from": "alice",
+  "channel": "bob",
+  "content": "Hey Bob — I stored the project brief in global memory. Start on the database schema."
+}
 ```
-check_messages(
-  recipient: "tau"
-)
+
+Réponse : `{ "messageId": "jn7..." }`
+
+## Étape 5 : Configurer l'Agent B (Bob)
+
+Ouvrez un second terminal (ou une seconde instance VS Code) et démarrez une nouvelle session Claude Code. Utilisez le même `CONVEX_URL` — les deux sessions partagent le même backend.
+
+Ajoutez la même config MCP de l'Étape 2.
+
+## Étape 6 : L'Agent B (Bob) vérifie ses messages
+
+Depuis la session Claude Code de l'Agent B (Bob) :
+
+```json
+{
+  "recipient": "bob"
+}
 ```
 
 Réponse :
@@ -90,31 +92,31 @@ Réponse :
 ```json
 [
   {
-    "from": "pi",
-    "content": "Hey Tau — I stored the project brief in global memory. Start on the database schema.",
+    "from": "alice",
+    "content": "Hey Bob — I stored the project brief in global memory. Start on the database schema.",
     "receiptId": "k97..."
   }
 ]
 ```
 
-## Étape 7 : L'Agent B (Tau) rappelle la mémoire
+## Étape 7 : L'Agent B (Bob) rappelle la mémoire
 
+```json
+{
+  "query": "project brief MVP",
+  "namespace": "global",
+  "limit": 3
+}
 ```
-recall(
-  query: "project brief MVP",
-  namespace: "global",
-  limit: 3
-)
-```
 
-La réponse inclut la mémoire stockée par l'Agent A (Pi) — avec un classement par recherche sémantique.
+La réponse inclut la mémoire stockée par l'Agent A (Alice) — avec un classement par recherche sémantique.
 
-## Étape 8 : L'Agent B (Tau) marque le message comme lu
+## Étape 8 : L'Agent B (Bob) marque le message comme lu
 
-```
-mark_as_read(
-  receiptIds: ["k97..."]
-)
+```json
+{
+  "receiptIds": ["k97..."]
+}
 ```
 
 Terminé. Deux agents, mémoire partagée, messagerie réelle, accusés de réception. Pas de hacks fichiers. Pas de polling. Pas de bricolage.
@@ -123,9 +125,9 @@ Terminé. Deux agents, mémoire partagée, messagerie réelle, accusés de réce
 
 1. **Un seul déploiement Convex** sert de backend partagé pour les deux agents
 2. **store_memory** a persisté une mémoire avec embedding vectoriel que tout agent peut rappeler
-3. **send_message** a délivré un message de Pi à Tau avec un accusé de réception
+3. **send_message** a délivré un message d'Alice à Bob avec un accusé de réception
 4. **recall** a utilisé la recherche sémantique pour trouver les mémoires pertinentes — pas une recherche par mot-clé
-5. **mark_as_read** a confirmé que Tau a traité le message
+5. **mark_as_read** a confirmé que Bob a traité le message
 
 ## Étapes suivantes
 

--- a/content/docs/getting-started/quickstart.mdx
+++ b/content/docs/getting-started/quickstart.mdx
@@ -24,7 +24,7 @@ Set the OpenAI key for vector embeddings:
 npx convex env set AI_GATEWAY_API_KEY sk-your-key-here
 ```
 
-## Step 2: Configure Agent A (Pi)
+## Step 2: Configure Agent A (Alice)
 
 Open Claude Code settings (`~/.claude.json` or your project's `.claude/settings.json`) and add:
 
@@ -44,45 +44,47 @@ Open Claude Code settings (`~/.claude.json` or your project's `.claude/settings.
 
 Restart Claude Code. You should see VantagePeers tools in the tool list.
 
-## Step 3: Agent A (Pi) stores a memory
+## Step 3: Agent A (Alice) stores a memory
 
-From Agent A (Pi)'s Claude Code session:
+From Agent A (Alice)'s Claude Code session:
 
-```
-store_memory(
-  namespace: "global",
-  type: "project",
-  content: "Project kickoff: building a REST API with FastAPI. Target: MVP by Friday.",
-  createdBy: "pi"
-)
-```
-
-Response: `{ memoryId: "k17..." }`
-
-## Step 4: Agent A (Pi) sends a message
-
-```
-send_message(
-  from: "pi",
-  channel: "tau",
-  content: "Hey Tau — I stored the project brief in global memory. Start on the database schema."
-)
+```json
+{
+  "namespace": "global",
+  "type": "project",
+  "content": "Project kickoff: building a REST API with FastAPI. Target: MVP by Friday.",
+  "createdBy": "alice"
+}
 ```
 
-Response: `{ messageId: "jn7..." }`
+Response: `{ "memoryId": "k17..." }`
 
-## Step 5: Configure Agent B (Tau)
+## Step 4: Agent A (Alice) sends a message
 
-On a second machine (or second Claude Code session), add the same MCP config from Step 2. Same `CONVEX_URL` — both agents share one backend.
-
-## Step 6: Agent B (Tau) checks messages
-
-From Agent B (Tau)'s Claude Code session:
-
+```json
+{
+  "from": "alice",
+  "channel": "bob",
+  "content": "Hey Bob — I stored the project brief in global memory. Start on the database schema."
+}
 ```
-check_messages(
-  recipient: "tau"
-)
+
+Response: `{ "messageId": "jn7..." }`
+
+## Step 5: Configure Agent B (Bob)
+
+Open a second terminal window (or a second VS Code instance) and start a new Claude Code session. Use the same `CONVEX_URL` — both sessions share one backend.
+
+Add the same MCP config from Step 2.
+
+## Step 6: Agent B (Bob) checks messages
+
+From Agent B (Bob)'s Claude Code session:
+
+```json
+{
+  "recipient": "bob"
+}
 ```
 
 Response:
@@ -90,31 +92,31 @@ Response:
 ```json
 [
   {
-    "from": "pi",
-    "content": "Hey Tau — I stored the project brief in global memory. Start on the database schema.",
+    "from": "alice",
+    "content": "Hey Bob — I stored the project brief in global memory. Start on the database schema.",
     "receiptId": "k97..."
   }
 ]
 ```
 
-## Step 7: Agent B (Tau) recalls the memory
+## Step 7: Agent B (Bob) recalls the memory
 
+```json
+{
+  "query": "project brief MVP",
+  "namespace": "global",
+  "limit": 3
+}
 ```
-recall(
-  query: "project brief MVP",
-  namespace: "global",
-  limit: 3
-)
-```
 
-Response includes the memory Agent A (Pi) stored — with semantic search ranking.
+Response includes the memory Agent A (Alice) stored — with semantic search ranking.
 
-## Step 8: Agent B (Tau) marks the message as read
+## Step 8: Agent B (Bob) marks the message as read
 
-```
-mark_as_read(
-  receiptIds: ["k97..."]
-)
+```json
+{
+  "receiptIds": ["k97..."]
+}
 ```
 
 Done. Two agents, shared memory, real messaging, read receipts. No file hacks. No polling. No duct tape.
@@ -123,9 +125,9 @@ Done. Two agents, shared memory, real messaging, read receipts. No file hacks. N
 
 1. **One Convex deployment** serves as the shared backend for both agents
 2. **store_memory** persisted a vector-embedded memory that any agent can recall
-3. **send_message** delivered a message from Pi to Tau with a receipt
+3. **send_message** delivered a message from Alice to Bob with a receipt
 4. **recall** used semantic search to find relevant memories — not keyword matching
-5. **mark_as_read** confirmed Tau processed the message
+5. **mark_as_read** confirmed Bob processed the message
 
 ## Next steps
 


### PR DESCRIPTION
## Summary
- Replace all pseudo-code function call syntax with valid JSON objects in both EN and FR quickstart pages (closes #64)
- Replace second machine wording with second terminal window (or VS Code instance) instruction (closes #65)
- Rename agent names from Pi/Tau to Alice/Bob for generic quickstart examples

## Test plan
- [ ] Verify EN quickstart renders correctly with JSON syntax highlighting
- [ ] Verify FR quickstart renders correctly with JSON syntax highlighting
- [ ] Confirm no pseudo-code function call syntax remains in quickstart files
- [ ] Confirm no second machine references remain

Orchestrator: Sigma — VantageOS Team | 2026-04-08