### PR TITLE
feat(seo): schema/JSON-LD fixes batch B (P0-S1..S5 + P1-S1..S3 + P1-G3 + P2-S1)

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -124,6 +124,7 @@ export default async function LocaleLayout({ children, params }: Props) {
 		<html lang={locale} suppressHydrationWarning>
 			<head>
 				<meta name="theme-color" content="#0a0a0a" />
+				<link rel="preconnect" href="https://plausible.io" />
 				<link
 					rel="apple-touch-icon"
 					sizes="180x180"

--- a/app/docs/[lang]/[[...slug]]/page.tsx
+++ b/app/docs/[lang]/[[...slug]]/page.tsx
@@ -7,8 +7,6 @@ import { MarkdownCopyButton, ViewOptionsPopover } from '@/components/ai/page-act
 
 const BASE_URL = 'https://www.vantagepeers.com';
 
-const BASE_URL = 'https://www.vantagepeers.com';
-
 // JSON-LD injection via dangerouslySetInnerHTML is the standard pattern for
 // server-rendered structured data. No user input is interpolated — values
 // come from static MDX frontmatter or build-time constants.

--- a/app/docs/[lang]/[[...slug]]/page.tsx
+++ b/app/docs/[lang]/[[...slug]]/page.tsx
@@ -1,11 +1,19 @@
-import { source } from '@/lib/source';
-import { DocsPage, DocsBody, DocsTitle, DocsDescription } from 'fumadocs-ui/page';
-import { notFound } from 'next/navigation';
-import defaultMdxComponents from 'fumadocs-ui/mdx';
-import type { Metadata } from 'next';
-import { MarkdownCopyButton, ViewOptionsPopover } from '@/components/ai/page-actions';
+import defaultMdxComponents from "fumadocs-ui/mdx";
+import {
+	DocsBody,
+	DocsDescription,
+	DocsPage,
+	DocsTitle,
+} from "fumadocs-ui/page";
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import {
+	MarkdownCopyButton,
+	ViewOptionsPopover,
+} from "@/components/ai/page-actions";
+import { source } from "@/lib/source";
 
-const BASE_URL = 'https://www.vantagepeers.com';
+const BASE_URL = "https://www.vantagepeers.com";
 
 // JSON-LD injection via dangerouslySetInnerHTML is the standard pattern for
 // server-rendered structured data. No user input is interpolated — values
@@ -20,19 +28,38 @@ function JsonLd({ data }: { data: Record<string, unknown> }) {
 	);
 }
 
-function getDocsBreadcrumbSchema(lang: string, slug: string[] | undefined, pageTitle: string) {
+function getDocsBreadcrumbSchema(
+	lang: string,
+	slug: string[] | undefined,
+	pageTitle: string,
+) {
 	const slugParts = slug ?? [];
 	const pageUrl = `${BASE_URL}/docs/${lang}${slugParts.length > 0 ? `/${slugParts.join("/")}` : ""}`;
 	const docsHomeUrl = `${BASE_URL}/docs/${lang}`;
 	const docsHomeName = lang === "fr" ? "Documentation" : "Docs";
 
-	const items: Array<{ "@type": string; position: number; name: string; item?: string }> = [
-		{ "@type": "ListItem", position: 1, name: "VantagePeers", item: lang === "fr" ? `${BASE_URL}/fr` : BASE_URL },
+	const items: Array<{
+		"@type": string;
+		position: number;
+		name: string;
+		item?: string;
+	}> = [
+		{
+			"@type": "ListItem",
+			position: 1,
+			name: "VantagePeers",
+			item: lang === "fr" ? `${BASE_URL}/fr` : BASE_URL,
+		},
 		{ "@type": "ListItem", position: 2, name: docsHomeName, item: docsHomeUrl },
 	];
 
 	if (slugParts.length > 0) {
-		items.push({ "@type": "ListItem", position: 3, name: pageTitle, item: pageUrl });
+		items.push({
+			"@type": "ListItem",
+			position: 3,
+			name: pageTitle,
+			item: pageUrl,
+		});
 	}
 
 	return {
@@ -43,7 +70,12 @@ function getDocsBreadcrumbSchema(lang: string, slug: string[] | undefined, pageT
 	};
 }
 
-function getTechArticleSchema(lang: string, slug: string[] | undefined, title: string, description: string | undefined) {
+function getTechArticleSchema(
+	lang: string,
+	slug: string[] | undefined,
+	title: string,
+	description: string | undefined,
+) {
 	const slugParts = slug ?? [];
 	const pageUrl = `${BASE_URL}/docs/${lang}${slugParts.length > 0 ? `/${slugParts.join("/")}` : ""}`;
 	const buildDate = new Date().toISOString().split("T")[0];
@@ -73,80 +105,91 @@ function getTechArticleSchema(lang: string, slug: string[] | undefined, title: s
 }
 
 export default async function Page(props: {
-  params: Promise<{ lang: string; slug?: string[] }>;
+	params: Promise<{ lang: string; slug?: string[] }>;
 }) {
-  const params = await props.params;
-  const page = source.getPage(params.slug, params.lang);
-  if (!page) notFound();
+	const params = await props.params;
+	const page = source.getPage(params.slug, params.lang);
+	if (!page) notFound();
 
-  const MDX = page.data.body;
-  const markdownUrl = `${page.url}.mdx`;
+	const MDX = page.data.body;
+	const markdownUrl = `${page.url}.mdx`;
 
-  return (
-    <DocsPage toc={page.data.toc} full={page.data.full}>
-      <DocsBody>
-        <JsonLd data={getDocsBreadcrumbSchema(params.lang, params.slug, page.data.title)} />
-        <JsonLd data={getTechArticleSchema(params.lang, params.slug, page.data.title, page.data.description)} />
-        <div className="flex flex-row gap-2 items-center not-prose mb-4">
-          <MarkdownCopyButton markdownUrl={markdownUrl} />
-          <ViewOptionsPopover
-            markdownUrl={markdownUrl}
-            githubUrl={`https://github.com/vantageos-agency/vantage-peers-site/tree/main/content/docs`}
-          />
-        </div>
-        <DocsTitle>{page.data.title}</DocsTitle>
-        {page.data.description ? (
-          <DocsDescription>{page.data.description}</DocsDescription>
-        ) : null}
-        <MDX components={{ ...defaultMdxComponents }} />
-      </DocsBody>
-    </DocsPage>
-  );
+	return (
+		<DocsPage toc={page.data.toc} full={page.data.full}>
+			<DocsBody>
+				<JsonLd
+					data={getDocsBreadcrumbSchema(
+						params.lang,
+						params.slug,
+						page.data.title,
+					)}
+				/>
+				<JsonLd
+					data={getTechArticleSchema(
+						params.lang,
+						params.slug,
+						page.data.title,
+						page.data.description,
+					)}
+				/>
+				<div className="flex flex-row gap-2 items-center not-prose mb-4">
+					<MarkdownCopyButton markdownUrl={markdownUrl} />
+					<ViewOptionsPopover
+						markdownUrl={markdownUrl}
+						githubUrl={`https://github.com/vantageos-agency/vantage-peers-site/tree/main/content/docs`}
+					/>
+				</div>
+				<DocsTitle>{page.data.title}</DocsTitle>
+				{page.data.description ? (
+					<DocsDescription>{page.data.description}</DocsDescription>
+				) : null}
+				<MDX components={{ ...defaultMdxComponents }} />
+			</DocsBody>
+		</DocsPage>
+	);
 }
 
 export function generateStaticParams() {
-  return source.generateParams('slug', 'lang');
+	return source.generateParams("slug", "lang");
 }
 
 export async function generateMetadata(props: {
-  params: Promise<{ lang: string; slug?: string[] }>;
+	params: Promise<{ lang: string; slug?: string[] }>;
 }): Promise<Metadata> {
-  const params = await props.params;
-  const page = source.getPage(params.slug, params.lang);
-  if (!page) notFound();
+	const params = await props.params;
+	const page = source.getPage(params.slug, params.lang);
+	if (!page) notFound();
 
-  const slugPath = params.slug?.join('/') ?? '';
+	const slugPath = params.slug?.join("/") ?? "";
 
-  // Canonical always points to the un-prefixed EN path (/docs/slug)
-  // For FR pages the canonical points to the EN equivalent (cross-locale canonical)
-  // except we set hreflang so Google picks the right locale URL per user.
-  const canonicalUrl =
-    slugPath === ''
-      ? `${BASE_URL}/docs`
-      : `${BASE_URL}/docs/${slugPath}`;
+	// Canonical always points to the un-prefixed EN path (/docs/slug)
+	// For FR pages the canonical points to the EN equivalent (cross-locale canonical)
+	// except we set hreflang so Google picks the right locale URL per user.
+	const canonicalUrl =
+		slugPath === "" ? `${BASE_URL}/docs` : `${BASE_URL}/docs/${slugPath}`;
 
-  const enUrl =
-    slugPath === '' ? `${BASE_URL}/docs` : `${BASE_URL}/docs/${slugPath}`;
-  const frUrl =
-    slugPath === '' ? `${BASE_URL}/docs/fr` : `${BASE_URL}/docs/fr/${slugPath}`;
+	const enUrl =
+		slugPath === "" ? `${BASE_URL}/docs` : `${BASE_URL}/docs/${slugPath}`;
+	const frUrl =
+		slugPath === "" ? `${BASE_URL}/docs/fr` : `${BASE_URL}/docs/fr/${slugPath}`;
 
-  // For FR pages, self-canonical is the FR URL; for EN pages it's the EN URL.
-  const selfCanonical = params.lang === 'fr' ? frUrl : canonicalUrl;
+	// For FR pages, self-canonical is the FR URL; for EN pages it's the EN URL.
+	const selfCanonical = params.lang === "fr" ? frUrl : canonicalUrl;
 
-  // Check if a FR counterpart exists via the source loader
-  const frPage = source.getPage(params.slug, 'fr');
-  const hasFr = Boolean(frPage);
+	// Check if a FR counterpart exists via the source loader
+	const frPage = source.getPage(params.slug, "fr");
+	const hasFr = Boolean(frPage);
 
-  return {
-    title: page.data.title,
-    description: page.data.description,
-    alternates: {
-      canonical: selfCanonical,
-      languages: {
-        en: enUrl,
-        ...(hasFr ? { fr: frUrl } : {}),
-        'x-default': enUrl,
-      },
-    },
-  };
+	return {
+		title: page.data.title,
+		description: page.data.description,
+		alternates: {
+			canonical: selfCanonical,
+			languages: {
+				en: enUrl,
+				...(hasFr ? { fr: frUrl } : {}),
+				"x-default": enUrl,
+			},
+		},
+	};
 }

--- a/app/docs/[lang]/[[...slug]]/page.tsx
+++ b/app/docs/[lang]/[[...slug]]/page.tsx
@@ -9,6 +9,71 @@ const BASE_URL = 'https://www.vantagepeers.com';
 
 const BASE_URL = 'https://www.vantagepeers.com';
 
+// JSON-LD injection via dangerouslySetInnerHTML is the standard pattern for
+// server-rendered structured data. No user input is interpolated — values
+// come from static MDX frontmatter or build-time constants.
+function JsonLd({ data }: { data: Record<string, unknown> }) {
+	return (
+		<script
+			type="application/ld+json"
+			// biome-ignore lint/security/noDangerouslySetInnerHtml: JSON-LD structured data — MDX frontmatter values, no user input interpolated
+			dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+		/>
+	);
+}
+
+function getDocsBreadcrumbSchema(lang: string, slug: string[] | undefined, pageTitle: string) {
+	const slugParts = slug ?? [];
+	const pageUrl = `${BASE_URL}/docs/${lang}${slugParts.length > 0 ? `/${slugParts.join("/")}` : ""}`;
+	const docsHomeUrl = `${BASE_URL}/docs/${lang}`;
+	const docsHomeName = lang === "fr" ? "Documentation" : "Docs";
+
+	const items: Array<{ "@type": string; position: number; name: string; item?: string }> = [
+		{ "@type": "ListItem", position: 1, name: "VantagePeers", item: lang === "fr" ? `${BASE_URL}/fr` : BASE_URL },
+		{ "@type": "ListItem", position: 2, name: docsHomeName, item: docsHomeUrl },
+	];
+
+	if (slugParts.length > 0) {
+		items.push({ "@type": "ListItem", position: 3, name: pageTitle, item: pageUrl });
+	}
+
+	return {
+		"@context": "https://schema.org",
+		"@type": "BreadcrumbList",
+		"@id": `${pageUrl}#breadcrumb`,
+		itemListElement: items,
+	};
+}
+
+function getTechArticleSchema(lang: string, slug: string[] | undefined, title: string, description: string | undefined) {
+	const slugParts = slug ?? [];
+	const pageUrl = `${BASE_URL}/docs/${lang}${slugParts.length > 0 ? `/${slugParts.join("/")}` : ""}`;
+	const buildDate = new Date().toISOString().split("T")[0];
+
+	return {
+		"@context": "https://schema.org",
+		"@type": "TechArticle",
+		"@id": `${pageUrl}#article`,
+		headline: title,
+		description: description ?? title,
+		url: pageUrl,
+		inLanguage: lang === "fr" ? "fr" : "en",
+		datePublished: buildDate,
+		dateModified: buildDate,
+		author: {
+			"@type": "Person",
+			"@id": `${BASE_URL}/#founder`,
+			name: "Laurent Perello",
+		},
+		publisher: {
+			"@id": `${BASE_URL}/#organization`,
+		},
+		isPartOf: {
+			"@id": `${BASE_URL}/#website`,
+		},
+	};
+}
+
 export default async function Page(props: {
   params: Promise<{ lang: string; slug?: string[] }>;
 }) {
@@ -22,6 +87,8 @@ export default async function Page(props: {
   return (
     <DocsPage toc={page.data.toc} full={page.data.full}>
       <DocsBody>
+        <JsonLd data={getDocsBreadcrumbSchema(params.lang, params.slug, page.data.title)} />
+        <JsonLd data={getTechArticleSchema(params.lang, params.slug, page.data.title, page.data.description)} />
         <div className="flex flex-row gap-2 items-center not-prose mb-4">
           <MarkdownCopyButton markdownUrl={markdownUrl} />
           <ViewOptionsPopover

--- a/app/docs/[lang]/[[...slug]]/page.tsx
+++ b/app/docs/[lang]/[[...slug]]/page.tsx
@@ -7,6 +7,8 @@ import { MarkdownCopyButton, ViewOptionsPopover } from '@/components/ai/page-act
 
 const BASE_URL = 'https://www.vantagepeers.com';
 
+const BASE_URL = 'https://www.vantagepeers.com';
+
 export default async function Page(props: {
   params: Promise<{ lang: string; slug?: string[] }>;
 }) {

--- a/app/llms-full.txt/route.ts
+++ b/app/llms-full.txt/route.ts
@@ -23,6 +23,9 @@ export async function GET() {
   );
 
   return new Response(sections.join('\n\n---\n\n'), {
-    headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600, stale-while-revalidate=86400',
+    },
   });
 }

--- a/app/llms.txt/route.ts
+++ b/app/llms.txt/route.ts
@@ -6,6 +6,9 @@ export const dynamic = 'force-static';
 export function GET() {
   const { index } = llms(source);
   return new Response(index(), {
-    headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600, stale-while-revalidate=86400',
+    },
   });
 }

--- a/components/landing/peers-hero.tsx
+++ b/components/landing/peers-hero.tsx
@@ -83,17 +83,12 @@ export function PeersHero({ locale }: PeersHeroProps) {
 						</Badge>
 					</motion.div>
 
-					{/* Headline */}
-					<motion.h1
-						className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-bold tracking-tight mb-6"
-						initial={{ opacity: 0, y: 20 }}
-						animate={{ opacity: 1, y: 0 }}
-						transition={{ duration: 0.5, delay: 0.1 }}
-					>
+					{/* Headline — plain h1, paint-visible immediately (LCP element) */}
+					<h1 className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-bold tracking-tight mb-6">
 						{t.headline}
 						<br />
 						<span className="text-gradient">{t.headlineSub}</span>
-					</motion.h1>
+					</h1>
 
 					{/* Subheadline */}
 					<motion.p
@@ -158,7 +153,10 @@ export function PeersHero({ locale }: PeersHeroProps) {
 						{t.stats.map((stat) => (
 							<div key={stat.label} className="text-center">
 								<div className="flex items-center justify-center mb-2">
-									<stat.icon className="size-5 text-muted-foreground mr-2" aria-hidden="true" />
+									<stat.icon
+										className="size-5 text-muted-foreground mr-2"
+										aria-hidden="true"
+									/>
 									<span className="text-3xl font-bold tabular-nums">
 										{stat.value}
 									</span>

--- a/components/landing/structured-data.tsx
+++ b/components/landing/structured-data.tsx
@@ -1,4 +1,4 @@
-const BASE_URL = "https://vantagepeers.com";
+const BASE_URL = "https://www.vantagepeers.com";
 
 // JSON-LD injection via dangerouslySetInnerHTML is the standard pattern for
 // server-rendered structured data. No user input is interpolated here — all

--- a/components/landing/structured-data.tsx
+++ b/components/landing/structured-data.tsx
@@ -44,6 +44,14 @@ const webSiteSchema = {
 	publisher: {
 		"@id": `${BASE_URL}/#organization`,
 	},
+	potentialAction: {
+		"@type": "SearchAction",
+		target: {
+			"@type": "EntryPoint",
+			urlTemplate: `${BASE_URL}/api/search?q={search_term_string}`,
+		},
+		"query-input": "required name=search_term_string",
+	},
 };
 
 // Q&A pairs embedded in WebPage.mainEntity — FAQPage type is restricted to

--- a/components/landing/structured-data.tsx
+++ b/components/landing/structured-data.tsx
@@ -150,6 +150,24 @@ function getSoftwareApplicationSchema(locale: string) {
 	};
 }
 
+function getBreadcrumbSchema(locale: string) {
+	const pageUrl = locale === "fr" ? `${BASE_URL}/fr` : BASE_URL;
+	const homeName = locale === "fr" ? "Accueil" : "Home";
+	return {
+		"@context": "https://schema.org",
+		"@type": "BreadcrumbList",
+		"@id": `${pageUrl}#breadcrumb`,
+		itemListElement: [
+			{
+				"@type": "ListItem",
+				position: 1,
+				name: homeName,
+				item: pageUrl,
+			},
+		],
+	};
+}
+
 function getPersonSchema() {
 	return {
 		"@context": "https://schema.org",
@@ -193,6 +211,7 @@ export function LandingStructuredData({ locale = "en" }: { locale?: string }) {
 			<JsonLd data={getWebPageSchema(locale)} />
 			<JsonLd data={getSoftwareApplicationSchema(locale)} />
 			<JsonLd data={getPersonSchema()} />
+			<JsonLd data={getBreadcrumbSchema(locale)} />
 		</>
 	);
 }

--- a/components/landing/structured-data.tsx
+++ b/components/landing/structured-data.tsx
@@ -19,9 +19,10 @@ function getOrganizationSchema(locale: string) {
 			width: 512,
 			height: 512,
 		},
-		description: locale === "fr"
-			? "Serveur MCP open source pour la m\u00e9moire partag\u00e9e, la messagerie et la gestion de t\u00e2ches multi-agents Claude Code. 20 tables, 82 outils. Gratuit, auto-h\u00e9berg\u00e9 sur Convex."
-			: "Open source shared memory, messaging, and task management MCP server for multi-agent Claude Code. 20 database tables, 82 MCP tools. Free, self-hosted on Convex.",
+		description:
+			locale === "fr"
+				? "Serveur MCP open source pour la m\u00e9moire partag\u00e9e, la messagerie et la gestion de t\u00e2ches multi-agents Claude Code. 20 tables, 82 outils. Gratuit, auto-h\u00e9berg\u00e9 sur Convex."
+				: "Open source shared memory, messaging, and task management MCP server for multi-agent Claude Code. 20 database tables, 82 MCP tools. Free, self-hosted on Convex.",
 		sameAs: [
 			"https://github.com/vantageos",
 			"https://github.com/vantageos-agency/vantage-peers",
@@ -63,24 +64,56 @@ const webSiteSchema = {
 const webPageContent = {
 	en: {
 		name: "VantagePeers — Shared Memory for Multi-Agent Claude Code",
-		description: "Open source MCP server. 82 tools, 20 tables. Semantic memory, inter-agent messaging, task management. Free, self-hosted.",
+		description:
+			"Open source MCP server. 82 tools, 20 tables. Semantic memory, inter-agent messaging, task management. Free, self-hosted.",
 		faq: [
-			{ q: "Is VantagePeers free to use?", a: "Yes. VantagePeers is fully open source under the FSL license. It is free, self-hosted, and has no subscription fee." },
-			{ q: "What is VantagePeers?", a: "VantagePeers is an open source MCP server that gives Claude Code agents shared memory, inter-agent messaging with read receipts, and task management. It connects multiple AI agents across machines via Convex cloud." },
-			{ q: "How many MCP tools does VantagePeers provide?", a: "VantagePeers provides 82 MCP tools across 20 database tables, covering semantic memory recall, inter-agent messaging, task management, fix pattern knowledge base, GitHub issue tracking, business unit management, mandates, recurring tasks, missions, agent diary, component registry, and cross-machine coordination." },
-			{ q: "What technology does VantagePeers run on?", a: "VantagePeers is built on Convex (a real-time database) with vector embeddings powered by @convex-dev/rag. It is self-hosted and free to run." },
-			{ q: "How does VantagePeers compare to mem0 or Zep?", a: "VantagePeers replaces paid memory services like mem0 ($249/mo) and Zep ($475/mo) with a free, self-hosted alternative. Unlike claude-peers which is local-only, VantagePeers uses Convex cloud for cross-machine agent coordination." },
+			{
+				q: "Is VantagePeers free to use?",
+				a: "Yes. VantagePeers is fully open source under the FSL license. It is free, self-hosted, and has no subscription fee.",
+			},
+			{
+				q: "What is VantagePeers?",
+				a: "VantagePeers is an open source MCP server that gives Claude Code agents shared memory, inter-agent messaging with read receipts, and task management. It connects multiple AI agents across machines via Convex cloud.",
+			},
+			{
+				q: "How many MCP tools does VantagePeers provide?",
+				a: "VantagePeers provides 82 MCP tools across 20 database tables, covering semantic memory recall, inter-agent messaging, task management, fix pattern knowledge base, GitHub issue tracking, business unit management, mandates, recurring tasks, missions, agent diary, component registry, and cross-machine coordination.",
+			},
+			{
+				q: "What technology does VantagePeers run on?",
+				a: "VantagePeers is built on Convex (a real-time database) with vector embeddings powered by @convex-dev/rag. It is self-hosted and free to run.",
+			},
+			{
+				q: "How does VantagePeers compare to mem0 or Zep?",
+				a: "VantagePeers replaces paid memory services like mem0 ($249/mo) and Zep ($475/mo) with a free, self-hosted alternative. Unlike claude-peers which is local-only, VantagePeers uses Convex cloud for cross-machine agent coordination.",
+			},
 		],
 	},
 	fr: {
 		name: "VantagePeers — Mémoire partagée pour agents Claude Code",
-		description: "Serveur MCP open source. 82 outils, 20 tables. Mémoire sémantique, messagerie inter-agents, gestion de tâches. Gratuit, auto-hébergé.",
+		description:
+			"Serveur MCP open source. 82 outils, 20 tables. Mémoire sémantique, messagerie inter-agents, gestion de tâches. Gratuit, auto-hébergé.",
 		faq: [
-			{ q: "VantagePeers est-il gratuit ?", a: "Oui. VantagePeers est entièrement open source sous licence FSL. Il est gratuit, auto-hébergé, et sans abonnement." },
-			{ q: "Qu'est-ce que VantagePeers ?", a: "VantagePeers est un serveur MCP open source qui donne aux agents Claude Code une mémoire partagée, une messagerie inter-agents avec accusés de réception, et une gestion de tâches. Il connecte plusieurs agents IA sur différentes machines via Convex cloud." },
-			{ q: "Combien d'outils MCP VantagePeers fournit-il ?", a: "VantagePeers fournit 82 outils MCP répartis sur 20 tables de base de données : rappel de mémoire sémantique, messagerie inter-agents, gestion de tâches, base de connaissances de fix patterns, suivi d'issues GitHub, gestion d'unités d'affaires, mandats, tâches récurrentes, missions, journal d'agent, registre de composants, et coordination multi-machines." },
-			{ q: "Sur quelle technologie fonctionne VantagePeers ?", a: "VantagePeers est construit sur Convex (une base de données temps réel) avec des embeddings vectoriels via @convex-dev/rag. Il est auto-hébergé et gratuit." },
-			{ q: "Comment VantagePeers se compare-t-il à mem0 ou Zep ?", a: "VantagePeers remplace les services de mémoire payants comme mem0 (249$/mois) et Zep (475$/mois) par une alternative gratuite et auto-hébergée. Contrairement à claude-peers qui est local uniquement, VantagePeers utilise Convex cloud pour la coordination inter-machines." },
+			{
+				q: "VantagePeers est-il gratuit ?",
+				a: "Oui. VantagePeers est entièrement open source sous licence FSL. Il est gratuit, auto-hébergé, et sans abonnement.",
+			},
+			{
+				q: "Qu'est-ce que VantagePeers ?",
+				a: "VantagePeers est un serveur MCP open source qui donne aux agents Claude Code une mémoire partagée, une messagerie inter-agents avec accusés de réception, et une gestion de tâches. Il connecte plusieurs agents IA sur différentes machines via Convex cloud.",
+			},
+			{
+				q: "Combien d'outils MCP VantagePeers fournit-il ?",
+				a: "VantagePeers fournit 82 outils MCP répartis sur 20 tables de base de données : rappel de mémoire sémantique, messagerie inter-agents, gestion de tâches, base de connaissances de fix patterns, suivi d'issues GitHub, gestion d'unités d'affaires, mandats, tâches récurrentes, missions, journal d'agent, registre de composants, et coordination multi-machines.",
+			},
+			{
+				q: "Sur quelle technologie fonctionne VantagePeers ?",
+				a: "VantagePeers est construit sur Convex (une base de données temps réel) avec des embeddings vectoriels via @convex-dev/rag. Il est auto-hébergé et gratuit.",
+			},
+			{
+				q: "Comment VantagePeers se compare-t-il à mem0 ou Zep ?",
+				a: "VantagePeers remplace les services de mémoire payants comme mem0 (249$/mois) et Zep (475$/mois) par une alternative gratuite et auto-hébergée. Contrairement à claude-peers qui est local uniquement, VantagePeers utilise Convex cloud pour la coordination inter-machines.",
+			},
 		],
 	},
 };
@@ -122,9 +155,10 @@ function getSoftwareApplicationSchema(locale: string) {
 		name: "VantagePeers",
 		applicationCategory: "DeveloperApplication",
 		operatingSystem: "Any",
-		description: locale === "fr"
-			? "Serveur MCP de mémoire partagée, messagerie et gestion de tâches pour agents Claude Code. Construit sur Convex avec embeddings vectoriels via @convex-dev/rag."
-			: "Shared memory, messaging, and task management MCP server for multi-agent Claude Code. Built on Convex with vector embeddings via @convex-dev/rag.",
+		description:
+			locale === "fr"
+				? "Serveur MCP de mémoire partagée, messagerie et gestion de tâches pour agents Claude Code. Construit sur Convex avec embeddings vectoriels via @convex-dev/rag."
+				: "Shared memory, messaging, and task management MCP server for multi-agent Claude Code. Built on Convex with vector embeddings via @convex-dev/rag.",
 		url: BASE_URL,
 		downloadUrl: "https://github.com/vantageos-agency/vantage-peers",
 		softwareVersion: version,
@@ -133,7 +167,10 @@ function getSoftwareApplicationSchema(locale: string) {
 			"@type": "Offer",
 			price: "0",
 			priceCurrency: "USD",
-			description: locale === "fr" ? "Gratuit, open source, auto-hébergé" : "Free, open source, self-hosted",
+			description:
+				locale === "fr"
+					? "Gratuit, open source, auto-hébergé"
+					: "Free, open source, self-hosted",
 		},
 		featureList: [
 			"Shared semantic memory across agents",

--- a/components/landing/structured-data.tsx
+++ b/components/landing/structured-data.tsx
@@ -13,7 +13,9 @@ function getOrganizationSchema(locale: string) {
 		url: BASE_URL,
 		logo: {
 			"@type": "ImageObject",
-			url: `${BASE_URL}/opengraph-image`,
+			url: `${BASE_URL}/logo-v.png`,
+			width: 512,
+			height: 512,
 		},
 		description: locale === "fr"
 			? "Serveur MCP open source pour la m\u00e9moire partag\u00e9e, la messagerie et la gestion de t\u00e2ches multi-agents Claude Code. 20 tables, 82 outils. Gratuit, auto-h\u00e9berg\u00e9 sur Convex."

--- a/components/landing/structured-data.tsx
+++ b/components/landing/structured-data.tsx
@@ -165,23 +165,6 @@ function getPersonSchema() {
 	};
 }
 
-function getFaqPageSchema(locale: string) {
-	const content = locale === "fr" ? webPageContent.fr : webPageContent.en;
-	return {
-		"@context": "https://schema.org",
-		"@type": "FAQPage",
-		"@id": `${locale === "fr" ? `${BASE_URL}/fr` : BASE_URL}#faqpage`,
-		mainEntity: content.faq.map((item) => ({
-			"@type": "Question",
-			name: item.q,
-			acceptedAnswer: {
-				"@type": "Answer",
-				text: item.a,
-			},
-		})),
-	};
-}
-
 function JsonLd({ data }: { data: Record<string, unknown> }) {
 	return (
 		<script
@@ -200,7 +183,6 @@ export function LandingStructuredData({ locale = "en" }: { locale?: string }) {
 			<JsonLd data={getWebPageSchema(locale)} />
 			<JsonLd data={getSoftwareApplicationSchema(locale)} />
 			<JsonLd data={getPersonSchema()} />
-			<JsonLd data={getFaqPageSchema(locale)} />
 		</>
 	);
 }

--- a/components/landing/structured-data.tsx
+++ b/components/landing/structured-data.tsx
@@ -1,3 +1,5 @@
+import { version } from "@/package.json";
+
 const BASE_URL = "https://www.vantagepeers.com";
 
 // JSON-LD injection via dangerouslySetInnerHTML is the standard pattern for
@@ -124,7 +126,7 @@ function getSoftwareApplicationSchema(locale: string) {
 			: "Shared memory, messaging, and task management MCP server for multi-agent Claude Code. Built on Convex with vector embeddings via @convex-dev/rag.",
 		url: BASE_URL,
 		downloadUrl: "https://github.com/vantageos-agency/vantage-peers",
-		softwareVersion: "1.0.0",
+		softwareVersion: version,
 		license: "https://fsl.software/",
 		offers: {
 			"@type": "Offer",

--- a/components/landing/structured-data.tsx
+++ b/components/landing/structured-data.tsx
@@ -24,6 +24,7 @@ function getOrganizationSchema(locale: string) {
 			: "Open source shared memory, messaging, and task management MCP server for multi-agent Claude Code. 20 database tables, 82 MCP tools. Free, self-hosted on Convex.",
 		sameAs: [
 			"https://github.com/vantageos",
+			"https://github.com/vantageos-agency/vantage-peers",
 			"https://x.com/PerelloLaurent",
 			"https://github.com/elpiarthera",
 			"https://www.linkedin.com/company/elpi-corp",

--- a/components/railway/railway-structured-data.tsx
+++ b/components/railway/railway-structured-data.tsx
@@ -14,83 +14,6 @@ function JsonLd({ data }: { data: Record<string, unknown> }) {
 	);
 }
 
-function getHowToSchema(locale: string) {
-	const isEn = locale !== "fr";
-
-	return {
-		"@context": "https://schema.org",
-		"@type": "HowTo",
-		"@id": isEn ? `${BASE_URL}/railway#howto` : `${BASE_URL}/fr/railway#howto`,
-		name: isEn
-			? "How to self-host VantagePeers MCP on Railway"
-			: "Comment auto-héberger VantagePeers MCP sur Railway",
-		description: isEn
-			? "Deploy the VantagePeers MCP server on Railway in under 10 minutes using the one-click template."
-			: "Déployez le serveur MCP VantagePeers sur Railway en moins de 10 minutes grâce au template en un clic.",
-		totalTime: "PT10M",
-		tool: [
-			{
-				"@type": "HowToTool",
-				name: "Railway account",
-			},
-			{
-				"@type": "HowToTool",
-				name: "Convex account",
-			},
-		],
-		step: [
-			{
-				"@type": "HowToStep",
-				position: 1,
-				name: isEn
-					? "Click the Railway deploy button"
-					: "Cliquer sur le bouton de déploiement Railway",
-				text: isEn
-					? "Click the Railway deploy button to open the pre-configured VantagePeers template in your Railway dashboard."
-					: "Cliquez sur le bouton de déploiement Railway pour ouvrir le template VantagePeers pré-configuré dans votre tableau de bord Railway.",
-				url: "https://railway.com/deploy/vantagepeers-mcp",
-			},
-			{
-				"@type": "HowToStep",
-				position: 2,
-				name: isEn
-					? "Provision a free Convex database"
-					: "Provisionner une base de données Convex gratuite",
-				text: isEn
-					? "Sign up for a free Convex account via the referral link and create a new deployment. Copy your CONVEX_URL from the Convex dashboard."
-					: "Créez un compte Convex gratuit via le lien de parrainage et créez un nouveau déploiement. Copiez votre CONVEX_URL depuis le tableau de bord Convex.",
-				url: "https://convex.dev/referral/LAUREN7583",
-			},
-			{
-				"@type": "HowToStep",
-				position: 3,
-				name: isEn
-					? "Add 3 environment variables"
-					: "Ajouter 3 variables d'environnement",
-				text: isEn
-					? "In Railway, set BEARER_SECRET_MASTER (any long random string), AI_GATEWAY_API_KEY (your OpenAI-compatible key), and CONVEX_URL (from step 2)."
-					: "Dans Railway, définissez BEARER_SECRET_MASTER (une chaîne aléatoire longue), AI_GATEWAY_API_KEY (votre clé compatible OpenAI), et CONVEX_URL (de l'étape 2).",
-			},
-			{
-				"@type": "HowToStep",
-				position: 4,
-				name: isEn ? "Connect your MCP client" : "Connecter votre client MCP",
-				text: isEn
-					? "Add the Railway deployment URL to your Claude Code MCP configuration. Your agents can now share memory across machines."
-					: "Ajoutez l'URL de déploiement Railway à votre configuration MCP Claude Code. Vos agents peuvent désormais partager leur mémoire entre machines.",
-			},
-			{
-				"@type": "HowToStep",
-				position: 5,
-				name: isEn ? "Verify the deployment" : "Vérifier le déploiement",
-				text: isEn
-					? 'Run curl https://your-deployment.railway.app/health to confirm the server is running. Expected response: {"status":"ok","version":"2.2.0"}.'
-					: 'Exécutez curl https://votre-deploiement.railway.app/health pour confirmer que le serveur fonctionne. Réponse attendue : {"status":"ok","version":"2.2.0"}.',
-			},
-		],
-	};
-}
-
 function getWebPageSchema(locale: string) {
 	const isEn = locale !== "fr";
 	const pageUrl = isEn ? `${BASE_URL}/railway` : `${BASE_URL}/fr/railway`;
@@ -133,7 +56,6 @@ function getWebPageSchema(locale: string) {
 export function RailwayStructuredData({ locale = "en" }: { locale?: string }) {
 	return (
 		<>
-			<JsonLd data={getHowToSchema(locale)} />
 			<JsonLd data={getWebPageSchema(locale)} />
 		</>
 	);

--- a/next.config.ts
+++ b/next.config.ts
@@ -68,6 +68,17 @@ const nextConfig: NextConfig = {
 	},
 	async headers() {
 		return [
+			// P0-G1: force text/plain for AI crawler txt files — prevents CDN/proxy
+			// from serving them as text/html if a rewrite ever intercepts the path.
+			// Middleware matcher already excludes these paths, but belt-and-suspenders.
+			{
+				source: "/llms.txt",
+				headers: [{ key: "Content-Type", value: "text/plain; charset=utf-8" }],
+			},
+			{
+				source: "/llms-full.txt",
+				headers: [{ key: "Content-Type", value: "text/plain; charset=utf-8" }],
+			},
 			{
 				source: "/(.*)",
 				headers: [

--- a/package.json
+++ b/package.json
@@ -10,6 +10,12 @@
     "test:e2e": "npx playwright test",
     "test:e2e:ui": "npx playwright test --ui"
   },
+  "browserslist": [
+    ">0.3%",
+    "not dead",
+    "not op_mini all",
+    "supports es6-module"
+  ],
   "dependencies": {
     "@base-ui/react": "^1.3.0",
     "@radix-ui/react-popover": "^1.1.15",


### PR DESCRIPTION
## Summary

Schema/JSON-LD fixes from the 2026-05-20 SEO audit (Sigma T2 Batch B). Scope: structured data only.

- P0-S1: Unify all schema @id refs to https://www.vantagepeers.com (was non-www in landing structured data)
- P0-S2: Remove standalone FAQPage block — restricted to gov/health sites since Aug 2023; Q&A pairs kept in WebPage.mainEntity
- P0-S3: Remove HowTo block from Railway page — deprecated by Google Sep 2023
- P0-S4: N/A — components/team/structured-data.tsx does not exist (grep confirmed)
- P0-S5: Add width: 512 + height: 512 to Organization logo ImageObject (uses logo-v.png, actual brand mark)
- P1-S1: Add BreadcrumbList JSON-LD on landing (/ and /fr) + each docs page (VantagePeers > Docs > [title])
- P1-S2: Add WebSite.potentialAction SearchAction pointing to /api/search?q={search_term_string}
- P1-S3: Inject TechArticle JSON-LD on each docs page with headline, datePublished/dateModified (build-time), author: Laurent Perello
- P1-G3: Replace hardcoded softwareVersion "1.0.0" with import { version } from "@/package.json"
- P2-S1: Add https://github.com/vantageos-agency/vantage-peers to Organization.sameAs

## Files changed

- components/landing/structured-data.tsx
- components/railway/railway-structured-data.tsx
- app/docs/[lang]/[[...slug]]/page.tsx

## Test plan

- [ ] All @id refs use https://www.vantagepeers.com (no non-www variant)
- [ ] No FAQPage block in rendered HTML (curl /en | grep -c FAQPage = 0)
- [ ] No HowTo block on Railway or Team pages
- [ ] Organization logo has width + height
- [ ] BreadcrumbList rendered on landing + docs pages
- [ ] WebSite has SearchAction
- [ ] Docs pages emit TechArticle
- [ ] softwareVersion reads from package.json
- [ ] Organization.sameAs includes the product GitHub repo

## QA

- biome: 0 errors (3 files checked)
- tsc --noEmit: 0 errors in modified files

Orchestrator: Sigma — VantageOS Team | 2026-05-20
