### PR TITLE
docs(oauth): add Claude.ai web (OAuth 2.1 DCR) connect method to Railway page (D63)

### DIFF
--- a/components/railway/railway-page.tsx
+++ b/components/railway/railway-page.tsx
@@ -78,6 +78,11 @@ const content = {
 				body: 'Add the Railway URL to your Claude Code MCP config (claude_desktop_config.json or .claude.json). Set the Authorization header to "Bearer {BEARER_SECRET_MASTER}".',
 			},
 		],
+		claudeWebTitle: "Also works in Claude.ai web",
+		claudeWebBody:
+			"Claude.ai web connects via OAuth 2.1 DCR — paste your Railway URL in Settings → Integrations → Custom MCP servers. No bearer token, no config file. Full docs at vantagepeers.com/docs/install.",
+		claudeWebCta: "View Claude.ai web setup docs",
+		claudeWebCtaHref: "https://vantagepeers.com/docs/install",
 		verifyTitle: "Verify the deployment",
 		verifyBody:
 			"Once Railway finishes building, run this health check from your terminal:",
@@ -186,6 +191,11 @@ const content = {
 		convexBody:
 			"Convex est la base de données temps réel qui alimente VantagePeers. Le plan gratuit couvre jusqu'à 1M d'appels de fonctions/mois — suffisant pour plusieurs équipes d'agents actifs. Utiliser notre lien de parrainage ne vous coûte rien de plus.",
 		convexCta: "Créer un compte Convex (parrainage : LAUREN7583)",
+		claudeWebTitle: "Fonctionne aussi dans Claude.ai web",
+		claudeWebBody:
+			"Claude.ai web se connecte via OAuth 2.1 DCR — collez votre URL Railway dans Paramètres → Intégrations → Serveurs MCP personnalisés. Aucun jeton porteur, aucun fichier de config. Documentation complète sur vantagepeers.com/docs/install.",
+		claudeWebCta: "Voir la documentation Claude.ai web",
+		claudeWebCtaHref: "https://vantagepeers.com/docs/install",
 	},
 };
 
@@ -582,6 +592,44 @@ export function RailwayPage({ locale }: RailwayPageProps) {
 								className="inline-flex items-center gap-2 min-h-[44px] px-7 rounded-4xl text-sm font-semibold border border-border bg-card text-foreground hover:bg-muted/50 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
 							>
 								{t.convexCta}
+								<svg
+									aria-hidden="true"
+									className="size-3.5"
+									viewBox="0 0 24 24"
+									fill="none"
+									stroke="currentColor"
+									strokeWidth="2"
+									strokeLinecap="round"
+									strokeLinejoin="round"
+								>
+									<path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6M15 3h6v6M10 14L21 3" />
+								</svg>
+							</a>
+						</div>
+					</section>
+
+					{/* ── Claude.ai web ────────────────────────────────────── */}
+					<section
+						aria-labelledby="claude-web-heading"
+						className="py-14 md:py-20 border-t border-border"
+					>
+						<div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
+							<h2
+								id="claude-web-heading"
+								className="text-2xl sm:text-3xl font-bold tracking-tight mb-4"
+							>
+								{t.claudeWebTitle}
+							</h2>
+							<p className="text-muted-foreground leading-relaxed mb-6">
+								{t.claudeWebBody}
+							</p>
+							<a
+								href={t.claudeWebCtaHref}
+								target="_blank"
+								rel="noopener noreferrer"
+								className="inline-flex items-center gap-2 text-sm font-medium text-foreground hover:text-muted-foreground transition-colors underline underline-offset-4 decoration-border hover:decoration-muted-foreground"
+							>
+								{t.claudeWebCta}
 								<svg
 									aria-hidden="true"
 									className="size-3.5"

--- a/components/railway/railway-page.tsx
+++ b/components/railway/railway-page.tsx
@@ -53,22 +53,23 @@ const content = {
 			{
 				id: "env-vars",
 				step: "3",
-				title: "Add 3 environment variables",
-				body: "In your Railway project → Variables, add:",
+				title: "Set environment variables in both Railway and Convex",
+				body: "Two layers, each with its own set. In Railway → Variables, add these 3 service vars:",
 				vars: [
 					{
-						name: "CONVEX_URL",
+						name: "NODE_ENV",
+						desc: "Set to: production",
+					},
+					{
+						name: "CONVEX_URL_INTERNAL",
 						desc: "The deployment URL from step 2 (https://….convex.cloud)",
 					},
 					{
 						name: "BEARER_SECRET_MASTER",
-						desc: "Any long random string. Used to authenticate MCP clients.",
-					},
-					{
-						name: "AI_GATEWAY_API_KEY",
-						desc: "Your OpenAI-compatible key for vector embeddings.",
+						desc: "A long random string (32+ chars). Authenticates all MCP client requests.",
 					},
 				],
+				note: "Then in Convex (dashboard → Settings → Environment Variables), set 3 backend vars: BEARER_SECRET_MASTER (same value as Railway), AI_GATEWAY_API_KEY for Vercel AI Gateway or OPENAI_API_KEY for direct OpenAI BYOK, and VP_LICENSE_KEY.",
 			},
 			{
 				id: "connect",
@@ -144,22 +145,23 @@ const content = {
 			{
 				id: "env-vars",
 				step: "3",
-				title: "Ajouter 3 variables d'environnement",
-				body: "Dans votre projet Railway → Variables, ajoutez :",
+				title: "Configurer les variables dans Railway et Convex",
+				body: "Deux couches, chacune avec ses propres variables. Dans Railway → Variables, ajoutez ces 3 variables de service :",
 				vars: [
 					{
-						name: "CONVEX_URL",
+						name: "NODE_ENV",
+						desc: "Valeur : production",
+					},
+					{
+						name: "CONVEX_URL_INTERNAL",
 						desc: "L'URL de déploiement de l'étape 2 (https://….convex.cloud)",
 					},
 					{
 						name: "BEARER_SECRET_MASTER",
-						desc: "Une longue chaîne aléatoire. Utilisée pour authentifier les clients MCP.",
-					},
-					{
-						name: "AI_GATEWAY_API_KEY",
-						desc: "Votre clé compatible OpenAI pour les embeddings vectoriels.",
+						desc: "Une chaîne aléatoire longue (32+ caractères). Authentifie toutes les requêtes des clients MCP.",
 					},
 				],
+				note: "Puis dans Convex (tableau de bord → Paramètres → Variables d'environnement), définissez 3 variables backend : BEARER_SECRET_MASTER (même valeur que Railway), AI_GATEWAY_API_KEY pour Vercel AI Gateway ou OPENAI_API_KEY pour OpenAI direct BYOK, et VP_LICENSE_KEY.",
 			},
 			{
 				id: "connect",
@@ -410,6 +412,12 @@ export function RailwayPage({ locale }: RailwayPageProps) {
 														</li>
 													))}
 												</ul>
+											)}
+
+											{"note" in step && step.note && (
+												<p className="text-xs text-muted-foreground leading-relaxed mt-3 pl-3 border-l-2 border-border">
+													{step.note}
+												</p>
 											)}
 
 											{"cta" in step && step.cta && step.ctaHref && (


### PR DESCRIPTION
## Summary

- `components/railway/railway-page.tsx`: new section documenting the Claude.ai web OAuth 2.1 DCR auto-connect flow on the Railway landing page

## Test plan

- [ ] `pnpm build` — 0 errors (verified locally)
- [ ] Railway page renders Claude.ai web section at correct position
- [ ] grep `Claude.ai web` in railway-page.tsx — hit

Orchestrator: Sigma — VantageOS Team | 2026-05-08