### PR TITLE
feat: install Plausible Analytics on vantagepeers.com

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { notFound } from "next/navigation";
+import Script from "next/script";
 import { NextIntlClientProvider } from "next-intl";
 import { getMessages, setRequestLocale } from "next-intl/server";
 import { LandingStructuredData } from "@/components/landing/structured-data";
@@ -129,6 +130,12 @@ export default async function LocaleLayout({ children, params }: Props) {
 					href="/apple-touch-icon.png"
 				/>
 				<LandingStructuredData locale={locale} />
+				<Script
+					defer
+					data-domain="vantagepeers.com"
+					src="https://plausible.io/js/script.js"
+					strategy="afterInteractive"
+				/>
 			</head>
 			<body
 				className={`${geistSans.variable} ${geistMono.variable} antialiased`}
@@ -143,11 +150,13 @@ export default async function LocaleLayout({ children, params }: Props) {
 						href="#main-content"
 						className="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-[9999] focus:px-4 focus:py-2 focus:rounded-2xl focus:bg-primary focus:text-primary-foreground focus:font-medium focus:outline-none focus:ring-2 focus:ring-ring"
 					>
-						{locale === "fr" ? "Aller au contenu principal" : "Skip to main content"}
+						{locale === "fr"
+							? "Aller au contenu principal"
+							: "Skip to main content"}
 					</a>
 					<noscript>
 						<style>{`
-							[data-framer-motion-initial], .motion-safe\:opacity-0 { opacity: 1 !important; transform: none !important; }
+							[data-framer-motion-initial], .motion-safe:opacity-0 { opacity: 1 !important; transform: none !important; }
 						`}</style>
 					</noscript>
 					<NextIntlClientProvider messages={messages}>

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,64 +1,64 @@
+import { createMDX } from "fumadocs-mdx/next";
 import type { NextConfig } from "next";
 import createNextIntlPlugin from "next-intl/plugin";
-import { createMDX } from "fumadocs-mdx/next";
 
 const withNextIntl = createNextIntlPlugin("./i18n/request.ts");
 const withMDX = createMDX();
 
 const nextConfig: NextConfig = {
-  async rewrites() {
-    return {
-      beforeFiles: [
-        // Docs i18n: /docs → /docs/en (default locale)
-        {
-          source: "/docs",
-          destination: "/docs/en",
-        },
-        // /docs/fr/* stays as-is (matched by [lang])
-        // /docs/* (non-fr) → /docs/en/* for backwards compatibility
-        {
-          source: "/docs/:path((?!en|fr).*)",
-          destination: "/docs/en/:path*",
-        },
-      ],
-      afterFiles: [
-        {
-          source: "/docs/:path*.mdx",
-          destination: "/llms.mdx/docs/:path*",
-        },
-      ],
-    };
-  },
-  async headers() {
-    return [
-      {
-        source: "/(.*)",
-        headers: [
-          {
-            key: "X-Content-Type-Options",
-            value: "nosniff",
-          },
-          {
-            key: "X-Frame-Options",
-            value: "DENY",
-          },
-          {
-            key: "Referrer-Policy",
-            value: "strict-origin-when-cross-origin",
-          },
-          {
-            key: "Permissions-Policy",
-            value: "camera=(), microphone=(), geolocation=()",
-          },
-          {
-            key: "Content-Security-Policy",
-            value:
-              "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https:;",
-          },
-        ],
-      },
-    ];
-  },
+	async rewrites() {
+		return {
+			beforeFiles: [
+				// Docs i18n: /docs → /docs/en (default locale)
+				{
+					source: "/docs",
+					destination: "/docs/en",
+				},
+				// /docs/fr/* stays as-is (matched by [lang])
+				// /docs/* (non-fr) → /docs/en/* for backwards compatibility
+				{
+					source: "/docs/:path((?!en|fr).*)",
+					destination: "/docs/en/:path*",
+				},
+			],
+			afterFiles: [
+				{
+					source: "/docs/:path*.mdx",
+					destination: "/llms.mdx/docs/:path*",
+				},
+			],
+		};
+	},
+	async headers() {
+		return [
+			{
+				source: "/(.*)",
+				headers: [
+					{
+						key: "X-Content-Type-Options",
+						value: "nosniff",
+					},
+					{
+						key: "X-Frame-Options",
+						value: "DENY",
+					},
+					{
+						key: "Referrer-Policy",
+						value: "strict-origin-when-cross-origin",
+					},
+					{
+						key: "Permissions-Policy",
+						value: "camera=(), microphone=(), geolocation=()",
+					},
+					{
+						key: "Content-Security-Policy",
+						value:
+							"default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://plausible.io; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://plausible.io https:;",
+					},
+				],
+			},
+		];
+	},
 };
 
 export default withMDX(withNextIntl(nextConfig));


### PR DESCRIPTION
## Summary

Install Plausible Analytics script on vantagepeers.com and update CSP to allow plausible.io.

## Changes

| File | Intent |
|------|--------|
| `app/[locale]/layout.tsx` | Add Script tag (strategy=afterInteractive, data-domain=vantagepeers.com) inside head |
| `next.config.ts` | Update Content-Security-Policy: add https://plausible.io to script-src and connect-src |

## CSP status

**Updated** — CSP lives in `next.config.ts` headers. Both `script-src` and `connect-src` now explicitly list `https://plausible.io`. No CSP in `middleware.ts` (next-intl routing only).

## Test plan

- [ ] Build clean (verified locally: pnpm run build passes)
- [ ] Preview deploy shows script tag in page source
- [ ] No CSP violations in browser console on preview URL
- [ ] Laurent adds vantagepeers.com to Plausible dashboard after merge

Orchestrator: Sigma — VantageOS Team | 2026-04-19