### PR TITLE
docs: document `since` param on check_messages (EN + FR) (S-BW-T5)

### DIFF
--- a/content/docs/capabilities/messaging.fr.mdx
+++ b/content/docs/capabilities/messaging.fr.mdx
@@ -121,6 +121,8 @@ Chaque message crée un enregistrement d'accusé par destinataire prévu. Les ac
 
 Marquer les messages comme lus n'est pas juste de la comptabilité — cela détermine ce que `check_messages` retourne au prochain appel. Si vous ne marquez jamais les messages comme lus, chaque appel retourne l'intégralité du backlog. Marquez comme lu après traitement pour garder la file de messages propre.
 
+Pour du polling incrémental, passez le paramètre `since` à `check_messages` avec le timestamp de votre dernier check — cela évite de re-transférer l'intégralité du backlog non lu.
+
 ## Cycle de vie du message
 
 ```

--- a/content/docs/capabilities/messaging.mdx
+++ b/content/docs/capabilities/messaging.mdx
@@ -121,6 +121,8 @@ Every message creates a receipt record per intended recipient. Receipts track wh
 
 Marking messages read is not just bookkeeping — it determines what `check_messages` returns on the next call. If you never mark messages read, every call returns the full backlog. Mark as read after processing to keep the message queue clean.
 
+For incremental polling, pass the `since` parameter to `check_messages` with the timestamp of your last check — this avoids re-transferring the full unread backlog.
+
 ## Message Lifecycle
 
 ```

--- a/content/docs/tools.fr.mdx
+++ b/content/docs/tools.fr.mdx
@@ -156,7 +156,7 @@ Envoie un message à un canal, rôle ou instance spécifique.
 
 ### `check_messages`
 
-Récupère les messages non lus pour un destinataire.
+Récupère les messages non lus pour un destinataire. Optionnellement filtre par instance ou interroge de manière incrémentale via `since`.
 
 ```json
 {
@@ -164,6 +164,18 @@ Récupère les messages non lus pour un destinataire.
   "recipientInstanceId": "alice-main"
 }
 ```
+
+Pour les polls fréquents, passez `since` (timestamp Unix ms de votre dernier check) pour ne recevoir que les messages créés après ce point. C'est le pattern recommandé pour les agents longue durée — il évite de re-transférer l'intégralité du backlog non lu à chaque appel.
+
+```json
+{
+  "recipient": "alice",
+  "recipientInstanceId": "alice-main",
+  "since": 1776803000000
+}
+```
+
+Retourne un tableau de messages avec leurs receipt IDs.
 
 ### `mark_as_read`
 

--- a/content/docs/tools.mdx
+++ b/content/docs/tools.mdx
@@ -183,12 +183,22 @@ To broadcast to all agents:
 
 ### `check_messages`
 
-Retrieves unread messages for a recipient. Optionally filter by instance.
+Retrieves unread messages for a recipient. Optionally filter by instance or poll incrementally via `since`.
 
 ```json
 {
   "recipient": "alice",
   "recipientInstanceId": "alice-main"
+}
+```
+
+For high-frequency polling, pass `since` (Unix ms timestamp of your last check) to receive only messages created after that point. This is the recommended pattern for long-running agents — it avoids re-transferring the full unread backlog on every call.
+
+```json
+{
+  "recipient": "alice",
+  "recipientInstanceId": "alice-main",
+  "since": 1776803000000
 }
 ```
 


### PR DESCRIPTION
## Summary

Documents the new optional `since` timestamp param on `check_messages` across EN + FR docs.

- **`content/docs/tools.mdx`** — extends the `check_messages` section with incremental polling usage + example.
- **`content/docs/tools.fr.mdx`** — same, FR translation.
- **`content/docs/capabilities/messaging.mdx`** — one-sentence note in "Why Mark Messages Read?" pointing to `since` for incremental polling.
- **`content/docs/capabilities/messaging.fr.mdx`** — same, FR.

## Context

Part of mission `k574va3f3ks6p7dx273f0hx67n858cr6` — VantagePeers bandwidth optimization.

Series across repos:
- T2 (Convex `since` param) — `vantage-peers#297` merged
- T3 (issues pagination) — `vantage-peers#298` merged
- T5-A (MCP wrapper propagation) — `vantage-peers#300` (open, paired)
- T5-B (this PR, site docs)

Incremental polling via `since` is the recommended pattern for long-running agents — avoids re-transferring the full unread backlog on every poll. Expected savings: up to 80% on high-frequency `check_messages` calls.

## Test plan

- [x] MDX renders (no syntax changes, only content)
- [x] EN and FR kept in sync
- [x] Terminology matches existing docs (`backlog`, `incremental polling`, `receipt IDs`)
- [ ] Manual visual check in Fumadocs preview post-merge

## Hard constraints honored

- Untracked files (`.claude/`, `cli.json`, `test-results/`) left untouched
- No changes to `llms.txt` / `llms-full.txt` (don't contain tool signatures)
- No force-push

Orchestrator: Sigma — VantagePeers | 2026-04-21
