### PR TITLE
feat(perf): Core Web Vitals fixes batch C (P0-P1..P3 + P1-P1..P3 + P2-P2)

### DIFF
--- a/components/landing/landing-page.tsx
+++ b/components/landing/landing-page.tsx
@@ -1,18 +1,69 @@
 "use client";
 
 import { MotionConfig } from "framer-motion";
+import dynamic from "next/dynamic";
 import { useState } from "react";
-import { PeersCode } from "@/components/landing/peers-code";
-import { PeersComparison } from "@/components/landing/peers-comparison";
-import { PeersCta } from "@/components/landing/peers-cta";
-import { PeersFaq } from "@/components/landing/peers-faq";
-import { PeersFeatures } from "@/components/landing/peers-features";
 import { PeersFooter } from "@/components/landing/peers-footer";
 import { PeersHeader } from "@/components/landing/peers-header";
 import { PeersHero } from "@/components/landing/peers-hero";
-import { PeersHowItWorks } from "@/components/landing/peers-how-it-works";
-import { PeersPricing } from "@/components/landing/peers-pricing";
-import { PeersProblem } from "@/components/landing/peers-problem";
+
+// Below-fold sections: deferred to reduce TBT / main-thread blocking
+const PeersProblem = dynamic(
+	() =>
+		import("@/components/landing/peers-problem").then((m) => ({
+			default: m.PeersProblem,
+		})),
+	{ ssr: false },
+);
+const PeersFeatures = dynamic(
+	() =>
+		import("@/components/landing/peers-features").then((m) => ({
+			default: m.PeersFeatures,
+		})),
+	{ ssr: false },
+);
+const PeersHowItWorks = dynamic(
+	() =>
+		import("@/components/landing/peers-how-it-works").then((m) => ({
+			default: m.PeersHowItWorks,
+		})),
+	{ ssr: false },
+);
+const PeersComparison = dynamic(
+	() =>
+		import("@/components/landing/peers-comparison").then((m) => ({
+			default: m.PeersComparison,
+		})),
+	{ ssr: false },
+);
+const PeersCode = dynamic(
+	() =>
+		import("@/components/landing/peers-code").then((m) => ({
+			default: m.PeersCode,
+		})),
+	{ ssr: false },
+);
+const PeersPricing = dynamic(
+	() =>
+		import("@/components/landing/peers-pricing").then((m) => ({
+			default: m.PeersPricing,
+		})),
+	{ ssr: false },
+);
+const PeersFaq = dynamic(
+	() =>
+		import("@/components/landing/peers-faq").then((m) => ({
+			default: m.PeersFaq,
+		})),
+	{ ssr: false },
+);
+const PeersCta = dynamic(
+	() =>
+		import("@/components/landing/peers-cta").then((m) => ({
+			default: m.PeersCta,
+		})),
+	{ ssr: false },
+);
 
 export type Locale = "en" | "fr";
 
@@ -30,7 +81,9 @@ export function LandingPage({ initialLocale = "en" }: LandingPageProps) {
 					href="#main-content"
 					className="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-50 focus:px-4 focus:py-2 focus:bg-primary focus:text-primary-foreground focus:rounded-4xl"
 				>
-					{locale === "fr" ? "Aller au contenu principal" : "Skip to main content"}
+					{locale === "fr"
+						? "Aller au contenu principal"
+						: "Skip to main content"}
 				</a>
 				<PeersHeader locale={locale} onLocaleChange={setLocale} />
 				<main id="main-content">


### PR DESCRIPTION
## Summary

- **P0-P1**: Convert 8 below-fold sections to `next/dynamic` ssr:false — deferring framer-motion. Expected TBT reduction: 600-800 ms.
- **P0-P2**: `localePrefix: as-needed` already in `i18n/routing.ts` — no `/` to `/en` redirect. 882 ms LCP recovery in place.
- **P0-P3**: `motion.h1` replaced with plain `<h1>` in `peers-hero.tsx` — LCP element paint-visible without JS.
- **P1-P1**: `<link rel="preconnect" href="https://plausible.io">` added to layout head. Recovers ~315 ms DNS/TCP.
- **P1-P2**: Render-blocking CSS chunks are Turbopack dev-mode artifacts only. No code change required.
- **P1-P3**: `browserslist` added to `package.json` targeting `supports es6-module` — drops ~14 KB legacy polyfills.
- **P2-P2**: Decorative grid/glow/gradient elements already plain divs — no motion wrappers present.

## Test plan

- [ ] Lighthouse Performance >= 90 (mobile) on `/` after deploy
- [ ] LCP <= 2.0 s
- [ ] TBT <= 350 ms
- [ ] No `/` to `/en` redirect (200 direct)
- [ ] Hero h1 renders without JS (disable JS in DevTools)
- [ ] preconnect to plausible.io in head
- [ ] First Load JS reduced vs baseline
- [ ] browserslist in package.json

Orchestrator: Sigma — VantageOS Team | 2026-05-20
