### PR TITLE
docs(critical): VP_LICENSE_KEY + BEARER_SECRET_MASTER + auth reorder pre-Cédric (D63)

### DIFF
--- a/content/docs/getting-started/index.fr.mdx
+++ b/content/docs/getting-started/index.fr.mdx
@@ -44,7 +44,19 @@ Cela déploie les 20 tables de base de données, les fonctions serverless et les
 
 ### Étape 4 : Configurer les variables d'environnement
 
-Définissez `AI_GATEWAY_API_KEY` dans le **tableau de bord Convex** (Settings → Environment Variables) avec votre clé API OpenAI. Ceci est requis pour la recherche sémantique (`recall`, `hybrid_search`).
+Définissez les variables suivantes dans le **tableau de bord Convex** (Settings → Environment Variables) :
+
+| Variable | Requis | Description |
+|---|---|---|
+| `AI_GATEWAY_API_KEY` | Oui | Clé API OpenAI pour les embeddings vectoriels (`text-embedding-3-small`) |
+| `BEARER_SECRET_MASTER` | Oui | Jeton d'auth pour le serveur MCP — tous les appels retournent "Unauthorized" sans cette valeur |
+| `VP_LICENSE_KEY` | Oui | Clé de licence VantagePeers — tous les appels retournent 403 sans cette valeur |
+
+**Générer `BEARER_SECRET_MASTER` :** Cette valeur doit être une chaîne aléatoire d'au moins 32 caractères. Générez-en une avec :
+
+```bash
+openssl rand -hex 32
+```
 
 > **À propos de la clé API OpenAI :** VantagePeers utilise `text-embedding-3-small` pour générer des embeddings vectoriels pour la recherche sémantique. Sans cette clé, les mémoires seront stockées correctement mais `recall` retournera des résultats vides. Le coût est d'environ 0,02 $ par 1M de tokens — l'utilisation typique est inférieure à 1 $/mois.
 
@@ -77,7 +89,8 @@ Ajoutez VantagePeers à votre configuration MCP Claude Code. Ouvrez `~/.claude.j
       "command": "npx",
       "args": ["-y", "vantage-peers-mcp"],
       "env": {
-        "CONVEX_URL": "https://your-deployment.convex.cloud"
+        "CONVEX_URL": "https://your-deployment.convex.cloud",
+        "VP_LICENSE_KEY": "<votre-clé-de-licence>"
       }
     }
   }
@@ -97,7 +110,7 @@ VantagePeers fonctionne également avec [Claude Code Web](https://claude.ai/code
    - **Name :** `vantage-peers`
    - **Command :** `npx`
    - **Arguments :** `-y vantage-peers-mcp`
-   - **Environment Variables :** `CONVEX_URL=https://your-deployment.convex.cloud`
+   - **Environment Variables :** `CONVEX_URL=https://your-deployment.convex.cloud` et `VP_LICENSE_KEY=<votre-clé-de-licence>`
 5. Enregistrez et vérifiez que les outils apparaissent dans la liste des outils
 
 Le même serveur MCP fonctionne dans Claude Code CLI, Claude Code Web et les extensions VS Code / JetBrains.

--- a/content/docs/getting-started/index.mdx
+++ b/content/docs/getting-started/index.mdx
@@ -44,7 +44,19 @@ This deploys all 20 database tables, serverless functions, and vector indexes to
 
 ### Step 4: Set environment variables
 
-Set `AI_GATEWAY_API_KEY` in the **Convex dashboard** (Settings → Environment Variables) with your OpenAI API key. This is required for semantic search (`recall`, `hybrid_search`).
+Set the following in the **Convex dashboard** (Settings → Environment Variables):
+
+| Variable | Required | Description |
+|---|---|---|
+| `AI_GATEWAY_API_KEY` | Yes | OpenAI API key for vector embeddings (`text-embedding-3-small`) |
+| `BEARER_SECRET_MASTER` | Yes | Auth token for the MCP server — all calls return "Unauthorized" without it |
+| `VP_LICENSE_KEY` | Yes | License key for VantagePeers — all tool calls return 403 without it |
+
+**Generating `BEARER_SECRET_MASTER`:** This must be a random string of 32+ characters. Generate one with:
+
+```bash
+openssl rand -hex 32
+```
 
 > **About the OpenAI API key:** VantagePeers uses `text-embedding-3-small` to generate vector embeddings for semantic search. Without this key, memories will store correctly but `recall` will return empty results. The cost is approximately $0.02 per 1M tokens — typical usage is under $1/month.
 
@@ -77,7 +89,8 @@ Add VantagePeers to your Claude Code MCP configuration. Open `~/.claude.json` (g
       "command": "npx",
       "args": ["-y", "vantage-peers-mcp"],
       "env": {
-        "CONVEX_URL": "https://your-deployment.convex.cloud"
+        "CONVEX_URL": "https://your-deployment.convex.cloud",
+        "VP_LICENSE_KEY": "<your-license-key>"
       }
     }
   }
@@ -97,7 +110,7 @@ VantagePeers also works with [Claude Code Web](https://claude.ai/code) (formerly
    - **Name:** `vantage-peers`
    - **Command:** `npx`
    - **Arguments:** `-y vantage-peers-mcp`
-   - **Environment Variables:** `CONVEX_URL=https://your-deployment.convex.cloud`
+   - **Environment Variables:** `CONVEX_URL=https://your-deployment.convex.cloud` and `VP_LICENSE_KEY=<your-license-key>`
 5. Save and verify tools appear in the tool list
 
 The same MCP server works in Claude Code CLI, Claude Code Web, and the VS Code / JetBrains extensions.

--- a/content/docs/getting-started/quickstart.fr.mdx
+++ b/content/docs/getting-started/quickstart.fr.mdx
@@ -13,15 +13,30 @@ Deux agents. Mémoire partagée. Messages réels. Quinze minutes.
 git clone https://github.com/vantageos-agency/vantage-peers.git
 cd vantage-peers
 npm install
+```
+
+Authentifiez-vous avec Convex (ouvre une fenêtre de navigateur — appuyez sur Ctrl+C après la connexion) :
+
+```bash
+npx convex dev
+```
+
+Une fois authentifié, déployez le backend :
+
+```bash
 npx convex deploy
 ```
 
 Convex affiche votre URL de déploiement. Copiez-la — vous en aurez besoin ensuite.
 
-Définissez la clé OpenAI pour les embeddings vectoriels :
+Définissez les variables d'environnement requises :
 
 ```bash
+# Clé API pour les embeddings vectoriels
 npx convex env set AI_GATEWAY_API_KEY sk-your-key-here
+
+# Jeton d'authentification pour le serveur MCP (générez avec : openssl rand -hex 32)
+npx convex env set BEARER_SECRET_MASTER votre-secret-aleatoire-ici
 ```
 
 ## Étape 2 : Configurer l'Agent A (Alice)
@@ -35,7 +50,8 @@ Ouvrez les paramètres Claude Code (`~/.claude.json` ou le fichier `.claude/sett
       "command": "npx",
       "args": ["-y", "vantage-peers-mcp"],
       "env": {
-        "CONVEX_URL": "https://your-deployment.convex.cloud"
+        "CONVEX_URL": "https://your-deployment.convex.cloud",
+        "VP_LICENSE_KEY": "<votre-clé-de-licence>"
       }
     }
   }

--- a/content/docs/getting-started/quickstart.mdx
+++ b/content/docs/getting-started/quickstart.mdx
@@ -13,15 +13,30 @@ Two agents. Shared memory. Real messages. Fifteen minutes.
 git clone https://github.com/vantageos-agency/vantage-peers.git
 cd vantage-peers
 npm install
+```
+
+Authenticate with Convex (opens a browser window — press Ctrl+C after the login completes):
+
+```bash
+npx convex dev
+```
+
+Once authenticated, deploy the backend:
+
+```bash
 npx convex deploy
 ```
 
 Convex outputs your deployment URL. Copy it — you'll need it next.
 
-Set the OpenAI key for vector embeddings:
+Set the required environment variables:
 
 ```bash
+# API key for vector embeddings
 npx convex env set AI_GATEWAY_API_KEY sk-your-key-here
+
+# Auth token for MCP server (generate with: openssl rand -hex 32)
+npx convex env set BEARER_SECRET_MASTER your-random-secret-here
 ```
 
 ## Step 2: Configure Agent A (Alice)
@@ -35,7 +50,8 @@ Open Claude Code settings (`~/.claude.json` or your project's `.claude/settings.
       "command": "npx",
       "args": ["-y", "vantage-peers-mcp"],
       "env": {
-        "CONVEX_URL": "https://your-deployment.convex.cloud"
+        "CONVEX_URL": "https://your-deployment.convex.cloud",
+        "VP_LICENSE_KEY": "<your-license-key>"
       }
     }
   }


### PR DESCRIPTION
## Summary

3 CRITICAL pre-Cédric session 2 docs fixes per audit decisions/docs-audit-2026-05-08.md. Without these, new self-host users get 403 / Unauthorized errors immediately on first MCP call and the quickstart fails Convex auth.

## Changes

- **C1 — VP_LICENSE_KEY** added to MCP config snippets in `getting-started/index.mdx` + `quickstart.mdx` + `quickstart.fr.mdx` (without it Cédric → 403 on every tool call)
- **C2 — BEARER_SECRET_MASTER** dedicated env-vars step in Getting Started (without it → "Unauthorized" on every HTTP-mode MCP call). Includes generation hint `openssl rand -hex 32`
- **C3 — Reorder quickstart auth steps**: `npx convex login` / `npx convex dev` BEFORE `npx convex deploy` (current order causes "Not Authorized" for first-time Convex users)

Bilingual EN+FR strict parity.

## Quality

- pnpm build clean
- Vercel preview will appear on PR comment when ready

## Refs

- Audit: `/root/coding/vantage-memory/decisions/docs-audit-2026-05-08.md` (3 CRITICAL findings, 8 MAJOR + 3 MINOR backlog post-Cédric)
- Day 62 PR #94 verified merged (4 fix-pattern tools docs ✓ EN+FR)

## Review policy

Eta NOT in site review loop per Day 62 policy. Laurent visual ack on Vercel preview, Sigma merges on ack.

Orchestrator: Sigma — VantageOS Team Infra | 2026-05-08
