### PR TITLE
fix: site code 75→82 tools (#68)

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -44,20 +44,20 @@ export async function generateMetadata({
 		en: {
 			title: "VantagePeers \u2014 Shared Memory for Multi-Agent Claude Code",
 			description:
-				"Open source memory, messaging, and task management MCP server. 20 tables, 75 tools. Free, self-hosted on Convex.",
+				"Open source memory, messaging, and task management MCP server. 20 tables, 82 tools. Free, self-hosted on Convex.",
 			ogTitle: "VantagePeers \u2014 Shared Memory for Multi-Agent Claude Code",
 			ogDesc:
-				"Open source MCP server. 75 tools, 20 tables. Semantic memory, inter-agent messaging, task management. Free, self-hosted.",
+				"Open source MCP server. 82 tools, 20 tables. Semantic memory, inter-agent messaging, task management. Free, self-hosted.",
 		},
 		fr: {
 			title:
 				"VantagePeers \u2014 M\u00e9moire partag\u00e9e pour agents Claude Code",
 			description:
-				"Serveur MCP open source pour la m\u00e9moire, la messagerie et la gestion de t\u00e2ches multi-agents. 20 tables, 75 outils. Gratuit, auto-h\u00e9berg\u00e9 sur Convex.",
+				"Serveur MCP open source pour la m\u00e9moire, la messagerie et la gestion de t\u00e2ches multi-agents. 20 tables, 82 outils. Gratuit, auto-h\u00e9berg\u00e9 sur Convex.",
 			ogTitle:
 				"VantagePeers \u2014 M\u00e9moire partag\u00e9e pour agents Claude Code",
 			ogDesc:
-				"Serveur MCP open source. 75 outils, 20 tables. M\u00e9moire s\u00e9mantique, messagerie inter-agents, gestion de t\u00e2ches. Gratuit.",
+				"Serveur MCP open source. 82 outils, 20 tables. M\u00e9moire s\u00e9mantique, messagerie inter-agents, gestion de t\u00e2ches. Gratuit.",
 		},
 	};
 

--- a/components/landing/peers-code.tsx
+++ b/components/landing/peers-code.tsx
@@ -41,7 +41,7 @@ INSTANCE_ID=pi-vps   # or pi-chromebook, tau-desktop, etc.
 # Namespaces isolate memory per project
 # global   → shared across all projects
 # project/X → scoped to project X`,
-			use: `# Store memory (75 tools available via MCP)
+			use: `# Store memory (82 tools available via MCP)
 store_memory(
   namespace="project/myapp",
   type="feedback",
@@ -108,7 +108,7 @@ INSTANCE_ID=pi-vps   # ou pi-chromebook, tau-desktop, etc.
 # Les namespaces isolent la mémoire par projet
 # global   → partage entre tous les projets
 # project/X → scope au projet X`,
-			use: `# Stocker la mémoire (75 outils disponibles via MCP)
+			use: `# Stocker la mémoire (82 outils disponibles via MCP)
 store_memory(
   namespace="project/myapp",
   type="feedback",

--- a/components/landing/peers-faq.tsx
+++ b/components/landing/peers-faq.tsx
@@ -30,7 +30,7 @@ const faqs = {
 		{
 			question: "Can I use this with any AI agent, not just Claude?",
 			answer:
-				"VantagePeers exposes 75 MCP tools. Any MCP-compatible agent can use them. Claude is the primary use case because of the Claude Code / Claude Desktop MCP support, but the protocol is open.",
+				"VantagePeers exposes 82 MCP tools. Any MCP-compatible agent can use them. Claude is the primary use case because of the Claude Code / Claude Desktop MCP support, but the protocol is open.",
 		},
 		{
 			question: "What happens to my data if Convex changes pricing?",
@@ -94,7 +94,7 @@ const faqs = {
 			question:
 				"Puis-je l'utiliser avec n'importe quel agent IA, pas seulement Claude ?",
 			answer:
-				"VantagePeers expose 75 outils MCP. N'importe quel agent compatible MCP peut les utiliser. Claude est le cas d'utilisation principal en raison du support MCP de Claude Code / Claude Desktop, mais le protocole est ouvert.",
+				"VantagePeers expose 82 outils MCP. N'importe quel agent compatible MCP peut les utiliser. Claude est le cas d'utilisation principal en raison du support MCP de Claude Code / Claude Desktop, mais le protocole est ouvert.",
 		},
 		{
 			question:

--- a/components/landing/peers-features.tsx
+++ b/components/landing/peers-features.tsx
@@ -20,7 +20,7 @@ const content = {
 	en: {
 		title: "Everything agents need. Nothing you pay for.",
 		subtitle:
-			"20 database tables. 75 MCP tools. One Convex deployment. All the primitives for coordinating AI agents across machines.",
+			"20 database tables. 82 MCP tools. One Convex deployment. All the primitives for coordinating AI agents across machines.",
 		features: [
 			{
 				icon: Brain,
@@ -115,7 +115,7 @@ const content = {
 	fr: {
 		title: "Tout ce dont les agents ont besoin. Rien que vous ne payez.",
 		subtitle:
-			"20 tables de base de données. 75 outils MCP. Un déploiement Convex. Tous les primitifs pour coordonner des agents IA multi-machines.",
+			"20 tables de base de données. 82 outils MCP. Un déploiement Convex. Tous les primitifs pour coordonner des agents IA multi-machines.",
 		features: [
 			{
 				icon: Brain,

--- a/components/landing/peers-how-it-works.tsx
+++ b/components/landing/peers-how-it-works.tsx
@@ -32,7 +32,7 @@ const content = {
 				icon: Network,
 				title: "Coordinate",
 				description:
-					"Agents store memory, send messages, assign tasks — all via the 75 MCP tools. Works across machines, across sessions, across agent instances.",
+					"Agents store memory, send messages, assign tasks — all via the 82 MCP tools. Works across machines, across sessions, across agent instances.",
 				color: "text-chart-4",
 				bgColor: "bg-chart-4/10",
 			},
@@ -68,7 +68,7 @@ const content = {
 				icon: Network,
 				title: "Coordonner",
 				description:
-					"Les agents stockent la mémoire, envoient des messages, assignent des tâches — le tout via les 75 outils MCP. Fonctionne entre machines, entre sessions, entre instances d'agents.",
+					"Les agents stockent la mémoire, envoient des messages, assignent des tâches — le tout via les 82 outils MCP. Fonctionne entre machines, entre sessions, entre instances d'agents.",
 				color: "text-chart-4",
 				bgColor: "bg-chart-4/10",
 			},

--- a/components/landing/peers-pricing.tsx
+++ b/components/landing/peers-pricing.tsx
@@ -15,7 +15,7 @@ const content = {
 				period: "forever",
 				description: "Full VantagePeers. Your Convex. Your data.",
 				features: [
-					"75 MCP tools, 20 tables",
+					"82 MCP tools, 20 tables",
 					"Semantic memory + RAG search",
 					"Cross-machine messaging",
 					"Task coordination + missions",
@@ -74,7 +74,7 @@ const content = {
 				period: "pour toujours",
 				description: "VantagePeers complet. Votre Convex. Vos donn\u00e9es.",
 				features: [
-					"75 outils MCP, 20 tables",
+					"82 outils MCP, 20 tables",
 					"M\u00e9moire s\u00e9mantique + recherche RAG",
 					"Messagerie cross-machine",
 					"Coordination de t\u00e2ches + missions",

--- a/components/landing/structured-data.tsx
+++ b/components/landing/structured-data.tsx
@@ -16,8 +16,8 @@ function getOrganizationSchema(locale: string) {
 			url: `${BASE_URL}/opengraph-image`,
 		},
 		description: locale === "fr"
-			? "Serveur MCP open source pour la m\u00e9moire partag\u00e9e, la messagerie et la gestion de t\u00e2ches multi-agents Claude Code. 20 tables, 75 outils. Gratuit, auto-h\u00e9berg\u00e9 sur Convex."
-			: "Open source shared memory, messaging, and task management MCP server for multi-agent Claude Code. 20 database tables, 75 MCP tools. Free, self-hosted on Convex.",
+			? "Serveur MCP open source pour la m\u00e9moire partag\u00e9e, la messagerie et la gestion de t\u00e2ches multi-agents Claude Code. 20 tables, 82 outils. Gratuit, auto-h\u00e9berg\u00e9 sur Convex."
+			: "Open source shared memory, messaging, and task management MCP server for multi-agent Claude Code. 20 database tables, 82 MCP tools. Free, self-hosted on Convex.",
 		sameAs: [
 			"https://github.com/vantageos",
 			"https://x.com/PerelloLaurent",
@@ -50,22 +50,22 @@ const webSiteSchema = {
 const webPageContent = {
 	en: {
 		name: "VantagePeers — Shared Memory for Multi-Agent Claude Code",
-		description: "Open source MCP server. 75 tools, 20 tables. Semantic memory, inter-agent messaging, task management. Free, self-hosted.",
+		description: "Open source MCP server. 82 tools, 20 tables. Semantic memory, inter-agent messaging, task management. Free, self-hosted.",
 		faq: [
 			{ q: "Is VantagePeers free to use?", a: "Yes. VantagePeers is fully open source under the FSL license. It is free, self-hosted, and has no subscription fee." },
 			{ q: "What is VantagePeers?", a: "VantagePeers is an open source MCP server that gives Claude Code agents shared memory, inter-agent messaging with read receipts, and task management. It connects multiple AI agents across machines via Convex cloud." },
-			{ q: "How many MCP tools does VantagePeers provide?", a: "VantagePeers provides 75 MCP tools across 20 database tables, covering semantic memory recall, inter-agent messaging, task management, fix pattern knowledge base, GitHub issue tracking, business unit management, mandates, recurring tasks, missions, agent diary, component registry, and cross-machine coordination." },
+			{ q: "How many MCP tools does VantagePeers provide?", a: "VantagePeers provides 82 MCP tools across 20 database tables, covering semantic memory recall, inter-agent messaging, task management, fix pattern knowledge base, GitHub issue tracking, business unit management, mandates, recurring tasks, missions, agent diary, component registry, and cross-machine coordination." },
 			{ q: "What technology does VantagePeers run on?", a: "VantagePeers is built on Convex (a real-time database) with vector embeddings powered by @convex-dev/rag. It is self-hosted and free to run." },
 			{ q: "How does VantagePeers compare to mem0 or Zep?", a: "VantagePeers replaces paid memory services like mem0 ($249/mo) and Zep ($475/mo) with a free, self-hosted alternative. Unlike claude-peers which is local-only, VantagePeers uses Convex cloud for cross-machine agent coordination." },
 		],
 	},
 	fr: {
 		name: "VantagePeers — Mémoire partagée pour agents Claude Code",
-		description: "Serveur MCP open source. 75 outils, 20 tables. Mémoire sémantique, messagerie inter-agents, gestion de tâches. Gratuit, auto-hébergé.",
+		description: "Serveur MCP open source. 82 outils, 20 tables. Mémoire sémantique, messagerie inter-agents, gestion de tâches. Gratuit, auto-hébergé.",
 		faq: [
 			{ q: "VantagePeers est-il gratuit ?", a: "Oui. VantagePeers est entièrement open source sous licence FSL. Il est gratuit, auto-hébergé, et sans abonnement." },
 			{ q: "Qu'est-ce que VantagePeers ?", a: "VantagePeers est un serveur MCP open source qui donne aux agents Claude Code une mémoire partagée, une messagerie inter-agents avec accusés de réception, et une gestion de tâches. Il connecte plusieurs agents IA sur différentes machines via Convex cloud." },
-			{ q: "Combien d'outils MCP VantagePeers fournit-il ?", a: "VantagePeers fournit 75 outils MCP répartis sur 20 tables de base de données : rappel de mémoire sémantique, messagerie inter-agents, gestion de tâches, base de connaissances de fix patterns, suivi d'issues GitHub, gestion d'unités d'affaires, mandats, tâches récurrentes, missions, journal d'agent, registre de composants, et coordination multi-machines." },
+			{ q: "Combien d'outils MCP VantagePeers fournit-il ?", a: "VantagePeers fournit 82 outils MCP répartis sur 20 tables de base de données : rappel de mémoire sémantique, messagerie inter-agents, gestion de tâches, base de connaissances de fix patterns, suivi d'issues GitHub, gestion d'unités d'affaires, mandats, tâches récurrentes, missions, journal d'agent, registre de composants, et coordination multi-machines." },
 			{ q: "Sur quelle technologie fonctionne VantagePeers ?", a: "VantagePeers est construit sur Convex (une base de données temps réel) avec des embeddings vectoriels via @convex-dev/rag. Il est auto-hébergé et gratuit." },
 			{ q: "Comment VantagePeers se compare-t-il à mem0 ou Zep ?", a: "VantagePeers remplace les services de mémoire payants comme mem0 (249$/mois) et Zep (475$/mois) par une alternative gratuite et auto-hébergée. Contrairement à claude-peers qui est local uniquement, VantagePeers utilise Convex cloud pour la coordination inter-machines." },
 		],
@@ -128,7 +128,7 @@ function getSoftwareApplicationSchema(locale: string) {
 			"Task management with dependencies and missions",
 			"Vector embedding search via @convex-dev/rag",
 			"Cross-machine agent coordination",
-			"75 MCP tools across 20 database tables",
+			"82 MCP tools across 20 database tables",
 			"Fix pattern knowledge base with semantic search",
 			"GitHub issue tracking integration",
 			"Agent diary and session management",

--- a/e2e/landing.spec.ts
+++ b/e2e/landing.spec.ts
@@ -24,17 +24,17 @@ test.describe("VantagePeers landing page", () => {
 		expect(bodyText).not.toContain("Persistent memory");
 	});
 
-	// Test 3: Hero stats show "20" tables and "75" tools
-	test("hero stats show 20 tables and 75 tools", async ({ page }) => {
+	// Test 3: Hero stats show "20" tables and "82" tools
+	test("hero stats show 20 tables and 82 tools", async ({ page }) => {
 		const bodyText = await page.locator("body").textContent();
 		expect(bodyText).toMatch(/20/);
-		expect(bodyText).toMatch(/75/);
+		expect(bodyText).toMatch(/82/);
 		// Verify via meta description which is always present
 		const metaDesc = await page
 			.locator('meta[name="description"]')
 			.getAttribute("content");
 		expect(metaDesc).toContain("20 tables");
-		expect(metaDesc).toContain("75 tools");
+		expect(metaDesc).toContain("82 tools");
 	});
 
 	// Test 4: FSL license badge visible (not MIT)


### PR DESCRIPTION
## Summary
- Updated all tool count references from 75 to 82 across 8 site code files (React components + e2e tests)
- Covers both English and French (fr) locale strings
- Does not touch docs/markdown content files

## Files changed
- components/landing/structured-data.tsx — EN + FR descriptions, FAQ answers, feature list
- app/[locale]/layout.tsx — EN + FR meta descriptions and OG descriptions
- components/landing/peers-code.tsx — EN + FR code example comments
- components/landing/peers-how-it-works.tsx — EN + FR step descriptions
- components/landing/peers-pricing.tsx — EN + FR feature lists
- components/landing/peers-faq.tsx — EN + FR FAQ answers
- components/landing/peers-features.tsx — EN + FR subtitles
- e2e/landing.spec.ts — test assertions updated to expect 82

## Test plan
- [ ] Verify npx playwright test e2e/landing.spec.ts passes with updated assertions
- [ ] Verify no remaining 75 tools or 75 outils in tsx/ts files

Closes #68

Orchestrator: Sigma — VantageOS Team | 2026-04-08