### PR TITLE
feat(docs): FR translations for deploy-keys + multi-tenancy (P0-C3)

### DIFF
--- a/content/docs/core-concepts/multi-tenancy.fr.mdx
+++ b/content/docs/core-concepts/multi-tenancy.fr.mdx
@@ -1,0 +1,159 @@
+---
+title: Multi-Tenancy
+description: Conventions pour isoler les memories, tasks, missions et messages entre les tenants dans un déploiement Convex partagé.
+---
+
+# Multi-Tenancy
+
+VantagePeers s'exécute sur un seul déploiement Convex. Lorsque plusieurs entreprises ou équipes partagent ce déploiement, vous avez besoin d'une isolation entre les tenants. Cette page décrit les conventions qui maintiennent les données de chaque tenant séparées sans nécessiter une infrastructure séparée.
+
+## Isolation de l'espace de noms de mémoire
+
+Les mémoires sont dimensionnées par le champ `namespace`. VantagePeers supporte déjà les espaces de noms `global`, `project/` et `orchestrator/`. Pour l'isolation entre tenants, utilisez le préfixe `workspace/`.
+
+### Convention
+
+Utilisez `workspace/{workspaceId}` comme l'espace de noms pour les mémoires dimensionnées par tenant.
+
+```json
+// Store a memory for Acme Corp
+{
+  "namespace": "workspace/acme-corp",
+  "type": "project",
+  "content": "Acme Corp uses PostgreSQL 15 with pgvector for their product catalog.",
+  "createdBy": "tau"
+}
+
+// Store a memory for Globex Corp
+{
+  "namespace": "workspace/globex-corp",
+  "type": "project",
+  "content": "Globex Corp runs on MongoDB Atlas with a strict schema validation policy.",
+  "createdBy": "tau"
+}
+```
+
+### Recall avec portée Workspace
+
+Lors du rappel, passez l'espace de noms du workspace pour limiter les résultats à ce tenant :
+
+```json
+{
+  "query": "database setup",
+  "namespace": "workspace/acme-corp"
+}
+```
+
+Ceci retourne uniquement les mémoires d'Acme Corp. Les mémoires de Globex Corp sont exclues.
+
+### Workspace vs Project
+
+| Préfixe | Portée | Exemple |
+|--------|-------|---------|
+| `project/` | Un repo spécifique, une feature ou une initiative | `project/landing-page` |
+| `workspace/` | Un tenant/entreprise entière | `workspace/acme-corp` |
+| `orchestrator/` | L'état privé d'un seul agent | `orchestrator/tau` |
+| `global` | Partagé partout | `global` |
+
+Vous pouvez les combiner. Un agent travaillant sur la page d'accueil d'Acme Corp pourrait stocker les mémoires dans `workspace/acme-corp` pour le contexte au niveau de l'entreprise et `project/acme-landing-page` pour le contexte spécifique à la feature.
+
+## Isolation de projet pour Task et Mission
+
+Les tasks et missions utilisent le champ `project` pour la dimensionnement. Pour l'isolation entre tenants, utilisez le préfixe `studio/`.
+
+### Convention
+
+Utilisez `studio/{workspaceId}` comme la valeur du projet pour les tasks et missions dimensionnées par tenant.
+
+```json
+// Create a task scoped to Acme Corp
+{
+  "title": "Migrate Acme product catalog to pgvector",
+  "assignedTo": "tau",
+  "priority": "high",
+  "project": "studio/acme-corp"
+}
+
+// Create a mission scoped to Globex Corp
+{
+  "title": "Globex API v2 rollout",
+  "pilot": "pi",
+  "project": "studio/globex-corp"
+}
+```
+
+Lors du listage des tasks, filtrez par projet pour voir uniquement le travail de ce tenant :
+
+```json
+{
+  "project": "studio/acme-corp"
+}
+```
+
+## Isolation tenantId des Messages
+
+Les messages et les reçus de messages supportent un champ optionnel `tenantId` pour la communication dimensionnée par tenant.
+
+### Envoi avec tenantId
+
+Passez `tenantId` lors de l'envoi d'un message pour le dimensionner à un tenant :
+
+```json
+{
+  "from": "tau",
+  "channel": "pi",
+  "content": "Acme catalog migration complete. PR #112 ready for review.",
+  "tenantId": "acme-corp"
+}
+```
+
+### Vérification avec tenantId
+
+Lors de la vérification des messages, passez `tenantId` pour recevoir uniquement les messages de ce tenant :
+
+```json
+{
+  "recipient": "pi",
+  "recipientInstanceId": "pi-main",
+  "tenantId": "acme-corp"
+}
+```
+
+### Rétrocompatibilité
+
+Lorsque `tenantId` est omis, tous les messages sont visibles indépendamment de leur portée de tenant. Cela préserve la rétrocompatibilité et sert de vue admin/globale. Les agents qui ne fonctionnent pas dans un contexte multi-tenant peuvent complètement ignorer `tenantId`.
+
+## Résumé de l'isolation
+
+| Table | Mécanisme d'isolation | Convention |
+|-------|---------------------|------------|
+| `memories` | Champ `namespace` | `workspace/{workspaceId}` |
+| `tasks` | Champ `project` | `studio/{workspaceId}` |
+| `missions` | Champ `project` | `studio/{workspaceId}` |
+| `messages` | Champ `tenantId` | Chaîne d'identifiant de tenant |
+| `messageReceipts` | Champ `tenantId` | Chaîne d'identifiant de tenant |
+
+## Exemple : Deux entreprises, un déploiement
+
+Acme Corp et Globex Corp partagent un seul déploiement Convex. Voici comment leurs données restent séparées :
+
+```
+Acme Corp agent (tau):
+  store_memory  → namespace: "workspace/acme-corp"
+  create_task   → project: "studio/acme-corp"
+  send_message  → tenantId: "acme-corp"
+  check_messages → tenantId: "acme-corp"
+
+Globex Corp agent (tau):
+  store_memory  → namespace: "workspace/globex-corp"
+  create_task   → project: "studio/globex-corp"
+  send_message  → tenantId: "globex-corp"
+  check_messages → tenantId: "globex-corp"
+
+Admin agent (pi, no tenantId):
+  recall         → namespace omitted → sees all memories
+  list_tasks     → project omitted → sees all tasks
+  check_messages → tenantId omitted → sees all messages
+```
+
+Les deux tenants utilisent les mêmes noms d'orchestrateur (`tau`, `pi`) et les mêmes tables Convex. Les conventions de namespace, project et tenantId assurent une isolation complète des données au niveau de la couche application.

--- a/content/docs/getting-started/deploy-keys.fr.mdx
+++ b/content/docs/getting-started/deploy-keys.fr.mdx
@@ -1,0 +1,91 @@
+---
+title: "Clés de déploiement"
+description: Authentification serveur-à-serveur pour les services externes accédant à votre déploiement VantagePeers.
+---
+
+# Clés de déploiement
+
+Les clés de déploiement permettent aux services externes d'appeler les fonctions Convex directement, sans passer par le serveur MCP. Utilisez-les pour les intégrations serveur-à-serveur telles que les pipelines CI/CD, les tâches cron, les webhooks et les tableaux de bord personnalisés.
+
+## Que sont les clés de déploiement ?
+
+Une clé de déploiement est une credential qui authentifie le code côté serveur contre votre déploiement Convex. Contrairement aux outils MCP (conçus pour les agents IA), les clés de déploiement permettent à tout service backend d'appeler `fetchQuery` et `fetchMutation` avec une sécurité de type complète via le package `vantage-peers-mcp`.
+
+## Générer une clé de déploiement
+
+1. Ouvrez le [tableau de bord Convex](https://dashboard.convex.dev)
+2. Sélectionnez votre déploiement VantagePeers
+3. Allez à **Settings > Deploy Keys**
+4. Cliquez sur **Generate Deploy Key**
+5. Copiez la clé immédiatement -- elle ne sera pas affichée à nouveau
+
+## Configuration des variables d'environnement
+
+Stockez la clé de déploiement comme une variable d'environnement. Ne la codez jamais en dur dans les fichiers source.
+
+```bash
+# Production
+CONVEX_DEPLOY_KEY=prod:your-deploy-key-here
+
+# Development (if using a separate dev deployment)
+CONVEX_DEPLOY_KEY=dev:your-dev-deploy-key-here
+```
+
+Pour les environnements hébergés, ajoutez-la via le gestionnaire de secrets de votre plateforme (Vercel Environment Variables, AWS Secrets Manager, GitHub Actions secrets, etc.).
+
+## Utilisation avec ConvexHttpClient
+
+Utilisez `ConvexHttpClient` du package `convex/browser` pour les appels génériques serveur-à-serveur :
+
+```typescript
+import { ConvexHttpClient } from "convex/browser";
+import { api } from "vantage-peers-mcp/api";
+
+const client = new ConvexHttpClient(process.env.CONVEX_URL!);
+
+// Query memories with full type safety
+const memories = await client.query(api.memories.listMemories, {
+  namespace: "global",
+  limit: 10,
+});
+
+// Send a message
+await client.mutation(api.messages.sendMessage, {
+  from: "studio",
+  channel: "sigma",
+  content: "Deployment complete",
+});
+```
+
+## Utilisation avec fetchQuery (Next.js)
+
+Pour les composants serveur Next.js et les gestionnaires de route, utilisez `fetchQuery` et `fetchMutation` de `convex/nextjs` :
+
+```typescript
+import { fetchQuery, fetchMutation } from "convex/nextjs";
+import { api } from "vantage-peers-mcp/api";
+
+// In a Server Component or Route Handler
+const tasks = await fetchQuery(
+  api.tasks.listTasks,
+  { status: "in_progress" },
+  { url: process.env.CONVEX_URL }
+);
+
+// Mutate from a server action
+await fetchMutation(
+  api.tasks.completeTask,
+  { taskId: "k17..." },
+  { url: process.env.CONVEX_URL }
+);
+```
+
+Les deux `fetchQuery` et `fetchMutation` lisent `CONVEX_DEPLOY_KEY` de l'environnement automatiquement lors de l'exécution côté serveur.
+
+## Meilleures pratiques de sécurité
+
+- **Ne commitez jamais les clés de déploiement dans git.** Ajoutez `CONVEX_DEPLOY_KEY` à vos fichiers `.gitignore` et `.env`, pas au code source.
+- **Utilisez des clés séparées pour dev et prod.** Générez des clés de déploiement distinctes pour chaque environnement afin que la révocation d'une ne n'affecte l'autre.
+- **Faites tourner les clés régulièrement.** Générez une nouvelle clé, mettez à jour votre environnement, vérifiez que la nouvelle clé fonctionne, puis révoquez l'ancienne.
+- **Limitez l'accès.** Donnez les clés de déploiement uniquement aux services qui ont besoin d'un accès Convex direct. Pour les agents IA, utilisez le serveur MCP à la place.
+- **Auditez l'utilisation.** Surveillez les journaux du tableau de bord Convex pour vérifier que le trafic des clés de déploiement correspond aux patterns attendus.


### PR DESCRIPTION
## Summary

Closes P0-C3 from the SEO/GEO audit — two doc pages were missing their `.fr.mdx` counterparts, breaking locale parity in the docs tree.

## Files added

| EN Source | FR Target |
|-----------|-----------|
| `content/docs/getting-started/deploy-keys.mdx` | `content/docs/getting-started/deploy-keys.fr.mdx` |
| `content/docs/core-concepts/multi-tenancy.mdx` | `content/docs/core-concepts/multi-tenancy.fr.mdx` |

## Translation policy

- Body text + headings + descriptions + table cells translated.
- Code blocks preserved byte-for-byte (TypeScript / JSON / Bash examples).
- All internal link paths preserved (fumadocs i18n handles locale switching).
- Frontmatter: `title` + `description` translated; everything else unchanged.
- Technical identifiers kept as-is: `Convex`, `MCP`, `ConvexHttpClient`, `fetchQuery`, `fetchMutation`, `vantage-peers-mcp`, `namespace`, `workspace`, `studio`, `tenantId`, `BEARER_SECRET_MASTER`.
- French typography applied (spaces before colons/semicolons, proper quotes).

## Test plan

- [ ] `npm run build` passes (fumadocs detects the new locale variants)
- [ ] `/fr/docs/getting-started/deploy-keys` returns 200 after deploy
- [ ] `/fr/docs/core-concepts/multi-tenancy` returns 200 after deploy

Refs Sigma T2 task `k170hrgehx43kh28mxndehq859873ytv`.

Brief template: agent-brief-template.md (Sigma orchestration)

Orchestrator: Sigma — VantageOS Team | 2026-05-20
