### PR TITLE
fix(seo): switch canonical base URL from apex to www (S-SM-T2)

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -8,7 +8,7 @@ import { LandingStructuredData } from "@/components/landing/structured-data";
 import { ThemeProvider } from "@/components/theme-provider";
 import { routing } from "@/i18n/routing";
 
-const BASE_URL = "https://vantagepeers.com";
+const BASE_URL = "https://www.vantagepeers.com";
 
 type Locale = "en" | "fr";
 

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -33,6 +33,6 @@ export default function robots(): MetadataRoute.Robots {
 				allow: "/",
 			},
 		],
-		sitemap: "https://vantagepeers.com/sitemap.xml",
+		sitemap: "https://www.vantagepeers.com/sitemap.xml",
 	};
 }

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,7 +1,7 @@
 import type { MetadataRoute } from "next";
 
 export default function sitemap(): MetadataRoute.Sitemap {
-	const baseUrl = "https://vantagepeers.com";
+	const baseUrl = "https://www.vantagepeers.com";
 
 	return [
 		{


### PR DESCRIPTION
## Why

Google and Bing currently hit a 307 apex→www redirect on every sitemap entry because `sitemap.ts` generates URLs against the apex (`https://vantagepeers.com`) while the runtime middleware 307's apex → www. Same content ends up being served, but every crawl spends an extra redirect hop and logs an "inconsistent canonical" signal (sitemap host ≠ canonical host ≠ served host).

This PR aligns the baked-in base URL with the host the runtime actually serves. The apex→www redirect in `next.config.ts` / middleware stays — apex visitors still reach the site, but sitemaps, canonical links, and OG image URLs no longer point at the redirected form.

## Changes (3 files, 3 single-line edits)

- `app/sitemap.ts:4` — `baseUrl` → `https://www.vantagepeers.com`
- `app/robots.ts:36` — `sitemap:` pointer → `https://www.vantagepeers.com/sitemap.xml`
- `app/[locale]/layout.tsx:11` — `BASE_URL` → `https://www.vantagepeers.com` (propagates to canonical, hreflang alternates, OG image URL)

## Explicitly NOT touched

- `app/opengraph-image.tsx:164` — this is display text on the OG card ("vantagepeers.com"), not a URL. Users looking at the card don't care about www vs apex, and the shorter form reads better.
- `next.config.ts` / middleware apex→www 307 — stays. Decision: redirect remains so apex hits still resolve, but canonical URLs no longer reference the redirected form.

## Verification

Grep counts across the 3 files:

| pattern | before | after |
|---|---|---|
| `https://vantagepeers\.com` (apex-exclusive) | 3 | 0 |
| `https://www\.vantagepeers\.com` | 0 | 3 |

Generated artifacts inspected after build:

- `.next/server/app/sitemap.xml.body` — all 15+ entries use `https://www.vantagepeers.com/...`
- `.next/server/app/robots.txt.body` — `Sitemap: https://www.vantagepeers.com/sitemap.xml`

Commands:

```
bun run build      # PASS — 96 static pages generated, no errors
bunx tsc --noEmit  # clean
```

## Mission

`k578zk4yv3c7fbwcgvm0na32ph85870k` — task S-SM-T2 (T1 analysis landed previously).

## Review notes for Eta

- Mechanical 3-line change, low blast radius.
- No redirect behavior changed — verify by hitting `https://vantagepeers.com/docs` after merge; should still 307 to www.
- Expect Search Console to re-ingest sitemap within a crawl cycle; monitor the "Discovered — currently not indexed" bucket.

---

Orchestrator: Sigma — VantagePeers | 2026-04-22
