### PR TITLE
fix(docs): close #110 + #111 — verify Quick Links targets, add regression tests

### DIFF
--- a/e2e/docs-links.spec.ts
+++ b/e2e/docs-links.spec.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "@playwright/test";
+
+// Regression tests for issues #110 and #111.
+// The docs landing Quick Links table must resolve to valid pages.
+// /docs/quickstart and /docs/architecture are NOT valid routes;
+// the correct targets are /docs/getting-started/quickstart and
+// /docs/core-concepts/architecture respectively.
+test.describe("docs Quick Links — no 404 regressions (#110, #111)", () => {
+	// Quickstart: must resolve to 200 (issue #110)
+	test("GET /docs/getting-started/quickstart returns 200", async ({
+		request,
+	}) => {
+		const response = await request.get("/docs/getting-started/quickstart");
+		expect(response.status()).toBe(200);
+	});
+
+	// Architecture: must resolve to 200 (issue #111)
+	test("GET /docs/core-concepts/architecture returns 200", async ({
+		request,
+	}) => {
+		const response = await request.get("/docs/core-concepts/architecture");
+		expect(response.status()).toBe(200);
+	});
+
+	// Verify docs landing links go to the correct sub-paths (not /docs/quickstart)
+	test("docs landing Quick Links point to correct sub-paths", async ({
+		page,
+	}) => {
+		await page.goto("/docs", { waitUntil: "domcontentloaded" });
+		const quickstartLink = page.locator(
+			'a[href*="getting-started/quickstart"]',
+		);
+		await expect(quickstartLink).toBeVisible();
+		const archLink = page.locator('a[href*="core-concepts/architecture"]');
+		await expect(archLink).toBeVisible();
+	});
+
+	// FR locale: same links must be present under /docs/fr
+	test("docs FR landing Quick Links point to correct sub-paths", async ({
+		page,
+	}) => {
+		await page.goto("/docs/fr", { waitUntil: "domcontentloaded" });
+		const quickstartLink = page.locator(
+			'a[href*="getting-started/quickstart"]',
+		);
+		await expect(quickstartLink).toBeVisible();
+		const archLink = page.locator('a[href*="core-concepts/architecture"]');
+		await expect(archLink).toBeVisible();
+	});
+});


### PR DESCRIPTION
## Summary

- **Root cause investigation**: Issues #110 and #111 reported `/docs/quickstart` and `/docs/architecture` returning 404. Full audit of `content/`, `components/`, and `app/` confirms these paths never existed as link targets in the source — the docs landing Quick Links table (`content/docs/index.mdx` + `content/docs/index.fr.mdx`) has always pointed to the correct sub-paths.
- **Grep proof — zero occurrences of broken paths** (run on `main` at commit `3afae01`):
  - `grep -rn 'docs/quickstart[^/.]' content/ components/ app/` → 0 results
  - `grep -rn 'docs/architecture[^/.]' content/ components/ app/` → 0 results
- **Correct links confirmed in source** (EN + FR):
  - `[Quickstart](/docs/getting-started/quickstart)` — HTTP 200 on prod
  - `[Architecture](/docs/core-concepts/architecture)` — HTTP 200 on prod
- **Regression suite added** (`e2e/docs-links.spec.ts`, 4 tests): validates both target URLs return 200 and that the docs landing links (EN + FR) reference the correct sub-paths. Catches any future link drift before deploy.

## Prod verification

```
curl -I https://www.vantagepeers.com/docs/getting-started/quickstart  → HTTP 200
curl -I https://www.vantagepeers.com/docs/core-concepts/architecture  → HTTP 200
```

## Test plan

- [ ] `e2e/docs-links.spec.ts` — 4 Playwright tests pass against prod (baseURL: https://www.vantagepeers.com)
- [ ] `npx @biomejs/biome check e2e/docs-links.spec.ts` — 0 errors
- [ ] `npx tsc --noEmit` — 0 errors in modified files

Closes #110
Closes #111

Orchestrator: Sigma — VantageOS Team | 2026-05-21
