### PR TITLE
docs(v2.3.1): fields=lite + status array/aliases on list tools + changelog — Orchestrator: Sigma — VantageOS Team | 2026-05-26

### DIFF
--- a/content/docs/changelog.fr.mdx
+++ b/content/docs/changelog.fr.mdx
@@ -1,0 +1,29 @@
+---
+title: Journal des modifications
+description: Historique des versions de vantage-peers-mcp.
+---
+
+# Journal des modifications
+
+## v2.3.1 — 2026-05-26
+
+### Ajouté
+
+- `list_tasks`, `list_missions`, `list_tasks_by_mission` et `list_briefing_notes` acceptent un paramètre `fields` (`"lite"` ou `"full"`, défaut `"full"`). Lite renvoie une projection compacte.
+- Le filtre `status` sur `list_tasks`, `list_missions` et `list_tasks_by_mission` accepte désormais des tableaux et des alias nommés :
+  - Tâches : `"open"` → todo+in_progress+review+blocked, `"active"` → todo+in_progress, `"all"` → aucun filtre
+  - Missions : `"open"` → brainstorm+plan+execute+validate (exclut complete), `"active"` → plan+execute, `"all"` → aucun filtre
+
+### Rétrocompatibilité
+
+- Le `status` chaîne unique reste inchangé.
+- Omettre `fields` revient à `"full"` — les appelants existants ne sont pas affectés.
+
+### Dépréciation
+
+- **`vantage-peers-mcp@2.3.0` est déprécié.** v2.3.0 a livré deux blockers détectés en delta-review : `status="all"` était annoncé mais rejeté par le backend, et `setPendingAliasReleases` était exposé en mutation publique. Passez à `>=2.3.1`.
+
+### Liens
+
+- Release GitHub : [v2.3.1](https://github.com/vantageos-agency/vantage-peers/releases/tag/v2.3.1)
+- npm : [vantage-peers-mcp@2.3.1](https://www.npmjs.com/package/vantage-peers-mcp)

--- a/content/docs/changelog.mdx
+++ b/content/docs/changelog.mdx
@@ -1,0 +1,29 @@
+---
+title: Changelog
+description: Release history for vantage-peers-mcp.
+---
+
+# Changelog
+
+## v2.3.1 — 2026-05-26
+
+### Added
+
+- `list_tasks`, `list_missions`, `list_tasks_by_mission`, and `list_briefing_notes` accept a `fields` parameter (`"lite"` or `"full"`, default `"full"`). Lite returns a compact projection.
+- `status` filter on `list_tasks`, `list_missions`, and `list_tasks_by_mission` now accepts arrays and named aliases:
+  - Tasks: `"open"` → todo+in_progress+review+blocked, `"active"` → todo+in_progress, `"all"` → no filter
+  - Missions: `"open"` → brainstorm+plan+execute+validate (excludes complete), `"active"` → plan+execute, `"all"` → no filter
+
+### Backward compatibility
+
+- Single-string `status` is unchanged.
+- Omitting `fields` defaults to `"full"` — existing callers are unaffected.
+
+### Deprecation
+
+- **`vantage-peers-mcp@2.3.0` is deprecated.** v2.3.0 shipped with two blockers caught in delta-review: `status="all"` was advertised but rejected by the backend, and `setPendingAliasReleases` was exposed as a public mutation. Upgrade to `>=2.3.1`.
+
+### Links
+
+- GitHub release: [v2.3.1](https://github.com/vantageos-agency/vantage-peers/releases/tag/v2.3.1)
+- npm: [vantage-peers-mcp@2.3.1](https://www.npmjs.com/package/vantage-peers-mcp)

--- a/content/docs/meta.fr.json
+++ b/content/docs/meta.fr.json
@@ -7,6 +7,7 @@
     "capabilities",
     "infrastructure",
     "---Référence---",
-    "tools"
+    "tools",
+    "changelog"
   ]
 }

--- a/content/docs/meta.json
+++ b/content/docs/meta.json
@@ -7,6 +7,7 @@
     "capabilities",
     "infrastructure",
     "---Reference---",
-    "tools"
+    "tools",
+    "changelog"
   ]
 }

--- a/content/docs/tools.fr.mdx
+++ b/content/docs/tools.fr.mdx
@@ -252,6 +252,23 @@ Les tâches suivent le travail de la création à la complétion avec piste d'au
 }
 ```
 
+**v2.3.1 — `fields` + `status` tableaux/alias.**
+
+`status` accepte :
+- une valeur unique (correspondance exacte)
+- un tableau : `["todo", "in_progress"]`
+- un alias : `"open"` → todo+in_progress+review+blocked, `"active"` → todo+in_progress, `"all"` → aucun filtre
+
+`fields=lite` renvoie une projection compacte (`_id`, `_creationTime`, `title`, `status`, `priority`, `assignedTo`, `missionId`). Omettre ou passer `"full"` pour le payload par défaut inchangé.
+
+```json
+{
+  "assignedTo": "alice",
+  "status": "active",
+  "fields": "lite"
+}
+```
+
 ### `list_tasks_by_mission`
 
 Lister toutes les tâches liées à une mission spécifique.
@@ -259,6 +276,16 @@ Lister toutes les tâches liées à une mission spécifique.
 ```json
 {
   "missionId": "mission-abc123"
+}
+```
+
+**v2.3.1** — accepte les mêmes `status` tableaux/alias (`"open"`, `"active"`, `"all"`) et `fields=lite|full` que `list_tasks`, limité à la mission donnée.
+
+```json
+{
+  "missionId": "mission-abc123",
+  "status": "active",
+  "fields": "lite"
 }
 ```
 
@@ -337,6 +364,22 @@ Les missions regroupent les tâches liées et suivent la progression.
 ```json
 {
   "pilot": "alice"
+}
+```
+
+**v2.3.1 — `fields` + `status` tableaux/alias.**
+
+`status` accepte une valeur unique, un tableau (`["plan", "execute"]`), ou un alias spécifique aux missions :
+- `"open"` → brainstorm+plan+execute+validate (exclut `complete`)
+- `"active"` → plan+execute
+- `"all"` → aucun filtre
+
+`fields=lite` renvoie uniquement `_id`, `_creationTime`, `name`, `status`, `pilot`, `priority`, `project`.
+
+```json
+{
+  "status": "active",
+  "fields": "lite"
 }
 ```
 
@@ -446,6 +489,15 @@ Créer ou mettre à jour un profil d'orchestrateur (mises à jour partielles sup
 
 ```json
 {
+  "limit": 10
+}
+```
+
+**v2.3.1** — accepte `fields=lite|full`. Lite renvoie `_id`, `_creationTime`, `topic`, `title`, `participants`, `createdBy`. Les notes de briefing n'ont pas de cycle de vie de statut, donc aucun alias `status` ne s'applique.
+
+```json
+{
+  "fields": "lite",
   "limit": 10
 }
 ```

--- a/content/docs/tools.mdx
+++ b/content/docs/tools.mdx
@@ -288,6 +288,23 @@ Lists tasks filtered by assignee and/or status.
 }
 ```
 
+**v2.3.1 — `fields` + `status` array/aliases.**
+
+`status` accepts:
+- a single value (exact match)
+- an array: `["todo", "in_progress"]`
+- an alias: `"open"` → todo+in_progress+review+blocked, `"active"` → todo+in_progress, `"all"` → no filter
+
+`fields=lite` returns a compact projection (`_id`, `_creationTime`, `title`, `status`, `priority`, `assignedTo`, `missionId`). Omit or pass `"full"` for the unchanged default payload.
+
+```json
+{
+  "assignedTo": "alice",
+  "status": "active",
+  "fields": "lite"
+}
+```
+
 ### `update_task`
 
 Updates task fields — status, priority, blockers, or completion note.
@@ -375,6 +392,16 @@ List all tasks linked to a specific mission.
 }
 ```
 
+**v2.3.1** — accepts the same `status` array/aliases (`"open"`, `"active"`, `"all"`) and `fields=lite|full` projection as `list_tasks`, scoped to the given mission.
+
+```json
+{
+  "missionId": "mission-abc123",
+  "status": "active",
+  "fields": "lite"
+}
+```
+
 ---
 
 ## Mission Tools
@@ -409,6 +436,22 @@ Lists all missions, optionally filtered by status or pilot.
 ```
 
 Status values: `brainstorm`, `plan`, `execute`, `validate`, `complete`.
+
+**v2.3.1 — `fields` + `status` array/aliases.**
+
+`status` accepts a single value, an array (`["plan", "execute"]`), or a mission-specific alias:
+- `"open"` → brainstorm+plan+execute+validate (excludes `complete`)
+- `"active"` → plan+execute
+- `"all"` → no filter
+
+`fields=lite` returns `_id`, `_creationTime`, `name`, `status`, `pilot`, `priority`, `project` only.
+
+```json
+{
+  "status": "active",
+  "fields": "lite"
+}
+```
 
 ### `update_mission`
 
@@ -550,6 +593,15 @@ Lists briefings, optionally filtered by participant.
 ```json
 {
   "participant": "alice"
+}
+```
+
+**v2.3.1** — accepts `fields=lite|full`. Lite returns `_id`, `_creationTime`, `topic`, `title`, `participants`, `createdBy`. Briefing notes have no status lifecycle, so no status aliases apply.
+
+```json
+{
+  "participant": "alice",
+  "fields": "lite"
 }
 ```
 


### PR DESCRIPTION
## Summary
Updates `tools.mdx` + `tools.fr.mdx` with v2.3.1 additions to the 4 list_* sections (fields=lite|full + status array/aliases). Adds `changelog.mdx` + FR + meta.json updates.

Orchestrator: Sigma — VantageOS Team | 2026-05-26

## Verification
- Build PASS (bun run build, .next/BUILD_ID present)
- 6 files changed (4 mdx + 2 json)
- Each file verifiable via `gh api repos/vantageos-agency/vantage-peers-site/contents/<path>?ref=feat/v2.3.1-fields-lite-status-multi`

## Cross-refs
- VP repo PR #530 (merged squash 36b469c)
- npm v2.3.1 published (v2.3.0 deprecated)
- GH release: https://github.com/vantageos-agency/vantage-peers/releases/tag/v2.3.1
