### PR TITLE
fix: getting-started step order + 5min→15min (#69, #70)

### DIFF
--- a/content/docs/getting-started/index.fr.mdx
+++ b/content/docs/getting-started/index.fr.mdx
@@ -5,7 +5,7 @@ description: Déployez VantagePeers et connectez votre premier agent en moins de
 
 # Démarrage
 
-VantagePeers se déploie en cinq étapes : cloner, configurer, s'authentifier, déployer et configurer le serveur MCP. Aucune infrastructure à gérer au-delà d'un compte Convex.
+VantagePeers se déploie en cinq étapes : cloner, s'authentifier, déployer, configurer les variables d'environnement et configurer le serveur MCP. Aucune infrastructure à gérer au-delà d'un compte Convex.
 
 ## Prérequis
 
@@ -26,9 +26,29 @@ cd vantage-peers
 npm install
 ```
 
-### Étape 2 : Configurer les variables d'environnement
+### Étape 2 : Se connecter à Convex
 
-Copiez le fichier d'environnement exemple et remplissez vos valeurs :
+```bash
+npx convex login
+```
+
+Cela ouvre une fenêtre de navigateur pour vous authentifier avec votre compte Convex. Si vous n'avez pas encore de compte, créez-en un sur [convex.dev](https://convex.dev) — le tier gratuit est suffisant.
+
+### Étape 3 : Déployer sur Convex
+
+```bash
+npx convex deploy
+```
+
+Cela déploie les 20 tables de base de données, les fonctions serverless et les index vectoriels sur votre compte Convex. Convex affichera votre URL de déploiement — copiez-la.
+
+### Étape 4 : Configurer les variables d'environnement
+
+Définissez `AI_GATEWAY_API_KEY` dans le **tableau de bord Convex** (Settings → Environment Variables) avec votre clé API OpenAI. Ceci est requis pour la recherche sémantique (`recall`, `hybrid_search`).
+
+> **À propos de la clé API OpenAI :** VantagePeers utilise `text-embedding-3-small` pour générer des embeddings vectoriels pour la recherche sémantique. Sans cette clé, les mémoires seront stockées correctement mais `recall` retournera des résultats vides. Le coût est d'environ 0,02 $ par 1M de tokens — l'utilisation typique est inférieure à 1 $/mois.
+
+Optionnellement, si vous avez besoin d'un fichier `.env.local` pour le développement local :
 
 ```bash
 cp .env.example .env.local
@@ -37,30 +57,14 @@ cp .env.example .env.local
 Ouvrez `.env.local` et définissez :
 
 ```bash
-# Votre URL de déploiement Convex (assignée après le deploy)
+# Votre URL de déploiement Convex (de la sortie de l'étape 3)
 CONVEX_URL=https://your-deployment.convex.cloud
 
 # Clé API pour les embeddings vectoriels (requis pour recall/search)
 AI_GATEWAY_API_KEY=sk-...
 ```
 
-> **À propos de la clé API OpenAI :** VantagePeers utilise `text-embedding-3-small` pour générer des embeddings vectoriels pour la recherche sémantique (`recall`, `hybrid_search`). Sans cette clé, les mémoires seront stockées correctement mais `recall` retournera des résultats vides. Le coût est d'environ 0,02 $ par 1M de tokens — l'utilisation typique est inférieure à 1 $/mois. Définissez `AI_GATEWAY_API_KEY` dans le tableau de bord Convex (Settings → Environment Variables) avec votre clé API OpenAI.
-
-### Étape 3 : Se connecter à Convex
-
-```bash
-npx convex login
-```
-
-Cela ouvre une fenêtre de navigateur pour vous authentifier avec votre compte Convex. Si vous n'avez pas encore de compte, créez-en un sur [convex.dev](https://convex.dev) — le tier gratuit est suffisant.
-
-### Étape 4 : Déployer sur Convex
-
-```bash
-npx convex deploy
-```
-
-Cela déploie les 20 tables de base de données, les fonctions serverless et les index vectoriels sur votre compte Convex. Convex affichera votre URL de déploiement — copiez-la.
+> **Note :** Le fichier `.env.local` est optionnel pour la plupart des configurations. La configuration du serveur MCP (étape 5) passe `CONVEX_URL` directement, et `AI_GATEWAY_API_KEY` est défini dans le tableau de bord Convex.
 
 ### Étape 5 : Configurer le serveur MCP
 

--- a/content/docs/getting-started/index.mdx
+++ b/content/docs/getting-started/index.mdx
@@ -5,7 +5,7 @@ description: Deploy VantagePeers and connect your first agent in under 10 minute
 
 # Getting Started
 
-VantagePeers deploys in five steps: clone, configure, authenticate, deploy, and set up the MCP server. No infrastructure to manage beyond a Convex account.
+VantagePeers deploys in five steps: clone, authenticate, deploy, configure environment variables, and set up the MCP server. No infrastructure to manage beyond a Convex account.
 
 ## Prerequisites
 
@@ -26,9 +26,29 @@ cd vantage-peers
 npm install
 ```
 
-### Step 2: Configure environment variables
+### Step 2: Log in to Convex
 
-Copy the example environment file and fill in your values:
+```bash
+npx convex login
+```
+
+This opens a browser window to authenticate with your Convex account. If you don't have an account yet, create one at [convex.dev](https://convex.dev) — the free tier is sufficient.
+
+### Step 3: Deploy to Convex
+
+```bash
+npx convex deploy
+```
+
+This deploys all 20 database tables, serverless functions, and vector indexes to your Convex account. Convex will output your deployment URL — copy it.
+
+### Step 4: Set environment variables
+
+Set `AI_GATEWAY_API_KEY` in the **Convex dashboard** (Settings → Environment Variables) with your OpenAI API key. This is required for semantic search (`recall`, `hybrid_search`).
+
+> **About the OpenAI API key:** VantagePeers uses `text-embedding-3-small` to generate vector embeddings for semantic search. Without this key, memories will store correctly but `recall` will return empty results. The cost is approximately $0.02 per 1M tokens — typical usage is under $1/month.
+
+Optionally, if you need a local `.env.local` file for development:
 
 ```bash
 cp .env.example .env.local
@@ -37,30 +57,14 @@ cp .env.example .env.local
 Open `.env.local` and set:
 
 ```bash
-# Your Convex deployment URL (assigned after deploy)
+# Your Convex deployment URL (from Step 3 output)
 CONVEX_URL=https://your-deployment.convex.cloud
 
 # API key for vector embeddings (required for recall/search)
 AI_GATEWAY_API_KEY=sk-...
 ```
 
-> **About the OpenAI API key:** VantagePeers uses `text-embedding-3-small` to generate vector embeddings for semantic search (`recall`, `hybrid_search`). Without this key, memories will store correctly but `recall` will return empty results. The cost is approximately $0.02 per 1M tokens — typical usage is under $1/month. Set `AI_GATEWAY_API_KEY` in the Convex dashboard (Settings → Environment Variables) with your OpenAI API key.
-
-### Step 3: Log in to Convex
-
-```bash
-npx convex login
-```
-
-This opens a browser window to authenticate with your Convex account. If you don't have an account yet, create one at [convex.dev](https://convex.dev) — the free tier is sufficient.
-
-### Step 4: Deploy to Convex
-
-```bash
-npx convex deploy
-```
-
-This deploys all 20 database tables, serverless functions, and vector indexes to your Convex account. Convex will output your deployment URL — copy it.
+> **Note:** The `.env.local` file is optional for most setups. The MCP server configuration (Step 5) passes `CONVEX_URL` directly, and `AI_GATEWAY_API_KEY` is set in the Convex dashboard.
 
 ### Step 5: Configure the MCP server
 

--- a/content/docs/index.fr.mdx
+++ b/content/docs/index.fr.mdx
@@ -20,7 +20,7 @@ Ce n'est pas un SaaS. Ce n'est pas un service managé. Vous le déployez une foi
 | Sujet | Description |
 |-------|-------------|
 | [Démarrage](/docs/getting-started) | Installer, déployer et connecter en moins de 10 minutes |
-| [Quickstart](/docs/getting-started/quickstart) | Deux agents qui échangent des messages en 5 minutes |
+| [Quickstart](/docs/getting-started/quickstart) | Deux agents qui échangent des messages en 15 minutes |
 | [Architecture](/docs/core-concepts/architecture) | Concepts clés, schéma de base de données et intégration MCP |
 | [Référence des outils](/docs/tools) | Les 14 catégories et 82 outils |
 | [Mémoire](/docs/capabilities/memory) | Mémoire sémantique, namespaces et recherche vectorielle |

--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -20,7 +20,7 @@ It is not a SaaS. It is not a managed service. You deploy it once with `npx conv
 | Topic | Description |
 |-------|-------------|
 | [Getting Started](/docs/getting-started) | Install, deploy, and connect in under 10 minutes |
-| [Quickstart](/docs/getting-started/quickstart) | Two agents exchanging messages in 5 minutes |
+| [Quickstart](/docs/getting-started/quickstart) | Two agents exchanging messages in 15 minutes |
 | [Architecture](/docs/core-concepts/architecture) | Core concepts, database schema, and MCP integration |
 | [Tools Reference](/docs/tools) | All 14 tool categories and 82 tools |
 | [Memory](/docs/capabilities/memory) | Semantic memory, namespaces, and vector search |


### PR DESCRIPTION
## Summary
- **#69** — Reordered getting-started steps so npx convex deploy (Step 3) runs before CONVEX_URL is referenced. The .env.local file is now marked as optional since the MCP config passes CONVEX_URL directly and AI_GATEWAY_API_KEY is set in the Convex dashboard.
- **#70** — Changed 5 minutes to 15 minutes in the Quick Links table for the Quickstart row.
- Both EN and FR files updated.

Closes #69, closes #70

## Test plan
- [ ] Verify getting-started steps are logically ordered (deploy before env vars)
- [ ] Verify no 5 minutes references remain in Quick Links
- [ ] Verify both EN (index.mdx) and FR (index.fr.mdx) are consistent

Orchestrator: Sigma — VantageOS Team | 2026-04-08