### PR TITLE
feat(landing): pricing 2-track refonte (Self-Hosted + Cloud) + pain section refonte (D62)

### DIFF
--- a/components/landing/peers-compare-tracks.tsx
+++ b/components/landing/peers-compare-tracks.tsx
@@ -1,0 +1,218 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { Check, Minus } from "lucide-react";
+
+type RowIcon = "check" | "neutral";
+
+interface CompareRow {
+	dimension: string;
+	selfHosted: string;
+	cloud: string;
+	selfHostedIcon: RowIcon;
+	cloudIcon: RowIcon;
+}
+
+interface CompareContent {
+	title: string;
+	headers: {
+		dimension: string;
+		selfHosted: string;
+		cloud: string;
+	};
+	rows: CompareRow[];
+}
+
+const content: Record<"en" | "fr", CompareContent> = {
+	en: {
+		title: "Self-Hosted or Cloud?",
+		headers: {
+			dimension: "Dimension",
+			selfHosted: "Self-Hosted",
+			cloud: "Cloud",
+		},
+		rows: [
+			{
+				dimension: "Setup time",
+				selfHosted: "10 min (CLI) or 2 min (Railway)",
+				cloud: "Instant — no setup",
+				selfHostedIcon: "neutral",
+				cloudIcon: "check",
+			},
+			{
+				dimension: "Hosting",
+				selfHosted: "Your Convex account",
+				cloud: "Managed by VantagePeers",
+				selfHostedIcon: "neutral",
+				cloudIcon: "check",
+			},
+			{
+				dimension: "Data residency",
+				selfHosted: "100% your Convex deployment",
+				cloud: "VantagePeers cloud (EU)",
+				selfHostedIcon: "check",
+				cloudIcon: "neutral",
+			},
+			{
+				dimension: "Updates",
+				selfHosted: "Manual (pull + redeploy)",
+				cloud: "Automatic",
+				selfHostedIcon: "neutral",
+				cloudIcon: "check",
+			},
+			{
+				dimension: "Price model",
+				selfHosted: "Free forever + optional paid support",
+				cloud: "Annual subscription",
+				selfHostedIcon: "check",
+				cloudIcon: "neutral",
+			},
+			{
+				dimension: "Who it's for",
+				selfHosted: "Devs comfortable with Convex CLI",
+				cloud: "Individuals + teams wanting zero ops",
+				selfHostedIcon: "neutral",
+				cloudIcon: "neutral",
+			},
+		],
+	},
+	fr: {
+		title: "Auto-hébergé ou Cloud ?",
+		headers: {
+			dimension: "Dimension",
+			selfHosted: "Auto-hébergé",
+			cloud: "Cloud",
+		},
+		rows: [
+			{
+				dimension: "Temps de mise en place",
+				selfHosted: "10 min (CLI) ou 2 min (Railway)",
+				cloud: "Instantané — aucune configuration",
+				selfHostedIcon: "neutral",
+				cloudIcon: "check",
+			},
+			{
+				dimension: "Hébergement",
+				selfHosted: "Votre compte Convex",
+				cloud: "Géré par VantagePeers",
+				selfHostedIcon: "neutral",
+				cloudIcon: "check",
+			},
+			{
+				dimension: "Résidence des données",
+				selfHosted: "100% votre déploiement Convex",
+				cloud: "Cloud VantagePeers (EU)",
+				selfHostedIcon: "check",
+				cloudIcon: "neutral",
+			},
+			{
+				dimension: "Mises à jour",
+				selfHosted: "Manuelles (pull + redéploiement)",
+				cloud: "Automatiques",
+				selfHostedIcon: "neutral",
+				cloudIcon: "check",
+			},
+			{
+				dimension: "Modèle tarifaire",
+				selfHosted: "Gratuit pour toujours + support payant optionnel",
+				cloud: "Abonnement annuel",
+				selfHostedIcon: "check",
+				cloudIcon: "neutral",
+			},
+			{
+				dimension: "Pour qui",
+				selfHosted: "Devs à l'aise avec Convex CLI",
+				cloud: "Individus + équipes voulant zéro ops",
+				selfHostedIcon: "neutral",
+				cloudIcon: "neutral",
+			},
+		],
+	},
+};
+
+function IconCell({ type }: { type: RowIcon }) {
+	if (type === "check") {
+		return (
+			<Check className="size-4 text-chart-1 shrink-0" aria-hidden="true" />
+		);
+	}
+	return (
+		<Minus
+			className="size-4 text-muted-foreground shrink-0"
+			aria-hidden="true"
+		/>
+	);
+}
+
+interface PeersCompareTracksProps {
+	locale: "en" | "fr";
+}
+
+export function PeersCompareTracks({ locale }: PeersCompareTracksProps) {
+	const t = content[locale];
+
+	return (
+		<div>
+			<div className="border-t border-border my-12" />
+			<motion.div
+				className="text-center mb-8"
+				initial={{ opacity: 0, y: 20 }}
+				whileInView={{ opacity: 1, y: 0 }}
+				viewport={{ once: true }}
+				transition={{ duration: 0.5 }}
+			>
+				<h3 className="text-2xl font-bold tracking-tight">{t.title}</h3>
+			</motion.div>
+
+			<motion.div
+				className="overflow-x-auto"
+				initial={{ opacity: 0, y: 20 }}
+				whileInView={{ opacity: 1, y: 0 }}
+				viewport={{ once: true }}
+				transition={{ duration: 0.5, delay: 0.1 }}
+			>
+				<table className="w-full min-w-[500px] border-collapse text-sm">
+					<thead>
+						<tr className="border-b border-border">
+							<th className="text-left py-3 pr-4 font-semibold w-[40%]">
+								{t.headers.dimension}
+							</th>
+							<th className="text-left py-3 px-4 font-semibold w-[30%]">
+								{t.headers.selfHosted}
+							</th>
+							<th className="text-left py-3 pl-4 font-semibold w-[30%]">
+								{t.headers.cloud}
+							</th>
+						</tr>
+					</thead>
+					<tbody>
+						{t.rows.map((row, index) => (
+							<tr
+								key={row.dimension}
+								className={`border-b border-border/50 ${
+									index % 2 === 0 ? "bg-muted/20" : ""
+								}`}
+							>
+								<td className="py-3 pr-4 font-medium text-foreground">
+									{row.dimension}
+								</td>
+								<td className="py-3 px-4 text-muted-foreground">
+									<div className="flex items-start gap-2">
+										<IconCell type={row.selfHostedIcon} />
+										<span>{row.selfHosted}</span>
+									</div>
+								</td>
+								<td className="py-3 pl-4 text-muted-foreground">
+									<div className="flex items-start gap-2">
+										<IconCell type={row.cloudIcon} />
+										<span>{row.cloud}</span>
+									</div>
+								</td>
+							</tr>
+						))}
+					</tbody>
+				</table>
+			</motion.div>
+		</div>
+	);
+}

--- a/components/landing/peers-pricing-cloud.tsx
+++ b/components/landing/peers-pricing-cloud.tsx
@@ -1,0 +1,230 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { Check } from "lucide-react";
+
+interface CloudTier {
+	name: string;
+	price: string;
+	period: string;
+	description: string;
+	features: string[];
+	cta: string;
+	ctaHref: string;
+	highlight: boolean;
+	badge?: string;
+	noPriceLabel?: string;
+}
+
+interface CloudContent {
+	cloudLabel: string;
+	cloudSubtitle: string;
+	tiers: CloudTier[];
+}
+
+const content: Record<"en" | "fr", CloudContent> = {
+	en: {
+		cloudLabel: "Cloud",
+		cloudSubtitle: "We host it. You just use it.",
+		tiers: [
+			{
+				name: "Solo",
+				price: "€49",
+				period: "/year",
+				description: "Full VantagePeers, hosted and managed.",
+				features: [
+					"Full VantagePeers hosted by us",
+					"No Convex account needed",
+					"Automatic updates",
+					"Web dashboard access",
+					"Email support",
+				],
+				cta: "Start Solo",
+				ctaHref: "mailto:contact@vantageos.com?subject=Cloud%20Solo",
+				highlight: false,
+				badge: "Launch price",
+			},
+			{
+				name: "Team",
+				price: "€290",
+				period: "/year",
+				description: "Shared memory for your whole team.",
+				features: [
+					"Everything in Solo",
+					"Shared memory across all team agents",
+					"Multi-user access",
+					"Team audit trail",
+					"Priority email support",
+				],
+				cta: "Start Team",
+				ctaHref: "mailto:contact@vantageos.com?subject=Cloud%20Team",
+				highlight: true,
+			},
+			{
+				name: "Enterprise",
+				price: "",
+				period: "",
+				description: "Custom deployment. SLA. Dedicated support.",
+				features: [
+					"Everything in Team",
+					"Dedicated cloud instance",
+					"Custom SLA + uptime guarantee",
+					"SSO + advanced access control",
+					"Dedicated onboarding + training",
+				],
+				cta: "Book a Call",
+				ctaHref: "mailto:contact@vantageos.com?subject=Enterprise",
+				highlight: false,
+				noPriceLabel: "Custom pricing",
+			},
+		],
+	},
+	fr: {
+		cloudLabel: "Cloud",
+		cloudSubtitle: "On héberge. Vous utilisez, c’est tout.",
+		tiers: [
+			{
+				name: "Solo",
+				price: "49€",
+				period: "/an",
+				description: "VantagePeers complet, hébergé et géré.",
+				features: [
+					"VantagePeers complet hébergé par nous",
+					"Pas de compte Convex nécessaire",
+					"Mises à jour automatiques",
+					"Accès au tableau de bord web",
+					"Support email",
+				],
+				cta: "Commencer Solo",
+				ctaHref: "mailto:contact@vantageos.com?subject=Cloud%20Solo",
+				highlight: false,
+				badge: "Prix de lancement",
+			},
+			{
+				name: "Équipe",
+				price: "290€",
+				period: "/an",
+				description: "Mémoire partagée pour toute votre équipe.",
+				features: [
+					"Tout ce qui est dans Solo",
+					"Mémoire partagée entre tous les agents de l’équipe",
+					"Accès multi-utilisateurs",
+					"Journal d’audit équipe",
+					"Support email prioritaire",
+				],
+				cta: "Commencer Équipe",
+				ctaHref: "mailto:contact@vantageos.com?subject=Cloud%20%C3%89quipe",
+				highlight: true,
+			},
+			{
+				name: "Entreprise",
+				price: "",
+				period: "",
+				description: "Déploiement personnalisé. SLA. Support dédié.",
+				features: [
+					"Tout ce qui est dans Équipe",
+					"Instance cloud dédiée",
+					"SLA personnalisé + garantie de disponibilité",
+					"SSO + contrôle d’accès avancé",
+					"Onboarding + formation dédiés",
+				],
+				cta: "Prendre rendez-vous",
+				ctaHref: "mailto:contact@vantageos.com?subject=Entreprise",
+				highlight: false,
+				noPriceLabel: "Tarification sur mesure",
+			},
+		],
+	},
+};
+
+interface PeersPricingCloudProps {
+	locale: "en" | "fr";
+}
+
+export function PeersPricingCloud({ locale }: PeersPricingCloudProps) {
+	const t = content[locale];
+
+	return (
+		<div>
+			<div className="border-t border-border my-12" />
+			<motion.div
+				className="mb-8"
+				initial={{ opacity: 0, y: 20 }}
+				whileInView={{ opacity: 1, y: 0 }}
+				viewport={{ once: true }}
+				transition={{ duration: 0.5 }}
+			>
+				<h3 className="text-2xl font-bold tracking-tight mb-2">
+					{t.cloudLabel}
+				</h3>
+				<p className="text-muted-foreground">{t.cloudSubtitle}</p>
+			</motion.div>
+
+			<div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+				{t.tiers.map((tier, index) => (
+					<motion.div
+						key={tier.name}
+						className={`rounded-2xl border p-6 flex flex-col ${
+							tier.highlight
+								? "border-chart-1 bg-chart-1/5 shadow-lg"
+								: "border-border bg-card"
+						}`}
+						initial={{ opacity: 0, y: 20 }}
+						whileInView={{ opacity: 1, y: 0 }}
+						viewport={{ once: true }}
+						transition={{ duration: 0.4, delay: index * 0.1 }}
+					>
+						<div className="mb-6">
+							{tier.badge ? (
+								<span className="inline-block text-xs font-semibold px-2.5 py-1 rounded-full bg-chart-1/15 text-chart-2 mb-3">
+									{tier.badge}
+								</span>
+							) : null}
+							<h4 className="text-xl font-semibold mb-2">{tier.name}</h4>
+							<div className="flex items-baseline gap-1 mb-2">
+								{tier.price ? (
+									<>
+										<span className="text-3xl font-bold">{tier.price}</span>
+										<span className="text-muted-foreground text-sm">
+											{tier.period}
+										</span>
+									</>
+								) : (
+									<span className="text-xl font-semibold text-muted-foreground">
+										{tier.noPriceLabel}
+									</span>
+								)}
+							</div>
+							<p className="text-muted-foreground text-sm">
+								{tier.description}
+							</p>
+						</div>
+
+						<ul className="space-y-3 mb-8 flex-1">
+							{tier.features.map((feature) => (
+								<li key={feature} className="flex items-start gap-2 text-sm">
+									<Check
+										className="size-4 text-chart-1 shrink-0 mt-0.5"
+										aria-hidden="true"
+									/>
+									<span>{feature}</span>
+								</li>
+							))}
+						</ul>
+
+						<a
+							href={tier.ctaHref}
+							className={`inline-flex items-center justify-center rounded-4xl font-medium min-h-[44px] px-6 transition-colors ${
+								tier.highlight
+									? "bg-primary text-primary-foreground hover:bg-primary/90"
+									: "bg-muted text-foreground hover:bg-muted/80"
+							}`}
+						>
+							{tier.cta}
+						</a>
+					</motion.div>
+				))}
+			</div>
+		</div>
+	);
+}

--- a/components/landing/peers-pricing-faq.tsx
+++ b/components/landing/peers-pricing-faq.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { ChevronDown } from "lucide-react";
+import { useState } from "react";
+import {
+	Collapsible,
+	CollapsibleContent,
+	CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { cn } from "@/lib/utils";
+
+interface FaqItem {
+	question: string;
+	answer: string;
+}
+
+interface PricingFaqContent {
+	title: string;
+	items: FaqItem[];
+}
+
+const content: Record<"en" | "fr", PricingFaqContent> = {
+	en: {
+		title: "Pricing questions",
+		items: [
+			{
+				question: "Why is billing annual only?",
+				answer:
+					"Annual billing lets us invest in infrastructure and support without subscription hedging. Monthly billing would mean higher prices for everyone. If you need a monthly option for Cloud, contact us — we can discuss on a case-by-case basis.",
+			},
+			{
+				question: "Can I migrate from Self-Hosted to Cloud?",
+				answer:
+					"Yes. Your data lives in your Convex deployment as structured JSON. We provide a migration guide and can handle the import as part of any Cloud onboarding. No data is lost — the schema is identical between Self-Hosted and Cloud.",
+			},
+			{
+				question: "Can I move from Cloud back to Self-Hosted?",
+				answer:
+					"Yes. We export your full dataset from our Convex deployment and you import it into your own. Migration is a documented, supported operation. You are never locked in.",
+			},
+			{
+				question: "What is the refund policy?",
+				answer:
+					"For setup services (QuickStart), we offer a full refund if the session did not happen. For annual Cloud subscriptions, we offer a pro-rata refund within the first 30 days. After 30 days, no refund — but you keep access until the end of the billing period.",
+			},
+			{
+				question: "What does Pro Support include, exactly?",
+				answer:
+					"Pro Support is for Self-Hosted users only. It covers: 24h response time via a dedicated channel, schema review on request, optimization advice, and upgrade assistance when new versions ship. It does not include custom development or feature requests.",
+			},
+			{
+				question: "How is data privacy handled in the Cloud plans?",
+				answer:
+					"Cloud instances run on EU infrastructure. Your agent memory, missions, and task data are isolated per account — no cross-tenant data access. We do not use your data for model training or analytics. Full details in our privacy policy.",
+			},
+		],
+	},
+	fr: {
+		title: "Questions tarifaires",
+		items: [
+			{
+				question: "Pourquoi uniquement une facturation annuelle ?",
+				answer:
+					"La facturation annuelle nous permet d'investir dans l'infrastructure et le support sans couverture d'abonnement. Une facturation mensuelle signifierait des prix plus élevés pour tout le monde. Si vous avez besoin d'une option mensuelle pour le Cloud, contactez-nous — on peut en discuter au cas par cas.",
+			},
+			{
+				question: "Puis-je migrer de l'auto-hébergé vers le Cloud ?",
+				answer:
+					"Oui. Vos données vivent dans votre déploiement Convex sous forme de JSON structuré. Nous fournissons un guide de migration et pouvons gérer l'import dans le cadre de tout onboarding Cloud. Aucune donnée n'est perdue — le schéma est identique entre l'auto-hébergé et le Cloud.",
+			},
+			{
+				question: "Puis-je revenir du Cloud vers l'auto-hébergé ?",
+				answer:
+					"Oui. On exporte votre jeu de données complet depuis notre déploiement Convex et vous l'importez dans le vôtre. La migration est une opération documentée et supportée. Vous n'êtes jamais enfermé.",
+			},
+			{
+				question: "Quelle est la politique de remboursement ?",
+				answer:
+					"Pour les services d'installation (QuickStart), nous offrons un remboursement complet si la session n'a pas eu lieu. Pour les abonnements Cloud annuels, nous offrons un remboursement au prorata dans les 30 premiers jours. Après 30 jours, pas de remboursement — mais vous conservez l'accès jusqu'à la fin de la période de facturation.",
+			},
+			{
+				question: "Qu'est-ce que le Support Pro inclut, exactement ?",
+				answer:
+					"Le Support Pro est réservé aux utilisateurs auto-hébergés. Il comprend : temps de réponse 24h via un canal dédié, revue de schéma sur demande, conseils d'optimisation, et assistance aux mises à jour lors de la sortie de nouvelles versions. Il n'inclut pas le développement personnalisé ni les demandes de fonctionnalités.",
+			},
+			{
+				question:
+					"Comment la confidentialité des données est-elle gérée dans les plans Cloud ?",
+				answer:
+					"Les instances Cloud fonctionnent sur une infrastructure EU. Votre mémoire d'agent, vos missions et données de tâches sont isolées par compte — pas d'accès cross-tenant. Nous n'utilisons pas vos données pour l'entraînement de modèles ni pour l'analytique. Tous les détails dans notre politique de confidentialité.",
+			},
+		],
+	},
+};
+
+interface PeersPricingFaqProps {
+	locale: "en" | "fr";
+}
+
+export function PeersPricingFaq({ locale }: PeersPricingFaqProps) {
+	const [openIndex, setOpenIndex] = useState<number | null>(null);
+	const t = content[locale];
+
+	return (
+		<div>
+			<div className="border-t border-border my-12" />
+			<motion.div
+				className="text-center mb-8"
+				initial={{ opacity: 0, y: 20 }}
+				whileInView={{ opacity: 1, y: 0 }}
+				viewport={{ once: true }}
+				transition={{ duration: 0.5 }}
+			>
+				<h3 className="text-2xl font-bold tracking-tight">{t.title}</h3>
+			</motion.div>
+
+			<div className="space-y-3 max-w-3xl mx-auto">
+				{t.items.map((item, index) => (
+					<motion.div
+						key={item.question}
+						initial={{ opacity: 0, y: 20 }}
+						whileInView={{ opacity: 1, y: 0 }}
+						viewport={{ once: true }}
+						transition={{ duration: 0.5, delay: index * 0.07 }}
+					>
+						<Collapsible
+							open={openIndex === index}
+							onOpenChange={(open) => setOpenIndex(open ? index : null)}
+						>
+							<CollapsibleTrigger className="w-full flex items-center justify-between p-4 text-left rounded-2xl bg-card border border-border hover:bg-muted/50 transition-colors">
+								<span className="font-medium pr-4">{item.question}</span>
+								<ChevronDown
+									aria-hidden="true"
+									className={cn(
+										"size-5 text-muted-foreground shrink-0 transition-transform duration-200",
+										openIndex === index && "rotate-180",
+									)}
+								/>
+							</CollapsibleTrigger>
+							<CollapsibleContent className="px-4 pt-2 pb-4 text-muted-foreground leading-relaxed">
+								{item.answer}
+							</CollapsibleContent>
+						</Collapsible>
+					</motion.div>
+				))}
+			</div>
+		</div>
+	);
+}

--- a/components/landing/peers-pricing.tsx
+++ b/components/landing/peers-pricing.tsx
@@ -2,12 +2,37 @@
 
 import { motion } from "framer-motion";
 import { Check, Github } from "lucide-react";
+import { PeersCompareTracks } from "./peers-compare-tracks";
+import { PeersPricingCloud } from "./peers-pricing-cloud";
+import { PeersPricingFaq } from "./peers-pricing-faq";
 
-const content = {
+interface PricingTier {
+	name: string;
+	price: string;
+	period: string;
+	description: string;
+	features: string[];
+	cta: string;
+	ctaHref: string;
+	highlight: boolean;
+	badge?: string;
+}
+
+interface PricingContent {
+	title: string;
+	subtitle: string;
+	selfHostedLabel: string;
+	selfHostedSubtitle: string;
+	tiers: PricingTier[];
+	sponsor: string;
+}
+
+const content: Record<"en" | "fr", PricingContent> = {
 	en: {
-		title: "Simple pricing. Free to start.",
-		subtitle:
-			"Self-host for free. Pay only if you want hands-on help.",
+		title: "Two tracks. One mission.",
+		subtitle: "Self-host for control. Cloud for speed.",
+		selfHostedLabel: "Self-Hosted",
+		selfHostedSubtitle: "Your Convex. Your data. Full control.",
 		tiers: [
 			{
 				name: "Self-Hosted",
@@ -19,8 +44,6 @@ const content = {
 					"Semantic memory + RAG search",
 					"Cross-machine messaging",
 					"Task coordination + missions",
-					"Fix patterns KB",
-					"GitHub issue tracking",
 					"Community support (GitHub Issues)",
 				],
 				cta: "Get Started",
@@ -28,26 +51,42 @@ const content = {
 				highlight: false,
 			},
 			{
+				name: "Railway 1-click",
+				price: "Free",
+				period: "forever",
+				description: "Deploy in 2 minutes. No terminal needed.",
+				features: [
+					"One-click Railway deploy",
+					"Full VantagePeers, your account",
+					"Automatic environment config",
+					"No Convex CLI knowledge needed",
+					"Community support (GitHub Issues)",
+				],
+				cta: "Deploy on Railway",
+				ctaHref: "https://github.com/vantageos-agency/vantage-peers#deploy",
+				highlight: false,
+			},
+			{
 				name: "QuickStart",
-				price: "\u20ac290",
+				price: "€290",
 				period: "one-time",
-				description: "We set it up for you. 1-hour guided call.",
+				description: "We set it up for you. Running in 1 hour.",
 				features: [
 					"Everything in Self-Hosted",
 					"1h guided setup call",
 					"Deploy to your Convex account",
-					"3 agents configured",
-					"MCP server wired to Claude Code",
-					"Email support for 1 week",
+					"3 agents configured + tested",
+					"Email support for 1 year",
 				],
 				cta: "Book a Call",
 				ctaHref: "mailto:contact@vantageos.com?subject=QuickStart",
 				highlight: true,
+				badge: "Most popular",
 			},
 			{
 				name: "Pro Support",
-				price: "\u20ac49",
-				period: "/month",
+				price: "€99",
+				period: "/year",
 				description: "Priority help when you need it.",
 				features: [
 					"Everything in Self-Hosted",
@@ -64,56 +103,71 @@ const content = {
 		sponsor: "Support the project on GitHub Sponsors",
 	},
 	fr: {
-		title: "Tarifs simples. Gratuit pour commencer.",
-		subtitle:
-			"Auto-h\u00e9bergez gratuitement. Payez uniquement si vous voulez de l\u2019aide.",
+		title: "Deux tracks. Une mission.",
+		subtitle: "Auto-hébergez pour le contrôle. Cloud pour la rapidité.",
+		selfHostedLabel: "Auto-hébergé",
+		selfHostedSubtitle: "Votre Convex. Vos données. Contrôle total.",
 		tiers: [
 			{
-				name: "Auto-h\u00e9berg\u00e9",
+				name: "Auto-hébergé",
 				price: "Gratuit",
 				period: "pour toujours",
-				description: "VantagePeers complet. Votre Convex. Vos donn\u00e9es.",
+				description: "VantagePeers complet. Votre Convex. Vos données.",
 				features: [
 					"82 outils MCP, 20 tables",
-					"M\u00e9moire s\u00e9mantique + recherche RAG",
+					"Mémoire sémantique + recherche RAG",
 					"Messagerie cross-machine",
-					"Coordination de t\u00e2ches + missions",
-					"Base de fix patterns",
-					"Suivi d\u2019issues GitHub",
-					"Support communaut\u00e9 (GitHub Issues)",
+					"Coordination de tâches + missions",
+					"Support communauté (GitHub Issues)",
 				],
 				cta: "Commencer",
 				ctaHref: "https://github.com/vantageos-agency/vantage-peers",
 				highlight: false,
 			},
 			{
-				name: "QuickStart",
-				price: "290\u20ac",
-				period: "unique",
-				description: "On configure pour vous. Appel guid\u00e9 d\u20191h.",
+				name: "Railway 1-clic",
+				price: "Gratuit",
+				period: "pour toujours",
+				description: "Déployé en 2 minutes. Sans terminal.",
 				features: [
-					"Tout ce qui est dans Auto-h\u00e9berg\u00e9",
-					"Appel de configuration guid\u00e9 d\u20191h",
-					"D\u00e9ploiement sur votre compte Convex",
-					"3 agents configur\u00e9s",
-					"Serveur MCP connect\u00e9 \u00e0 Claude Code",
-					"Support email pendant 1 semaine",
+					"Déploiement Railway en un clic",
+					"VantagePeers complet, votre compte",
+					"Configuration d'environnement automatique",
+					"Aucune connaissance Convex CLI requise",
+					"Support communauté (GitHub Issues)",
 				],
-				cta: "R\u00e9server un appel",
+				cta: "Déployer sur Railway",
+				ctaHref: "https://github.com/vantageos-agency/vantage-peers#deploy",
+				highlight: false,
+			},
+			{
+				name: "QuickStart",
+				price: "290€",
+				period: "unique",
+				description: "On configure pour vous. Opérationnel en 1h.",
+				features: [
+					"Tout ce qui est dans Auto-hébergé",
+					"Appel de configuration guidé 1h",
+					"Déploiement sur votre compte Convex",
+					"3 agents configurés + testés",
+					"Support email pendant 1 an",
+				],
+				cta: "Réserver un appel",
 				ctaHref: "mailto:contact@vantageos.com?subject=QuickStart",
 				highlight: true,
+				badge: "Le plus populaire",
 			},
 			{
 				name: "Support Pro",
-				price: "49\u20ac",
-				period: "/mois",
+				price: "99€",
+				period: "/an",
 				description: "Aide prioritaire quand vous en avez besoin.",
 				features: [
-					"Tout ce qui est dans Auto-h\u00e9berg\u00e9",
-					"Temps de r\u00e9ponse prioritaire 24h",
+					"Tout ce qui est dans Auto-hébergé",
+					"Temps de réponse prioritaire 24h",
 					"Canal de support direct",
-					"Revue + optimisation du sch\u00e9ma",
-					"Assistance aux mises \u00e0 jour",
+					"Revue + optimisation du schéma",
+					"Assistance aux mises à jour",
 				],
 				cta: "Nous contacter",
 				ctaHref: "mailto:contact@vantageos.com?subject=Support%20Pro",
@@ -147,7 +201,20 @@ export function PeersPricing({ locale }: PeersPricingProps) {
 					<p className="text-lg text-muted-foreground">{t.subtitle}</p>
 				</motion.div>
 
-				<div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+				<motion.div
+					className="mb-8"
+					initial={{ opacity: 0, y: 20 }}
+					whileInView={{ opacity: 1, y: 0 }}
+					viewport={{ once: true }}
+					transition={{ duration: 0.5, delay: 0.1 }}
+				>
+					<h3 className="text-2xl font-bold tracking-tight mb-2">
+						{t.selfHostedLabel}
+					</h3>
+					<p className="text-muted-foreground">{t.selfHostedSubtitle}</p>
+				</motion.div>
+
+				<div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-5">
 					{t.tiers.map((tier, index) => (
 						<motion.div
 							key={tier.name}
@@ -162,7 +229,12 @@ export function PeersPricing({ locale }: PeersPricingProps) {
 							transition={{ duration: 0.4, delay: index * 0.1 }}
 						>
 							<div className="mb-6">
-								<h3 className="text-xl font-semibold mb-2">{tier.name}</h3>
+								{tier.badge ? (
+									<span className="inline-block text-xs font-semibold px-2.5 py-1 rounded-full bg-chart-1/15 text-chart-2 mb-3">
+										{tier.badge}
+									</span>
+								) : null}
+								<h4 className="text-xl font-semibold mb-2">{tier.name}</h4>
 								<div className="flex items-baseline gap-1 mb-2">
 									<span className="text-3xl font-bold">{tier.price}</span>
 									<span className="text-muted-foreground text-sm">
@@ -177,7 +249,10 @@ export function PeersPricing({ locale }: PeersPricingProps) {
 							<ul className="space-y-3 mb-8 flex-1">
 								{tier.features.map((feature) => (
 									<li key={feature} className="flex items-start gap-2 text-sm">
-										<Check className="size-4 text-chart-1 shrink-0 mt-0.5" aria-hidden="true" />
+										<Check
+											className="size-4 text-chart-1 shrink-0 mt-0.5"
+											aria-hidden="true"
+										/>
 										<span>{feature}</span>
 									</li>
 								))}
@@ -197,8 +272,12 @@ export function PeersPricing({ locale }: PeersPricingProps) {
 					))}
 				</div>
 
+				<PeersPricingCloud locale={locale} />
+				<PeersCompareTracks locale={locale} />
+				<PeersPricingFaq locale={locale} />
+
 				<motion.div
-					className="text-center mt-8"
+					className="text-center mt-12"
 					initial={{ opacity: 0 }}
 					whileInView={{ opacity: 1 }}
 					viewport={{ once: true }}

--- a/components/landing/peers-problem.tsx
+++ b/components/landing/peers-problem.tsx
@@ -1,77 +1,106 @@
 "use client";
 
 import { motion } from "framer-motion";
-import { CreditCard, Lock, ServerCrash, WifiOff } from "lucide-react";
+import {
+	ClipboardList,
+	Copy,
+	EyeOff,
+	Layers,
+	RotateCcw,
+	Unplug,
+} from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 
 const content = {
 	en: {
-		title: "Existing solutions are broken.",
-		titleAccent: "Here is why.",
+		title: "Your AI agents forget everything between sessions.",
 		subtitle:
-			"You tried mem0. You got a $249/month invoice. You tried Zep — Community Edition was abandoned. You hacked together something local — no cross-machine, no read receipts, no tasks.",
+			"You spend more time explaining context than doing actual work. Your agents reset. Your notes scatter. Your team stays in the dark. That is not an AI problem — it is a memory problem.",
 		problems: [
 			{
-				icon: CreditCard,
-				title: "$249-475/month just for memory",
+				icon: RotateCcw,
+				title: "Your agent starts from zero. Every time.",
 				description:
-					"mem0 charges $249/mo for graph memory. Zep starts at $475/mo plus overages. Memory should not cost more than your LLM.",
+					"Every new session, every new tab — your agent has no idea what you worked on yesterday. You repeat yourself. It guesses. You correct it.",
 			},
 			{
-				icon: ServerCrash,
-				title: "Zep Community Edition abandoned",
+				icon: ClipboardList,
+				title: "10 minutes wasted before any real work starts.",
 				description:
-					"Zep pushed everyone to their cloud. The self-hosted version stopped receiving updates. You cannot build on an abandoned foundation.",
+					"Before you can actually build, you re-explain the project, the constraints, the last decision. Every. Single. Time. That is not setup — that is a tax.",
 			},
 			{
-				icon: Lock,
-				title: "Vendor lock-in",
+				icon: Layers,
+				title: "Your context lives in 5 tools at once.",
 				description:
-					"Proprietary schemas, closed APIs, no export. When they raise prices or shut down, your agents lose their memory overnight.",
+					"Notion. ChatGPT history. Claude projects. A doc somewhere. A Slack thread. None of it talks to your agents. You are the glue — manually.",
 			},
 			{
-				icon: WifiOff,
-				title: "Local-only hacks break at scale",
+				icon: Copy,
+				title: "Copy-pasting between ChatGPT and Claude is not a workflow.",
 				description:
-					"SQLite files and JSON dumps do not survive multi-agent, multi-machine setups. No messaging. No read receipts. No tasks.",
+					"Switching models mid-project means manually transferring context. You copy. You paste. You hope nothing gets lost. It always does.",
+			},
+			{
+				icon: Unplug,
+				title: "Your agents work in silos. They never compare notes.",
+				description:
+					"You have one agent for code, one for research, one for writing. They do not share what they learn. Every agent is an island.",
+			},
+			{
+				icon: EyeOff,
+				title: "Your team has no idea what your agents are doing.",
+				description:
+					"No shared memory. No audit trail. No way to pick up where someone else's agent left off. Collaboration with AI stops at the individual level.",
 			},
 		],
 		closing:
-			"You do not need a SaaS. You need an open protocol that runs on your infrastructure.",
+			"This is not an AI limitation. Your models are capable — they just have no memory between sessions, no shared context across agents, and no way to coordinate at team scale. VantagePeers gives your agents a persistent, shared brain. Open. Self-hosted. Yours.",
 	},
 	fr: {
-		title: "Les solutions existantes sont cassées.",
-		titleAccent: "Voici pourquoi.",
+		title: "Tes agents IA oublient tout entre les sessions.",
 		subtitle:
-			"Vous avez essayé mem0 — 249$/mois pour la mémoire graphe. Vous avez essayé Zep — la Community Edition a été abandonnée. Vous avez bricolé quelque chose en local — pas de multi-machine, pas d'accusés de lecture, pas de tâches.",
+			"Tu passes plus de temps à expliquer le contexte qu'à travailler vraiment. Tes agents repartent de zéro. Tes notes s'éparpillent. Ton équipe ne sait rien de ce qui se passe. Ce n'est pas un problème d'IA — c'est un problème de mémoire.",
 		problems: [
 			{
-				icon: CreditCard,
-				title: "249-475$/mois juste pour la mémoire",
+				icon: RotateCcw,
+				title: "Ton agent repart de zéro. À chaque fois.",
 				description:
-					"mem0 facture 249$/mois pour la mémoire graphe. Zep commence à 475$/mois + dépassements. La mémoire ne devrait pas coûter plus que votre LLM.",
+					"Nouvelle session, nouvel onglet — ton agent ne sait pas ce que tu faisais hier. Tu te répètes. Il devine. Tu corriges.",
 			},
 			{
-				icon: ServerCrash,
-				title: "Zep Community Edition abandonnée",
+				icon: ClipboardList,
+				title: "10 minutes perdues avant chaque vraie session.",
 				description:
-					"Zep a poussé tout le monde vers son cloud. La version auto-hébergée a arrêté de recevoir des mises à jour. On ne peut pas construire sur une base abandonnée.",
+					"Avant de pouvoir vraiment avancer, tu ré-expliques le projet, les contraintes, la dernière décision. À chaque fois. Ça ne s'appelle pas de la configuration — ça s'appelle une perte de temps.",
 			},
 			{
-				icon: Lock,
-				title: "Dépendance vendeur",
+				icon: Layers,
+				title: "Ton contexte est éparpillé dans 5 outils.",
 				description:
-					"Schémas propriétaires, APIs fermées, pas d'export. Quand ils augmentent les prix ou ferment, vos agents perdent leur mémoire du jour au lendemain.",
+					"Notion. Historique ChatGPT. Projets Claude. Un doc quelque part. Un fil Slack. Rien de tout ça ne parle à tes agents. C'est toi qui fais la colle — à la main.",
 			},
 			{
-				icon: WifiOff,
-				title: "Les hacks locaux ne passent pas à l'échelle",
+				icon: Copy,
+				title: "Copier-coller entre ChatGPT et Claude, c'est pas un workflow.",
 				description:
-					"Les fichiers SQLite et dumps JSON ne survivent pas aux configurations multi-agents et multi-machines. Pas de messagerie. Pas d'accusés de lecture. Pas de tâches.",
+					"Changer de modèle en cours de projet veut dire transférer le contexte à la main. Tu copies. Tu colles. Tu espères que rien se perd. Il y a toujours quelque chose.",
+			},
+			{
+				icon: Unplug,
+				title: "Tes agents travaillent en silos. Ils ne se parlent pas.",
+				description:
+					"Un agent pour le code, un pour la recherche, un pour la rédaction. Ils ne partagent pas ce qu'ils apprennent. Chaque agent est une île.",
+			},
+			{
+				icon: EyeOff,
+				title: "Ton équipe ne sait pas ce que font tes agents.",
+				description:
+					"Pas de mémoire partagée. Pas de trace. Pas moyen de reprendre là où l'agent d'un collègue s'est arrêté. La collaboration avec l'IA s'arrête à l'individu.",
 			},
 		],
 		closing:
-			"Vous n'avez pas besoin d'un SaaS. Vous avez besoin d'un protocole ouvert qui tourne sur votre infrastructure.",
+			"Ce n'est pas une limite de l'IA. Tes modèles sont capables — ils n'ont juste pas de mémoire entre les sessions, pas de contexte partagé entre les agents, pas de coordination à l'échelle de l'équipe. VantagePeers donne à tes agents une mémoire persistante et partagée. Ouverte. Auto-hébergée. La tienne.",
 	},
 };
 
@@ -93,13 +122,12 @@ export function PeersProblem({ locale }: PeersProblemProps) {
 					transition={{ duration: 0.5 }}
 				>
 					<h2 className="text-3xl sm:text-4xl font-bold tracking-tight mb-4">
-						{t.title}{" "}
-						<span className="text-muted-foreground">{t.titleAccent}</span>
+						{t.title}
 					</h2>
 					<p className="text-lg text-muted-foreground">{t.subtitle}</p>
 				</motion.div>
 
-				<div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
+				<div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
 					{t.problems.map((problem, index) => (
 						<motion.div
 							key={problem.title}
@@ -111,7 +139,10 @@ export function PeersProblem({ locale }: PeersProblemProps) {
 							<Card className="relative overflow-hidden h-full">
 								<CardContent className="relative p-6 text-center">
 									<div className="size-12 rounded-3xl bg-destructive/10 flex items-center justify-center mx-auto mb-4">
-										<problem.icon className="size-6 text-destructive" />
+										<problem.icon
+											className="size-6 text-destructive"
+											aria-hidden="true"
+										/>
 									</div>
 									<h3 className="font-semibold text-lg mb-2">
 										{problem.title}


### PR DESCRIPTION
## Summary

- **peers-pricing.tsx** [modified]: New section header Two tracks. One mission., Self-Hosted track H3 + subtitle, 4-tier grid (Self-Hosted free, Railway 1-click free, QuickStart 290EUR one-time w/ badge, Pro Support 99EUR/year). Composes 3 new sub-components. Bilingual EN+FR.
- **peers-pricing-cloud.tsx** [new]: Cloud track — Solo 49EUR/year (Launch price badge), Team 290EUR/year (highlighted), Enterprise (custom pricing, no quota). Bilingual EN+FR.
- **peers-compare-tracks.tsx** [new]: 6-row SH vs Cloud comparison table, check/neutral icons, overflow-x-auto on mobile. Bilingual EN+FR.
- **peers-pricing-faq.tsx** [new]: 6 Q&A accordion (all closed by default, inline in #pricing). Covers annual billing, SH/Cloud migration, refunds, Pro Support scope, Cloud data privacy. Bilingual EN+FR.
- **peers-problem.tsx** [modified]: T3 pain refonte — new headline, 6 pain cards (RotateCcw, ClipboardList, Layers, Copy, Unplug, EyeOff icons), 3-col grid, T3 conclusion verbatim. Bilingual EN+FR.

## Build verification

- pnpm build: 0 errors, 96 pages generated
- npx tsc --noEmit: 0 errors
- npx @biomejs/biome check: 0 errors on all 5 files
- Pre-existing lint errors in .source/, app/docs/, components/team-landing/ are outside scope and unmodified

## Deviations from T2 spec

- Railway template URL: unconfirmed — used GitHub README anchor fallback per T2 instruction
- T3 conclusion copy: kept verbatim (Self-hosted. Yours.) per Sigma decision in task rules

## Spec references (in /tmp)

- T1: sigma-d62-vp-site-architecture-analysis.md
- T2: sigma-d62-vp-site-pricing-architecture.md
- T3: sigma-d62-vp-site-pain-refonte-copy.md

## Review policy

Eta NOT requested per J62 policy. Laurent visual ack on Vercel preview only.

Mission ref: k576hca4pvv3tnj6jbz8ks6919868k9g

Orchestrator: Sigma — VantageOS Team Infra | 2026-05-07