### PR TITLE
docs(doctrines): add Ship 24/7 doctrine page EN+FR

### DIFF
--- a/content/docs/changelog.fr.mdx
+++ b/content/docs/changelog.fr.mdx
@@ -1,0 +1,29 @@
+---
+title: Journal des modifications
+description: Historique des versions de vantage-peers-mcp.
+---
+
+# Journal des modifications
+
+## v2.3.1 — 2026-05-26
+
+### Ajouté
+
+- `list_tasks`, `list_missions`, `list_tasks_by_mission` et `list_briefing_notes` acceptent un paramètre `fields` (`"lite"` ou `"full"`, défaut `"full"`). Lite renvoie une projection compacte.
+- Le filtre `status` sur `list_tasks`, `list_missions` et `list_tasks_by_mission` accepte désormais des tableaux et des alias nommés :
+  - Tâches : `"open"` → todo+in_progress+review+blocked, `"active"` → todo+in_progress, `"all"` → aucun filtre
+  - Missions : `"open"` → brainstorm+plan+execute+validate (exclut complete), `"active"` → plan+execute, `"all"` → aucun filtre
+
+### Rétrocompatibilité
+
+- Le `status` chaîne unique reste inchangé.
+- Omettre `fields` revient à `"full"` — les appelants existants ne sont pas affectés.
+
+### Dépréciation
+
+- **`vantage-peers-mcp@2.3.0` est déprécié.** v2.3.0 a livré deux blockers détectés en delta-review : `status="all"` était annoncé mais rejeté par le backend, et `setPendingAliasReleases` était exposé en mutation publique. Passez à `>=2.3.1`.
+
+### Liens
+
+- Release GitHub : [v2.3.1](https://github.com/vantageos-agency/vantage-peers/releases/tag/v2.3.1)
+- npm : [vantage-peers-mcp@2.3.1](https://www.npmjs.com/package/vantage-peers-mcp)

--- a/content/docs/changelog.mdx
+++ b/content/docs/changelog.mdx
@@ -1,0 +1,29 @@
+---
+title: Changelog
+description: Release history for vantage-peers-mcp.
+---
+
+# Changelog
+
+## v2.3.1 — 2026-05-26
+
+### Added
+
+- `list_tasks`, `list_missions`, `list_tasks_by_mission`, and `list_briefing_notes` accept a `fields` parameter (`"lite"` or `"full"`, default `"full"`). Lite returns a compact projection.
+- `status` filter on `list_tasks`, `list_missions`, and `list_tasks_by_mission` now accepts arrays and named aliases:
+  - Tasks: `"open"` → todo+in_progress+review+blocked, `"active"` → todo+in_progress, `"all"` → no filter
+  - Missions: `"open"` → brainstorm+plan+execute+validate (excludes complete), `"active"` → plan+execute, `"all"` → no filter
+
+### Backward compatibility
+
+- Single-string `status` is unchanged.
+- Omitting `fields` defaults to `"full"` — existing callers are unaffected.
+
+### Deprecation
+
+- **`vantage-peers-mcp@2.3.0` is deprecated.** v2.3.0 shipped with two blockers caught in delta-review: `status="all"` was advertised but rejected by the backend, and `setPendingAliasReleases` was exposed as a public mutation. Upgrade to `>=2.3.1`.
+
+### Links
+
+- GitHub release: [v2.3.1](https://github.com/vantageos-agency/vantage-peers/releases/tag/v2.3.1)
+- npm: [vantage-peers-mcp@2.3.1](https://www.npmjs.com/package/vantage-peers-mcp)

--- a/content/docs/core-concepts/meta.fr.json
+++ b/content/docs/core-concepts/meta.fr.json
@@ -1,5 +1,8 @@
 {
   "title": "Concepts clés",
   "defaultOpen": true,
-  "pages": ["architecture"]
+  "pages": [
+    "architecture",
+    "ship-24-7"
+  ]
 }

--- a/content/docs/core-concepts/meta.json
+++ b/content/docs/core-concepts/meta.json
@@ -1,5 +1,9 @@
 {
   "title": "Core Concepts",
   "defaultOpen": true,
-  "pages": ["architecture", "multi-tenancy"]
+  "pages": [
+    "architecture",
+    "multi-tenancy",
+    "ship-24-7"
+  ]
 }

--- a/content/docs/core-concepts/ship-24-7.fr.mdx
+++ b/content/docs/core-concepts/ship-24-7.fr.mdx
@@ -1,0 +1,78 @@
+---
+title: Doctrine Ship 24/7
+description: Une doctrine de workflow flotte — ne jamais différer un ship prêt sur base temporelle. Pair offline ≠ raison d'attendre. Re-router l'exécution à la place.
+---
+
+# Doctrine Ship 24/7
+
+Un principe de workflow flotte adopté au Day 83 du build VantageOS (2026-05-27).
+
+## Énoncé
+
+**Ne jamais différer un ship prêt sur base temporelle.** Heure de la journée, jour de la semaine, weekend, "tard le soir", "pair signed off", "cron coupé", "prochaine session" ne sont PAS des raisons valides pour différer un merge / deploy / publish.
+
+Si une PR est mergeable et reviewed APPROVED → on merge maintenant. Si un deploy est authorized → on deploy maintenant. Si un fix est ready → on ship maintenant.
+
+## Pourquoi
+
+Une flotte qui tourne en asynchrone sur plusieurs orchestrateurs peut dériver vers des patterns "j'attends que le pair revienne en ligne". Cette dérive s'aggrave :
+
+- Momentum perdu : le contexte nécessaire pour shipper est le plus frais au moment de l'approbation. Quelques heures plus tard, recharger ce contexte coûte une taxe cognitive.
+- Risque pipeline : une PR open et mergeable qui dort la nuit est à un merge conflict, un changement upstream ou un CI break d'avoir à être refaite.
+- Asymétrie : différer est rarement réversible sans coût ; shipper est réversible (un revert est une ligne).
+
+## Re-router, pas différer
+
+Si l'orchestrateur prévu pour exécuter est offline, on re-route l'exécution. Options :
+
+1. **Pi (ou tout orchestrateur actif) exécute directement** depuis son workspace avec les override tokens canoniques.
+2. **Auto-task system + autorisation Pi pré-créée** pour pickup par l'orchestrateur cible à son prochain démarrage de session.
+3. **Dispatch subagent background** si le travail est borné et l'outillage canonique disponible.
+
+L'absence d'un pair n'est pas une raison d'attendre. C'est une raison de choisir un autre chemin d'exécution.
+
+## Ce qui compte comme un defer légitime
+
+Une seule catégorie de defer légitime : **contrainte client**.
+
+- Attente d'une confirmation client (ex. "post-RDV Marie", "après confirmation Anthony repo source").
+- Lié à un livrable externe (ex. "après collecte signature Yousign").
+- Coordonné avec une fenêtre de revue humaine (ex. "après ack visuel Laurent").
+
+Ces defer-là attendent une input externe manquante, pas une fatigue flotte.
+
+## Enforcement
+
+Chaque workspace de la flotte tourne un hook PreToolUse qui scanne le contenu des appels VantagePeers (`send_message`, `create_task`, `update_task`, `complete_task`) à la recherche de langage temporal-defer.
+
+Phrases bannies (extraits) :
+
+- "defer to tomorrow / next session / weekend / lundi-dimanche"
+- "tard le soir → defer", "fin de journée → defer"
+- "sigma signed off → defer", "pair offline → defer"
+- "overnight risk → defer", "divergence main/prod → defer"
+- "wait until weekend / next session / next morning"
+- "ship tomorrow / tonight / this evening / next week"
+
+Autorisé (marqueurs contrainte client) :
+
+- "RDV Marie ce soir", "post-RDV client"
+- "awaiting Marie confirm repo", "attente confirmation Anthony"
+
+Opt-out (urgence rare seulement) : `# allow-temporal-defer: <raison>` dans le contenu. À utiliser avec parcimonie — le défaut est ship maintenant.
+
+## Pour les utilisateurs self-host VantagePeers
+
+Cette doctrine est opt-in. Si vous self-hostez VantagePeers et que votre équipe adopte une cadence de ship 24/7 similaire (ou veut l'adopter), vous pouvez installer le hook canonique dans votre workspace Claude Code :
+
+1. Téléchargez `enforce-ship-24-7.py` depuis la référence hooks flotte VantageOS (voir section Tools).
+2. Placez-le dans `.claude/hooks/enforce-ship-24-7.py` et `chmod +x`.
+3. Enregistrez-le dans `.claude/settings.json` sous les matchers PreToolUse pour les quatre appels VantagePeers.
+4. Testez avec une phrase bannie : `echo '{"tool_name":"mcp__vantage-peers__send_message","tool_input":{"content":"defer to tomorrow"}}' | python3 .claude/hooks/enforce-ship-24-7.py` doit exit 2.
+
+Le hook est fail-open : toute exception interne passe sans bloquer. Il ne cassera jamais votre workflow.
+
+## Liens
+
+- [Fix Patterns](/docs/capabilities/fix-patterns) — capitaliser les patterns flotte récurrents.
+- [Tasks](/docs/capabilities/tasks) — l'unité de travail flotte que cette doctrine régit.

--- a/content/docs/core-concepts/ship-24-7.mdx
+++ b/content/docs/core-concepts/ship-24-7.mdx
@@ -1,0 +1,78 @@
+---
+title: Ship 24/7 doctrine
+description: A fleet workflow doctrine — never defer a ready ship on temporal grounds. Pair offline ≠ reason to wait. Re-route execution instead.
+---
+
+# Ship 24/7 doctrine
+
+A fleet workflow principle adopted on Day 83 of the VantageOS build (2026-05-27).
+
+## Statement
+
+**Never defer a ready ship on temporal grounds.** Time of day, day of week, weekend, "late evening", "pair signed off", "cron cancelled", "next session" are NOT valid reasons to defer a merge / deploy / publish.
+
+If a PR is mergeable and reviewed APPROVED → merge now. If a deploy is authorized → deploy now. If a fix is ready → ship now.
+
+## Why
+
+A fleet running asynchronously across orchestrators can drift into "wait for the pair to come back online" patterns. That drift compounds:
+
+- Momentum lost: the context required to ship is freshest at the moment of approval. Hours later, re-loading that context is a tax.
+- Pipeline risk: an open mergeable PR sitting overnight is one merge conflict, one upstream change, or one CI break away from re-work.
+- Asymmetry: deferring is rarely reversible without cost; shipping is reversible (revert is a one-liner).
+
+## Re-route, don't defer
+
+If the orchestrator scheduled to execute is offline, re-route the execution. Options:
+
+1. **Pi (or any active orchestrator) executes directly** from their workspace using the canonical override tokens.
+2. **Auto-task system + pre-created Pi authorization** for pickup by the target orchestrator at their next session start.
+3. **Background subagent dispatch** if the work is bounded and the canonical tooling is available.
+
+The absence of a pair is not a reason to wait. It is a reason to choose a different execution path.
+
+## What counts as a legitimate defer
+
+There is one and only one category of legitimate defer: **client-constraint**.
+
+- Awaiting client confirmation (e.g. "post-RDV Marie", "after Anthony confirms repo source").
+- Bound to an external deliverable (e.g. "after the Yousign signature is collected").
+- Coordinated with a human review window (e.g. "after Laurent visual ack").
+
+These defer the work because the external input is missing, not because the fleet is tired.
+
+## Enforcement
+
+Each workspace in the fleet runs a PreToolUse hook that scans the content of VantagePeers tool calls (`send_message`, `create_task`, `update_task`, `complete_task`) for temporal-defer language.
+
+Banned phrases include:
+
+- "defer to tomorrow / next session / weekend / monday-sunday"
+- "tard le soir → defer", "fin de journée → defer"
+- "sigma signed off → defer", "pair offline → defer"
+- "overnight risk → defer", "divergence main/prod → defer"
+- "wait until weekend / next session / next morning"
+- "ship tomorrow / tonight / this evening / next week"
+
+Allowed (client-constraint markers):
+
+- "RDV Marie ce soir", "post-RDV client"
+- "awaiting Marie confirm repo", "attente confirmation Anthony"
+
+Opt-out (rare emergencies only): `# allow-temporal-defer: <reason>` in the content. Use sparingly — the default is ship now.
+
+## For self-hosted VantagePeers users
+
+This doctrine is opt-in. If you self-host VantagePeers and your team adopts a similar 24/7 ship cadence (or wants to), you can install the canonical hook in your Claude Code workspace:
+
+1. Download `enforce-ship-24-7.py` from the VantageOS fleet hooks reference (see Tools section).
+2. Place it in `.claude/hooks/enforce-ship-24-7.py` and `chmod +x`.
+3. Register it in `.claude/settings.json` under PreToolUse matchers for the four VantagePeers tool calls.
+4. Test with a banned phrase: `echo '{"tool_name":"mcp__vantage-peers__send_message","tool_input":{"content":"defer to tomorrow"}}' | python3 .claude/hooks/enforce-ship-24-7.py` should exit 2.
+
+The hook is fail-open: any internal exception passes through without blocking. It will never break your workflow.
+
+## Related
+
+- [Fix Patterns](/docs/capabilities/fix-patterns) — capitalizing recurring fleet patterns.
+- [Tasks](/docs/capabilities/tasks) — the unit of fleet work this doctrine governs.

--- a/content/docs/meta.fr.json
+++ b/content/docs/meta.fr.json
@@ -7,6 +7,7 @@
     "capabilities",
     "infrastructure",
     "---Référence---",
-    "tools"
+    "tools",
+    "changelog"
   ]
 }

--- a/content/docs/meta.json
+++ b/content/docs/meta.json
@@ -7,6 +7,7 @@
     "capabilities",
     "infrastructure",
     "---Reference---",
-    "tools"
+    "tools",
+    "changelog"
   ]
 }

--- a/content/docs/tools.fr.mdx
+++ b/content/docs/tools.fr.mdx
@@ -252,6 +252,23 @@ Les tâches suivent le travail de la création à la complétion avec piste d'au
 }
 ```
 
+**v2.3.1 — `fields` + `status` tableaux/alias.**
+
+`status` accepte :
+- une valeur unique (correspondance exacte)
+- un tableau : `["todo", "in_progress"]`
+- un alias : `"open"` → todo+in_progress+review+blocked, `"active"` → todo+in_progress, `"all"` → aucun filtre
+
+`fields=lite` renvoie une projection compacte (`_id`, `_creationTime`, `title`, `status`, `priority`, `assignedTo`, `missionId`). Omettre ou passer `"full"` pour le payload par défaut inchangé.
+
+```json
+{
+  "assignedTo": "alice",
+  "status": "active",
+  "fields": "lite"
+}
+```
+
 ### `list_tasks_by_mission`
 
 Lister toutes les tâches liées à une mission spécifique.
@@ -259,6 +276,16 @@ Lister toutes les tâches liées à une mission spécifique.
 ```json
 {
   "missionId": "mission-abc123"
+}
+```
+
+**v2.3.1** — accepte les mêmes `status` tableaux/alias (`"open"`, `"active"`, `"all"`) et `fields=lite|full` que `list_tasks`, limité à la mission donnée.
+
+```json
+{
+  "missionId": "mission-abc123",
+  "status": "active",
+  "fields": "lite"
 }
 ```
 
@@ -337,6 +364,22 @@ Les missions regroupent les tâches liées et suivent la progression.
 ```json
 {
   "pilot": "alice"
+}
+```
+
+**v2.3.1 — `fields` + `status` tableaux/alias.**
+
+`status` accepte une valeur unique, un tableau (`["plan", "execute"]`), ou un alias spécifique aux missions :
+- `"open"` → brainstorm+plan+execute+validate (exclut `complete`)
+- `"active"` → plan+execute
+- `"all"` → aucun filtre
+
+`fields=lite` renvoie uniquement `_id`, `_creationTime`, `name`, `status`, `pilot`, `priority`, `project`.
+
+```json
+{
+  "status": "active",
+  "fields": "lite"
 }
 ```
 
@@ -446,6 +489,15 @@ Créer ou mettre à jour un profil d'orchestrateur (mises à jour partielles sup
 
 ```json
 {
+  "limit": 10
+}
+```
+
+**v2.3.1** — accepte `fields=lite|full`. Lite renvoie `_id`, `_creationTime`, `topic`, `title`, `participants`, `createdBy`. Les notes de briefing n'ont pas de cycle de vie de statut, donc aucun alias `status` ne s'applique.
+
+```json
+{
+  "fields": "lite",
   "limit": 10
 }
 ```

--- a/content/docs/tools.mdx
+++ b/content/docs/tools.mdx
@@ -288,6 +288,23 @@ Lists tasks filtered by assignee and/or status.
 }
 ```
 
+**v2.3.1 — `fields` + `status` array/aliases.**
+
+`status` accepts:
+- a single value (exact match)
+- an array: `["todo", "in_progress"]`
+- an alias: `"open"` → todo+in_progress+review+blocked, `"active"` → todo+in_progress, `"all"` → no filter
+
+`fields=lite` returns a compact projection (`_id`, `_creationTime`, `title`, `status`, `priority`, `assignedTo`, `missionId`). Omit or pass `"full"` for the unchanged default payload.
+
+```json
+{
+  "assignedTo": "alice",
+  "status": "active",
+  "fields": "lite"
+}
+```
+
 ### `update_task`
 
 Updates task fields — status, priority, blockers, or completion note.
@@ -375,6 +392,16 @@ List all tasks linked to a specific mission.
 }
 ```
 
+**v2.3.1** — accepts the same `status` array/aliases (`"open"`, `"active"`, `"all"`) and `fields=lite|full` projection as `list_tasks`, scoped to the given mission.
+
+```json
+{
+  "missionId": "mission-abc123",
+  "status": "active",
+  "fields": "lite"
+}
+```
+
 ---
 
 ## Mission Tools
@@ -409,6 +436,22 @@ Lists all missions, optionally filtered by status or pilot.
 ```
 
 Status values: `brainstorm`, `plan`, `execute`, `validate`, `complete`.
+
+**v2.3.1 — `fields` + `status` array/aliases.**
+
+`status` accepts a single value, an array (`["plan", "execute"]`), or a mission-specific alias:
+- `"open"` → brainstorm+plan+execute+validate (excludes `complete`)
+- `"active"` → plan+execute
+- `"all"` → no filter
+
+`fields=lite` returns `_id`, `_creationTime`, `name`, `status`, `pilot`, `priority`, `project` only.
+
+```json
+{
+  "status": "active",
+  "fields": "lite"
+}
+```
 
 ### `update_mission`
 
@@ -550,6 +593,15 @@ Lists briefings, optionally filtered by participant.
 ```json
 {
   "participant": "alice"
+}
+```
+
+**v2.3.1** — accepts `fields=lite|full`. Lite returns `_id`, `_creationTime`, `topic`, `title`, `participants`, `createdBy`. Briefing notes have no status lifecycle, so no status aliases apply.
+
+```json
+{
+  "participant": "alice",
+  "fields": "lite"
 }
 ```
 


### PR DESCRIPTION
Fleet workflow principle adopted Day 83 (2026-05-27): never defer ready ships on temporal grounds. Pair offline = re-route execution, not defer. Allowed defer = client-constraint only.

## Adds

- `core-concepts/ship-24-7.mdx` (EN) — full doctrine + enforcement reference
- `core-concepts/ship-24-7.fr.mdx` (FR)
- Updates `meta.json` + `meta.fr.json` nav (adds ship-24-7 to Core Concepts)

## Why

Day 83 trigger : Pi deferred PR #535 with temporal justification (late evening interpretation wrong + temporal reasoning banned even when accurate). Laurent feedback explicit: "jour, nuit, weekend, ça ne doit pas exister pour toi et les orchestrateurs. ON ship 24/7 s'il le faut!"

Fleet enforcement live on 39 workspaces (hook v1.0.1 SHA 1c7f3b01). VR canonical id j97fwx1vh0f789azjz6jrqd3yx87gyh2.

Memory: j57bkwc99fnwp348m52d9rw5p987ggq6 (global feedback fleet-wide).
Related fix_pattern: m977jtqj0a90vqgvec75f725yd87hmy9 (VR upsert content null + JSON SHA drift).

## For self-host VP users

Page includes opt-in hook install instructions. Hook is fail-open, never blocks workflow internally.

Orchestrator: Pi — VantageOS Team | 2026-05-27