### PR TITLE
feat(docs): Paradigm B + troubleshooting + CLI + root nav scaffold EN/FR

### DIFF
--- a/content/docs/auth/meta.fr.json
+++ b/content/docs/auth/meta.fr.json
@@ -1,0 +1,4 @@
+{
+  "title": "Authentification",
+  "pages": []
+}

--- a/content/docs/auth/meta.json
+++ b/content/docs/auth/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Auth",
+  "pages": []
+}

--- a/content/docs/cli/index.fr.mdx
+++ b/content/docs/cli/index.fr.mdx
@@ -1,0 +1,163 @@
+---
+title: Référence CLI
+description: Comment lancer le serveur vantage-peers-mcp — transport stdio pour Claude Code, transport HTTP pour Railway/Claude.ai, et toute la configuration par variables d'environnement.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout'
+import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
+import { Step, Steps } from 'fumadocs-ui/components/steps'
+
+# Référence CLI
+
+`vantage-peers-mcp` inclut deux points d'entrée serveur. Les deux sont configurés entièrement par variables d'environnement — il n'y a pas de flags CLI. Choisissez selon votre transport :
+
+| Point d'entrée | Transport | Cas d'usage |
+|---|---|---|
+| `dist/server.js` | stdio | Agents Claude Code (local) |
+| `dist/server-http.js` | HTTP Streamable | Déploiement Railway, connecteur Claude.ai, clients distants |
+
+---
+
+## Transport stdio (Claude Code)
+
+Le serveur stdio lit depuis stdin et écrit sur stdout en suivant le protocole de transport MCP stdio. Il est conçu pour être lancé par Claude Code en tant que processus enfant.
+
+### Lancer directement
+
+```bash
+CONVEX_URL=https://votre-deploiement.convex.cloud node dist/server.js
+```
+
+Ou avec `bun` en développement :
+
+```bash
+CONVEX_URL=https://votre-deploiement.convex.cloud bun run server.ts
+```
+
+### Configuration Claude Code
+
+Ajoutez à votre `claude_desktop_config.json` (macOS : `~/Library/Application Support/Claude/claude_desktop_config.json`) :
+
+```json
+{
+  "mcpServers": {
+    "vantage-peers": {
+      "command": "node",
+      "args": ["/chemin/vers/mcp-server/dist/server.js"],
+      "env": {
+        "CONVEX_URL": "https://votre-deploiement.convex.cloud"
+      }
+    }
+  }
+}
+```
+
+Ou via `npx` (sans installation locale) :
+
+```json
+{
+  "mcpServers": {
+    "vantage-peers": {
+      "command": "npx",
+      "args": ["-y", "vantage-peers-mcp@latest"],
+      "env": {
+        "CONVEX_URL": "https://votre-deploiement.convex.cloud"
+      }
+    }
+  }
+}
+```
+
+### Ordre de résolution CONVEX_URL (stdio)
+
+Le serveur stdio résout `CONVEX_URL` dans cet ordre :
+
+1. Variable d'environnement `CONVEX_URL` (env explicite, priorité absolue)
+2. Entrée `CONVEX_URL=` dans `.env.local` dans le répertoire de travail où le serveur est lancé
+3. Si aucune n'est trouvée : arrêt avec erreur
+
+---
+
+## Transport HTTP (Railway / Claude.ai)
+
+Le serveur HTTP expose un endpoint MCP HTTP Streamable, un serveur d'autorisation OAuth 2.0 complet, et une auth Bearer master optionnelle. Destiné au déploiement Railway ou à tout serveur permanent.
+
+### Lancer en local
+
+```bash
+PORT=3000 \
+CONVEX_URL_INTERNAL=https://votre-deploiement.convex.cloud \
+BEARER_SECRET_MASTER=votre-secret \
+PUBLIC_BASE_URL=http://localhost:3000 \
+node dist/server-http.js
+```
+
+### Lancer en production (Railway)
+
+Définissez ces variables d'environnement dans votre projet Railway :
+
+```
+CONVEX_URL_INTERNAL=https://votre-deploiement.convex.cloud
+BEARER_SECRET_MASTER=<secret aléatoire de 32 caractères>
+PUBLIC_BASE_URL=https://votre-app.up.railway.app
+PORT=3000
+NODE_ENV=production
+```
+
+Railway injecte `PORT` automatiquement — vous n'avez pas besoin de le définir manuellement dans Railway.
+
+---
+
+## Référence des variables d'environnement
+
+### Partagées (les deux transports)
+
+| Variable | Requis | Description |
+|---|---|---|
+| `CONVEX_URL` | Oui (stdio) | URL du déploiement Convex. Résolue depuis l'env ou `.env.local`. |
+| `VP_EMIT_UI_MARKERS` | Non | Définir à `1` pour activer les marqueurs de flux `__VP_TOOL_RESULT__`. Voir [Marqueur de flux](/docs/paradigm-b/stream-marker). |
+
+### Transport HTTP uniquement
+
+| Variable | Requis | Description |
+|---|---|---|
+| `CONVEX_URL_INTERNAL` | Oui | URL du déploiement Convex pour le client orchestrateur interne utilisé par les mutations d'état OAuth. |
+| `BEARER_SECRET_MASTER` | Oui | Token Bearer master pour les endpoints admin (`/admin/*`). À garder secret. |
+| `PUBLIC_BASE_URL` | Recommandé | URL publique de ce serveur, utilisée comme `issuer` OAuth dans les métadonnées de découverte. |
+| `PORT` | Non | Port HTTP. Défaut : `3000`. |
+| `NODE_ENV` | Non | Définir à `production` sur Railway. Contrôle la verbosité des erreurs. |
+
+### Backend Convex (à définir dans le tableau de bord Convex)
+
+Ces variables sont définies dans le **tableau de bord Convex** (Paramètres → Variables d'environnement), pas dans le processus serveur :
+
+| Variable | Requis | Description |
+|---|---|---|
+| `AI_GATEWAY_API_KEY` | Oui (pour la recherche) | Clé API compatible OpenAI pour les embeddings `text-embedding-3-small`. |
+| `AI_GATEWAY_BASE_URL` | Non | Remplacer l'URL de base de l'API OpenAI pour une passerelle compatible. |
+| `GITHUB_WEBHOOK_SECRET` | Non | Secret HMAC pour valider les en-têtes `X-Hub-Signature-256` des webhooks GitHub. |
+| `GITHUB_TOKEN` | Non | Token d'accès personnel GitHub pour les appels API authentifiés (limite de débit plus élevée). |
+| `VP_EMIT_UI_MARKERS` | Non | Active les marqueurs de flux Paradigme B sur les réponses des outils. Définir à `1` pour activer. |
+
+---
+
+## Vérification de santé (transport HTTP)
+
+```bash
+curl https://votre-serveur.railway.app/health
+# → {"status":"ok","version":"2.4.0"}
+```
+
+L'endpoint de santé est non authentifié et retourne la version du serveur en cours d'exécution.
+
+---
+
+## Mise à jour
+
+```bash
+npm install vantage-peers-mcp@latest
+# ou
+npx vantage-peers-mcp@latest  # toujours la dernière version sans installation
+```
+
+Consultez toujours le [Changelog](/docs/changelog) pour les changements de variables d'environnement cassants entre les versions majeures.

--- a/content/docs/cli/index.mdx
+++ b/content/docs/cli/index.mdx
@@ -1,0 +1,181 @@
+---
+title: CLI Reference
+description: How to run the vantage-peers-mcp server — stdio transport for Claude Code, HTTP transport for Railway/Claude.ai, and all environment variable configuration.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout'
+import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
+import { Step, Steps } from 'fumadocs-ui/components/steps'
+
+# CLI Reference
+
+`vantage-peers-mcp` ships two server entry points. Both are configured entirely via environment variables — there are no CLI flags. Choose based on your transport:
+
+| Entry point | Transport | Use case |
+|---|---|---|
+| `dist/server.js` | stdio | Claude Code agents (local) |
+| `dist/server-http.js` | Streamable HTTP | Railway deploy, Claude.ai connector, remote clients |
+
+---
+
+## Stdio Transport (Claude Code)
+
+The stdio server reads from stdin and writes to stdout following the MCP stdio transport protocol. It is designed to be launched by Claude Code as a child process.
+
+### Run directly
+
+```bash
+CONVEX_URL=https://your-deployment.convex.cloud node dist/server.js
+```
+
+Or with `bun` during development:
+
+```bash
+CONVEX_URL=https://your-deployment.convex.cloud bun run server.ts
+```
+
+### Claude Code configuration
+
+Add to your `claude_desktop_config.json` (macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "vantage-peers": {
+      "command": "node",
+      "args": ["/path/to/mcp-server/dist/server.js"],
+      "env": {
+        "CONVEX_URL": "https://your-deployment.convex.cloud"
+      }
+    }
+  }
+}
+```
+
+Or via `npx` (no local install needed):
+
+```json
+{
+  "mcpServers": {
+    "vantage-peers": {
+      "command": "npx",
+      "args": ["-y", "vantage-peers-mcp@latest"],
+      "env": {
+        "CONVEX_URL": "https://your-deployment.convex.cloud"
+      }
+    }
+  }
+}
+```
+
+### CONVEX_URL resolution order (stdio)
+
+The stdio server resolves `CONVEX_URL` in this order:
+
+1. `CONVEX_URL` environment variable (explicit env, always wins)
+2. `CONVEX_URL=` entry in `.env.local` in the working directory where the server is launched
+3. If neither is found: exits with error
+
+---
+
+## HTTP Transport (Railway / Claude.ai)
+
+The HTTP server exposes a Streamable HTTP MCP endpoint, full OAuth 2.0 authorization server, and optional master bearer auth. Intended for Railway deployment or any always-on server.
+
+### Run locally
+
+```bash
+PORT=3000 \
+CONVEX_URL_INTERNAL=https://your-deployment.convex.cloud \
+BEARER_SECRET_MASTER=your-secret \
+PUBLIC_BASE_URL=http://localhost:3000 \
+node dist/server-http.js
+```
+
+### Run in production (Railway)
+
+Set these environment variables in your Railway project:
+
+```
+CONVEX_URL_INTERNAL=https://your-deployment.convex.cloud
+BEARER_SECRET_MASTER=<random 32-char secret>
+PUBLIC_BASE_URL=https://your-railway-app.up.railway.app
+PORT=3000
+NODE_ENV=production
+```
+
+Railway injects `PORT` automatically — you do not need to set it manually in Railway.
+
+---
+
+## Environment Variable Reference
+
+### Shared (both transports)
+
+| Variable | Required | Description |
+|---|---|---|
+| `CONVEX_URL` | Yes (stdio) | Convex deployment URL. Resolved from env or `.env.local`. |
+| `VP_EMIT_UI_MARKERS` | No | Set to `1` to enable `__VP_TOOL_RESULT__` stream markers on auto-emit tools. See [Stream Marker](/docs/paradigm-b/stream-marker). |
+
+### HTTP transport only
+
+| Variable | Required | Description |
+|---|---|---|
+| `CONVEX_URL_INTERNAL` | Yes | Convex deployment URL for the internal orchestrator client used by OAuth state mutations. |
+| `BEARER_SECRET_MASTER` | Yes | Master bearer token for admin endpoints (`/admin/*`). Must be kept secret. |
+| `PUBLIC_BASE_URL` | Recommended | Public URL of this server, used as the OAuth `issuer` in discovery metadata. Defaults to `https://vantage-peers-production.up.railway.app` if not set. |
+| `PORT` | No | HTTP port. Default: `3000`. |
+| `NODE_ENV` | No | Set to `production` on Railway. Controls error verbosity. |
+
+### Convex backend (set in Convex dashboard)
+
+These variables are set in the **Convex dashboard** (Settings → Environment Variables), not in the server process:
+
+| Variable | Required | Description |
+|---|---|---|
+| `AI_GATEWAY_API_KEY` | Yes (for search) | OpenAI-compatible API key for `text-embedding-3-small` embeddings. |
+| `AI_GATEWAY_BASE_URL` | No | Override the OpenAI API base URL for a compatible gateway. |
+| `GITHUB_WEBHOOK_SECRET` | No | HMAC secret for validating GitHub webhook `X-Hub-Signature-256` headers. |
+| `GITHUB_TOKEN` | No | GitHub personal access token for authenticated API calls (higher rate limit). |
+| `VP_EMIT_UI_MARKERS` | No | Enables Paradigm B stream markers on tool responses. Set to `1` to activate. |
+
+---
+
+## Health check (HTTP transport)
+
+```bash
+curl https://your-server.railway.app/health
+# → {"status":"ok","version":"2.4.0"}
+```
+
+The health endpoint is unauthenticated and returns the running server version.
+
+---
+
+## Package binary
+
+After `npm install -g vantage-peers-mcp`, the `vantage-peers-mcp` binary is available:
+
+```bash
+# Stdio (same as node dist/server.js)
+CONVEX_URL=... vantage-peers-mcp
+
+# HTTP
+PORT=3000 CONVEX_URL_INTERNAL=... BEARER_SECRET_MASTER=... vantage-peers-mcp-http
+```
+
+<Callout type="info">
+The package binary (`bin.vantage-peers-mcp` in `package.json`) points to `dist/server.js`. For the HTTP server, run `node dist/server-http.js` directly or use the Railway deploy button in the README.
+</Callout>
+
+---
+
+## Upgrade
+
+```bash
+npm install vantage-peers-mcp@latest
+# or
+npx vantage-peers-mcp@latest  # always runs latest without installing
+```
+
+Always check the [Changelog](/docs/changelog) for breaking environment variable changes between major versions.

--- a/content/docs/cli/meta.fr.json
+++ b/content/docs/cli/meta.fr.json
@@ -1,0 +1,6 @@
+{
+  "title": "CLI",
+  "pages": [
+    "index"
+  ]
+}

--- a/content/docs/cli/meta.json
+++ b/content/docs/cli/meta.json
@@ -1,0 +1,6 @@
+{
+  "title": "CLI",
+  "pages": [
+    "index"
+  ]
+}

--- a/content/docs/meta.fr.json
+++ b/content/docs/meta.fr.json
@@ -6,8 +6,17 @@
     "core-concepts",
     "capabilities",
     "infrastructure",
+    "---Déploiement & Intégration---",
+    "self-host",
+    "auth",
+    "cli",
     "---Référence---",
     "tools",
-    "changelog"
+    "api-reference",
+    "paradigm-b",
+    "toolkit",
+    "changelog",
+    "---Support---",
+    "troubleshooting"
   ]
 }

--- a/content/docs/meta.json
+++ b/content/docs/meta.json
@@ -6,8 +6,17 @@
     "core-concepts",
     "capabilities",
     "infrastructure",
+    "---Deploy & Integrate---",
+    "self-host",
+    "auth",
+    "cli",
     "---Reference---",
     "tools",
-    "changelog"
+    "api-reference",
+    "paradigm-b",
+    "toolkit",
+    "changelog",
+    "---Support---",
+    "troubleshooting"
   ]
 }

--- a/content/docs/paradigm-b/consumer-guide.fr.mdx
+++ b/content/docs/paradigm-b/consumer-guide.fr.mdx
@@ -1,0 +1,195 @@
+---
+title: Guide du consommateur
+description: Comment Hermes, Mu et Registry consomment le Paradigme B — importation des schémas, parsing des marqueurs et rendu des primitives.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout'
+import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
+import { Step, Steps } from 'fumadocs-ui/components/steps'
+
+# Guide du consommateur
+
+Ce guide couvre la façon dont trois consommateurs de référence intègrent le Paradigme B. Chacun a une architecture différente, mais tous trois partagent le même patron `parseToolResult` + validation Zod + switch de rendu.
+
+## Patron d'intégration commun
+
+Tous les consommateurs suivent ce flux en trois étapes :
+
+<Steps>
+  <Step>
+    **Intercepter** : capturer le texte brut d'une réponse d'outil MCP ou d'un résultat d'appel direct Convex.
+  </Step>
+  <Step>
+    **Parser** : appeler `parseToolResult(text)` — retourne un `VpToolResult` validé ou `null`.
+  </Step>
+  <Step>
+    **Afficher** : faire un switch sur `result.kind` et dispatcher vers le renderer approprié.
+  </Step>
+</Steps>
+
+```ts
+import { parseToolResult } from 'vantage-peers-mcp/ui-resources/stream-marker'
+import type { VpToolResult } from 'vantage-peers-mcp/ui-resources/schemas'
+
+function gererReponseOutil(texteBreut: string): void {
+  const result = parseToolResult(texteBreut)
+
+  if (!result) {
+    afficherTexteSimple(texteBreut)
+    return
+  }
+
+  afficherStructure(result)
+}
+
+function afficherStructure(result: VpToolResult): void {
+  switch (result.kind) {
+    case 'tasks-table':      return afficherTableauTaches(result.items)
+    case 'messages-feed':    return afficherFilMessages(result.items)
+    case 'diary-entry':      return afficherEntreeJournal(result.item)
+    case 'mission-timeline': return afficherTimelineMissions(result.items)
+    case 'briefing-note':    return afficherNoteBriefing(result.item)
+    case 'memory-quote':     return afficherCitationMemoire(result.items)
+    default:
+      result satisfies never
+  }
+}
+```
+
+---
+
+## Consommateur 1 : Hermes vantage-peers-extension
+
+**Architecture** : Extension Claude Desktop utilisant un client Convex direct (pas MCP HTTP). Hermes s'abonne aux requêtes temps réel Convex et appelle les actions Convex directement.
+
+**Points d'intégration** : Hermes reçoit les résultats des appels d'outils via l'API d'utilisation d'outils de Claude Desktop. Quand `VP_EMIT_UI_MARKERS=1`, ces résultats contiennent des marqueurs intégrés.
+
+```ts
+// hermes/src/tool-handler.ts
+import { parseToolResult } from 'vantage-peers-mcp/ui-resources/stream-marker'
+import { VpToolResultSchema } from 'vantage-peers-mcp/ui-resources/schemas'
+
+export function surResultatAppelOutil(nomOutil: string, resultatBrut: string): void {
+  const vpResult = parseToolResult(resultatBrut)
+
+  if (!vpResult) {
+    claudeDesktop.afficherTexte(resultatBrut)
+    return
+  }
+
+  const valide = VpToolResultSchema.safeParse(vpResult)
+  if (!valide.success) {
+    console.warn('[Hermes] Non-conformité schéma VpToolResult:', valide.error)
+    claudeDesktop.afficherTexte(resultatBrut)
+    return
+  }
+
+  // Rendu via injection Shadow DOM
+  const hote = document.createElement('div')
+  const shadow = hote.attachShadow({ mode: 'open' })
+
+  const uri = construireUriUi(valide.data)
+  recupererRessourceUi(uri).then((html) => {
+    shadow.innerHTML = html
+    claudeDesktop.afficherWidget(hote)
+  })
+}
+```
+
+<Callout type="info">
+Hermes utilise un **rendu en deux passes** : il parse le marqueur pour obtenir les métadonnées kind/count immédiatement, puis récupère le HTML complet depuis la ressource `ui://` pour le rendu final.
+</Callout>
+
+---
+
+## Consommateur 2 : Panneau latéral Mu vantage-bridge
+
+**Architecture** : Extension navigateur avec panneau latéral se connectant via transport MCP HTTP (Streamable HTTP). Mu communique avec le serveur MCP VantagePeers déployé sur Railway.
+
+**Intégration** : Mu intercepte toutes les réponses `tools/call` de la connexion MCP HTTP et les fait passer par `parseToolResult`.
+
+```ts
+// mu/src/mcp-bridge.ts
+import { parseToolResult } from 'vantage-peers-mcp/ui-resources/stream-marker'
+
+export async function appelerOutil(
+  nomOutil: string,
+  args: Record<string, unknown>
+): Promise<void> {
+  const reponse = await clientMcpHttp.callTool({ name: nomOutil, arguments: args })
+
+  const texteBreut = reponse.content
+    .filter((c) => c.type === 'text')
+    .map((c) => c.text)
+    .join('\n')
+
+  const vpResult = parseToolResult(texteBreut)
+
+  if (vpResult) {
+    panneauLateral.postMessage({ type: 'VP_PRIMITIVE', payload: vpResult })
+  } else {
+    panneauLateral.postMessage({ type: 'TEXT', payload: texteBreut })
+  }
+}
+```
+
+---
+
+## Consommateur 3 : Registry json-render
+
+**Architecture** : Le Registry VantagePeers est un workflow natif Convex. Après les appels d'outils, il utilise l'extraction de marqueurs post-appel pour persister les données structurées et afficher des résumés compacts dans sa propre interface.
+
+**Intégration** : Le Registry traite les résultats d'actions Convex (pas les réponses MCP). Quand un outil émet automatiquement un marqueur, le Registry l'extrait pour construire un résumé JSON dans son journal d'activité.
+
+```ts
+// registry/src/tool-result-processor.ts
+import { parseToolResult } from 'vantage-peers-mcp/ui-resources/stream-marker'
+import { VpToolResultSchema } from 'vantage-peers-mcp/ui-resources/schemas'
+
+export function extraireEtJournaliser(
+  nomOutil: string,
+  resultatBrut: string,
+  idSession: string
+): void {
+  const vpResult = parseToolResult(resultatBrut)
+
+  if (!vpResult) {
+    journalActivite.push({
+      idSession,
+      nomOutil,
+      type: 'text',
+      apercu: resultatBrut.slice(0, 200)
+    })
+    return
+  }
+
+  const parse = VpToolResultSchema.parse(vpResult)
+  const meta = extraireMeta(parse)
+
+  journalActivite.push({
+    idSession,
+    nomOutil,
+    type: 'structured',
+    kind: parse.kind,
+    nombre: meta.nombre,
+    apercu: meta.apercu,
+    payload: parse,
+  })
+}
+```
+
+---
+
+## Choisir la bonne approche
+
+| Scénario | Approche recommandée |
+|---|---|
+| Besoin du HTML complet avec CSS (Shadow DOM) | Récupérer la ressource `ui://` après le parsing du marqueur |
+| Besoin uniquement des données structurées | Utiliser `parseToolResult` + `VpToolResultSchema` directement |
+| Journal d'audit à fort volume | Patron Registry : extraire les métadonnées, persister `payload` |
+| Panneau latéral temps réel | Patron Mu : bridge post-message entre client MCP et renderer |
+| Extension desktop avec Convex direct | Patron Hermes : deux passes (métadonnées marqueur + HTML ui://) |
+
+<Callout type="warn">
+Utilisez toujours `parseToolResult` du package npm — ne réimplémentez pas la logique de parsing des marqueurs. Les tokens délimiteurs (`__VP_TOOL_RESULT__` / `__END__`) sont stables dans la v2.x mais seront versionnés en v3. Utilisez le package pour une compatibilité automatique.
+</Callout>

--- a/content/docs/paradigm-b/consumer-guide.mdx
+++ b/content/docs/paradigm-b/consumer-guide.mdx
@@ -1,0 +1,264 @@
+---
+title: Consumer Guide
+description: How Hermes, Mu, and Registry consume Paradigm B — importing schemas, parsing markers, and rendering primitives.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout'
+import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
+import { Step, Steps } from 'fumadocs-ui/components/steps'
+
+# Consumer Guide
+
+This guide covers how three reference consumers integrate Paradigm B. Each has a different architecture, but all three share the same `parseToolResult` + Zod validate + render switch pattern.
+
+## Common Integration Pattern
+
+All consumers follow this three-step flow:
+
+<Steps>
+  <Step>
+    **Intercept**: capture the raw text from an MCP tool response or a Convex direct call result.
+  </Step>
+  <Step>
+    **Parse**: call `parseToolResult(text)` — returns a validated `VpToolResult` or `null`.
+  </Step>
+  <Step>
+    **Render**: switch on `result.kind` and dispatch to the appropriate renderer.
+  </Step>
+</Steps>
+
+```ts
+import { parseToolResult } from 'vantage-peers-mcp/ui-resources/stream-marker'
+import type { VpToolResult } from 'vantage-peers-mcp/ui-resources/schemas'
+
+function handleMcpToolResponse(rawText: string): void {
+  const result = parseToolResult(rawText)
+
+  if (!result) {
+    // No marker — plain text, render as markdown/text
+    renderPlainText(rawText)
+    return
+  }
+
+  renderStructured(result)
+}
+
+function renderStructured(result: VpToolResult): void {
+  switch (result.kind) {
+    case 'tasks-table':      return renderTasksTable(result.items)
+    case 'messages-feed':    return renderMessagesFeed(result.items)
+    case 'diary-entry':      return renderDiaryEntry(result.item)
+    case 'mission-timeline': return renderMissionTimeline(result.items)
+    case 'briefing-note':    return renderBriefingNote(result.item)
+    case 'memory-quote':     return renderMemoryQuote(result.items)
+    default:
+      result satisfies never
+  }
+}
+```
+
+---
+
+## Consumer 1: Hermes vantage-peers-extension
+
+**Architecture**: Claude Desktop extension using Convex direct client (not MCP HTTP). Hermes subscribes to Convex real-time queries and calls Convex actions directly.
+
+**Integration points**: Hermes receives tool call results through Claude Desktop's tool use API. When `VP_EMIT_UI_MARKERS=1`, those results contain embedded markers.
+
+```ts
+// hermes/src/tool-handler.ts
+import { parseToolResult } from 'vantage-peers-mcp/ui-resources/stream-marker'
+import { VpToolResultSchema } from 'vantage-peers-mcp/ui-resources/schemas'
+
+export function onToolCallResult(toolName: string, rawResult: string): void {
+  // 1. Try to extract a structured VP result
+  const vpResult = parseToolResult(rawResult)
+
+  if (!vpResult) {
+    // No marker → fall back to default text rendering
+    claudeDesktop.renderText(rawResult)
+    return
+  }
+
+  // 2. Optional: re-validate with Zod for extra safety
+  const validated = VpToolResultSchema.safeParse(vpResult)
+  if (!validated.success) {
+    console.warn('[Hermes] VpToolResult schema mismatch:', validated.error)
+    claudeDesktop.renderText(rawResult)
+    return
+  }
+
+  // 3. Render via Shadow DOM injection
+  const shadowHost = document.createElement('div')
+  const shadow = shadowHost.attachShadow({ mode: 'open' })
+
+  // Fetch the HTML version from ui:// resource for full styling
+  const uri = buildUiUri(validated.data)
+  fetchUiResource(uri).then((html) => {
+    shadow.innerHTML = html
+    claudeDesktop.renderWidget(shadowHost)
+  })
+}
+
+function buildUiUri(result: VpToolResult): string {
+  // Convert parsed marker → ui:// URI for re-fetch with full HTML render
+  switch (result.kind) {
+    case 'tasks-table':
+      return `ui://vp/v1/tasks-table?limit=${result.items.length}`
+    case 'messages-feed':
+      return `ui://vp/v1/messages-feed?limit=${result.items.length}`
+    // ... etc
+    default:
+      return `ui://vp/v1/${result.kind}`
+  }
+}
+```
+
+<Callout type="info">
+Hermes uses **two-pass rendering**: it parses the marker to get kind/count metadata immediately, then fetches the full HTML from the `ui://` resource for final render. This avoids re-implementing the HTML template in the extension.
+</Callout>
+
+---
+
+## Consumer 2: Mu vantage-bridge Sidepanel
+
+**Architecture**: Browser extension sidepanel connecting via MCP HTTP transport (Streamable HTTP). Mu talks to the VantagePeers MCP server deployed on Railway.
+
+**Integration**: Mu intercepts all `tools/call` responses from the MCP HTTP connection and runs them through `parseToolResult`.
+
+```ts
+// mu/src/mcp-bridge.ts
+import { parseToolResult } from 'vantage-peers-mcp/ui-resources/stream-marker'
+
+// Mu's MCP HTTP client wraps every tool call
+export async function callTool(
+  toolName: string,
+  args: Record<string, unknown>
+): Promise<void> {
+  const response = await mcpHttpClient.callTool({ name: toolName, arguments: args })
+
+  // MCP tool result is always { content: [{ type: 'text', text: '...' }] }
+  const rawText = response.content
+    .filter((c) => c.type === 'text')
+    .map((c) => c.text)
+    .join('\n')
+
+  const vpResult = parseToolResult(rawText)
+
+  if (vpResult) {
+    // Post to sidepanel renderer
+    sidepanel.postMessage({ type: 'VP_PRIMITIVE', payload: vpResult })
+  } else {
+    sidepanel.postMessage({ type: 'TEXT', payload: rawText })
+  }
+}
+```
+
+```ts
+// mu/src/sidepanel/renderer.ts
+import type { VpToolResult } from 'vantage-peers-mcp/ui-resources/schemas'
+
+window.addEventListener('message', (event) => {
+  const msg = event.data as { type: string; payload: unknown }
+
+  if (msg.type === 'VP_PRIMITIVE') {
+    const result = msg.payload as VpToolResult
+    renderPrimitive(result)
+  } else if (msg.type === 'TEXT') {
+    renderMarkdown(msg.payload as string)
+  }
+})
+
+function renderPrimitive(result: VpToolResult): void {
+  const container = document.getElementById('vp-output')!
+  container.innerHTML = '' // clear previous
+
+  // Shadow DOM for CSS isolation
+  const host = document.createElement('div')
+  container.appendChild(host)
+  const shadow = host.attachShadow({ mode: 'open' })
+
+  // Build minimal HTML from payload — or fetch from ui:// resource
+  shadow.innerHTML = buildHtmlFromPayload(result)
+}
+```
+
+---
+
+## Consumer 3: Registry json-render
+
+**Architecture**: VantagePeers Registry is a Convex-native workflow. After tool calls, it uses post-tool-call marker extraction to persist structured data and render compact summaries in its own UI.
+
+**Integration**: Registry processes Convex action results (not MCP responses). When a tool auto-emits a marker, the Registry extracts it to build a JSON summary for its activity log.
+
+```ts
+// registry/src/tool-result-processor.ts
+import { parseToolResult } from 'vantage-peers-mcp/ui-resources/stream-marker'
+import { VpToolResultSchema } from 'vantage-peers-mcp/ui-resources/schemas'
+
+export function extractAndLog(
+  toolName: string,
+  rawResult: string,
+  sessionId: string
+): void {
+  const vpResult = parseToolResult(rawResult)
+
+  if (!vpResult) {
+    // No structured data — log raw text summary
+    activityLog.push({ sessionId, toolName, type: 'text', preview: rawResult.slice(0, 200) })
+    return
+  }
+
+  // Validate fully before persisting
+  const parsed = VpToolResultSchema.parse(vpResult)
+
+  // Extract count / summary metadata by kind
+  const meta = extractMeta(parsed)
+
+  activityLog.push({
+    sessionId,
+    toolName,
+    type: 'structured',
+    kind: parsed.kind,
+    count: meta.count,
+    preview: meta.preview,
+    payload: parsed,        // full structured data — used by json-render view
+  })
+}
+
+function extractMeta(result: VpToolResult): { count: number; preview: string } {
+  switch (result.kind) {
+    case 'tasks-table':
+      return { count: result.items.length, preview: result.items[0]?.title ?? '' }
+    case 'messages-feed':
+      return { count: result.items.length, preview: result.items[0]?.content?.slice(0, 80) ?? '' }
+    case 'diary-entry':
+      return { count: 1, preview: result.item.content.slice(0, 80) }
+    case 'mission-timeline':
+      return { count: result.items.length, preview: result.items[0]?.name ?? '' }
+    case 'briefing-note':
+      return { count: 1, preview: result.item.title }
+    case 'memory-quote':
+      return { count: result.items.length, preview: result.items[0]?.content?.slice(0, 80) ?? '' }
+    default:
+      result satisfies never
+      return { count: 0, preview: '' }
+  }
+}
+```
+
+---
+
+## Choosing the Right Approach
+
+| Scenario | Recommended approach |
+|---|---|
+| Need full HTML with embedded CSS (Shadow DOM) | Fetch `ui://` resource after parsing marker |
+| Need only structured data (no HTML rendering) | Use `parseToolResult` + `VpToolResultSchema` directly |
+| High-volume log/audit trail | Use Registry pattern: extract metadata, persist `payload` |
+| Real-time sidepanel | Use Mu pattern: post-message bridge between MCP client and renderer |
+| Desktop extension with Convex direct | Use Hermes pattern: two-pass (marker metadata + ui:// HTML) |
+
+<Callout type="warn">
+Always use `parseToolResult` from the npm package — do not reimplement the marker parsing logic. The marker boundary tokens (`__VP_TOOL_RESULT__` / `__END__`) are stable across v2.x but will be versioned in v3. Use the package to get automatic compatibility.
+</Callout>

--- a/content/docs/paradigm-b/index.fr.mdx
+++ b/content/docs/paradigm-b/index.fr.mdx
@@ -1,0 +1,123 @@
+---
+title: Paradigme B — Ressources ui://
+description: Interface générative native MCP via les ressources ui:// SEP-1865 et les marqueurs de flux __VP_TOOL_RESULT__. Validé dans vantage-peers-mcp v2.4.0.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout'
+import { Card, Cards } from 'fumadocs-ui/components/card'
+import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
+import { Step, Steps } from 'fumadocs-ui/components/steps'
+
+# Paradigme B — Ressources ui://
+
+VantagePeers prend en charge deux paradigmes d'interface générative distincts. Cette section couvre le **Paradigme B**, l'approche native MCP introduite dans la SEP-1865 et livrée dans `vantage-peers-mcp@2.4.0`.
+
+## Les deux paradigmes en bref
+
+| | Paradigme A | Paradigme B |
+|---|---|---|
+| **Hôte** | Application Theta Next.js | Tout consommateur MCP |
+| **Transport** | iframe + relais Clerk SSO | Protocole de ressources MCP `ui://` |
+| **Auth** | Propagation de session Clerk SSO | Jeton Bearer via serveur MCP |
+| **Rendu** | iframe (contrôle total de la page) | HTML inline scopé Shadow DOM |
+| **Template VR** | `gui-iframe-embed-v1` v1.1.0 §2.5 | SEP-1865 |
+| **Statut** | Déploiement Theta | Validé par Sigma, EN PRODUCTION (v2.4.0) |
+
+Le Paradigme A offre une surface Next.js hébergée par Theta avec un contrôle design complet et l'authentification Clerk SSO. Le Paradigme B donne à chaque consommateur MCP (Hermes, Mu, Registry, Claude Desktop) l'accès à des primitives UI structurées sans infrastructure d'hébergement supplémentaire.
+
+## Arbre de décision
+
+```
+Avez-vous besoin d'une interface web authentifiée complète (pages de connexion, navigation complexe) ?
+├── Oui  →  Paradigme A (iframe embed Theta, gui-iframe-embed-v1 v1.1.0 §2.5)
+└── Non
+    │
+    Vos consommateurs MCP ont-ils besoin de vues structurées inline riches
+    (tableaux de tâches, fils de messages, journal, missions) ?
+    ├── Oui  →  Paradigme B (ressources ui://, cette section)
+    └── Non  →  Les réponses textuelles des outils suffisent
+```
+
+**Choisissez le Paradigme B lorsque :**
+- Vous construisez une extension Claude Desktop, un panneau latéral ou un bridge MCP
+- Vous voulez une sortie structurée visuelle sans déployer un hôte web
+- Vos consommateurs parlent déjà MCP (resources/read, resources/list)
+- Vous avez besoin de HTML conforme WCAG AA, sécurisé contre les XSS, bilingue (FR/EN) livré en ligne
+
+**Choisissez le Paradigme A lorsque :**
+- Une mise en page complète et la session Clerk SSO sont requises
+- Vous avez besoin d'un routage d'URL approfondi et d'un état de navigation
+- Le template VR `gui-iframe-embed-v1` v1.1.0 est déjà dans votre stack (voir §2.5)
+
+## Ce qui est inclus dans le Paradigme B
+
+### 6 primitives ui://
+
+Toutes les primitives sont servies sous le schéma URI `ui://vp/v1/<primitive>?<query>`.
+
+| Primitive | URI | Source de données |
+|---|---|---|
+| `tasks-table` | `ui://vp/v1/tasks-table` | `tasks:list` |
+| `messages-feed` | `ui://vp/v1/messages-feed` | `messages:listMessages` |
+| `diary-entry` | `ui://vp/v1/diary-entry` | `diary:getEntry` |
+| `mission-timeline` | `ui://vp/v1/mission-timeline` | `missions:list` |
+| `briefing-note` | `ui://vp/v1/briefing-note` | `briefingNotes:get` |
+| `memory-quote` | `ui://vp/v1/memory-quote` | `memories:search` |
+
+Chaque primitive retourne du HTML inline avec du CSS intégré, scopé pour le rendu Shadow DOM. La sortie est conforme WCAG AA et bilingue (FR/EN via `?lang=fr`).
+
+### Schémas Zod
+
+Tous les payloads sont validés avec des unions discriminées Zod avant l'émission. Importez depuis :
+
+```ts
+import { VpToolResultSchema } from 'vantage-peers-mcp/ui-resources/schemas'
+import type { VpToolResult } from 'vantage-peers-mcp/ui-resources/schemas'
+```
+
+### Helpers de marqueurs de flux
+
+Lorsque `VP_EMIT_UI_MARKERS=1` est défini sur votre déploiement Convex, les réponses des outils intègrent automatiquement des marqueurs structurés :
+
+```
+__VP_TOOL_RESULT__{"kind":"tasks-table","items":[...]}__END__
+```
+
+Parsez-les avec :
+
+```ts
+import { parseToolResult, wrapToolResult } from 'vantage-peers-mcp/ui-resources/stream-marker'
+```
+
+## Prérequis
+
+<Callout type="info">
+Le Paradigme B requiert `vantage-peers-mcp@2.4.0` ou supérieur et `VP_EMIT_UI_MARKERS=1` dans les variables d'environnement Convex pour l'émission automatique sur les réponses des outils.
+</Callout>
+
+<Steps>
+  <Step>
+    Installez ou mettez à jour le package du serveur MCP :
+    ```bash
+    npm install vantage-peers-mcp@^2.4.0
+    ```
+  </Step>
+  <Step>
+    Définissez la variable d'environnement dans votre tableau de bord Convex (Paramètres → Variables d'environnement) :
+    ```
+    VP_EMIT_UI_MARKERS=1
+    ```
+    Consultez la [référence des variables d'environnement](/docs/infrastructure/deploy-keys) pour tous les détails.
+  </Step>
+  <Step>
+    Vérifiez que le serveur MCP expose les ressources `ui://` en appelant `resources/list` — vous devriez voir 6 entrées avec des URI correspondant à `ui://vp/v1/*`.
+  </Step>
+</Steps>
+
+## Contenu de la section
+
+<Cards>
+  <Card title="Référence des ressources UI" href="/docs/paradigm-b/ui-resources" description="Les 6 primitives : schéma URI, paramètres de requête, sortie HTML, exemples de récupération." />
+  <Card title="Marqueur de flux" href="/docs/paradigm-b/stream-marker" description="Helpers wrapToolResult / parseToolResult, VpToolResultSchema, les 6 types d'unions discriminées." />
+  <Card title="Guide du consommateur" href="/docs/paradigm-b/consumer-guide" description="Comment Hermes, Mu et Registry consomment le Paradigme B avec des exemples de code." />
+</Cards>

--- a/content/docs/paradigm-b/index.mdx
+++ b/content/docs/paradigm-b/index.mdx
@@ -1,0 +1,123 @@
+---
+title: Paradigm B — ui:// Resources
+description: MCP-native generative UI via SEP-1865 ui:// resources and __VP_TOOL_RESULT__ stream markers. Validated in vantage-peers-mcp v2.4.0.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout'
+import { Card, Cards } from 'fumadocs-ui/components/card'
+import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
+import { Step, Steps } from 'fumadocs-ui/components/steps'
+
+# Paradigm B — ui:// Resources
+
+VantagePeers supports two distinct generative UI paradigms. This section covers **Paradigm B**, the MCP-native approach introduced in SEP-1865 and shipped in `vantage-peers-mcp@2.4.0`.
+
+## Two Paradigms at a Glance
+
+| | Paradigm A | Paradigm B |
+|---|---|---|
+| **Host** | Theta Next.js app | Any MCP consumer |
+| **Transport** | iframe + Clerk SSO relay | `ui://` MCP resource protocol |
+| **Auth** | Clerk SSO session propagation | Bearer token via MCP server |
+| **Rendering** | iframe (full page control) | Shadow DOM scoped HTML inline |
+| **VR template** | `gui-iframe-embed-v1` v1.1.0 §2.5 | SEP-1865 |
+| **Status** | Theta deployment | Sigma-validated LIVE (v2.4.0) |
+
+Paradigm A gives you a full Theta-hosted Next.js surface with complete design control and Clerk SSO. Paradigm B gives every MCP consumer (Hermes, Mu, Registry, Claude Desktop) access to structured UI primitives without any additional hosting infrastructure.
+
+## Decision Tree
+
+```
+Do you need a full authenticated web UI (login pages, complex navigation)?
+├── Yes  →  Paradigm A (Theta iframe embed, gui-iframe-embed-v1 v1.1.0 §2.5)
+└── No
+    │
+    Do your MCP consumers need rich inline structured views
+    (task boards, message feeds, diary, missions)?
+    ├── Yes  →  Paradigm B (ui:// resources, this section)
+    └── No   →  Plain text tool responses are sufficient
+```
+
+**Pick Paradigm B when:**
+- You are building a Claude Desktop extension, sidepanel, or MCP bridge
+- You want structured visual output without deploying a web host
+- Your consumers already speak MCP (resources/read, resources/list)
+- You need WCAG AA, XSS-safe, bilingual (FR/EN) HTML delivered inline
+
+**Pick Paradigm A when:**
+- Full page layout and Clerk SSO session are required
+- You need deep URL routing and navigation state
+- The VR template `gui-iframe-embed-v1` v1.1.0 is already in your stack (see §2.5)
+
+## What Ships in Paradigm B
+
+### 6 ui:// Primitives
+
+All primitives are served under the URI scheme `ui://vp/v1/<primitive>?<query>`.
+
+| Primitive | URI | Data source |
+|---|---|---|
+| `tasks-table` | `ui://vp/v1/tasks-table` | `tasks:list` |
+| `messages-feed` | `ui://vp/v1/messages-feed` | `messages:listMessages` |
+| `diary-entry` | `ui://vp/v1/diary-entry` | `diary:getEntry` |
+| `mission-timeline` | `ui://vp/v1/mission-timeline` | `missions:list` |
+| `briefing-note` | `ui://vp/v1/briefing-note` | `briefingNotes:get` |
+| `memory-quote` | `ui://vp/v1/memory-quote` | `memories:search` |
+
+Each primitive returns inline HTML with embedded CSS, scoped for Shadow DOM rendering. Output is WCAG AA compliant and bilingual (FR/EN via `?lang=fr`).
+
+### Zod Schemas
+
+All payloads are validated with Zod discriminated unions before emission. Import from:
+
+```ts
+import { VpToolResultSchema } from 'vantage-peers-mcp/ui-resources/schemas'
+import type { VpToolResult } from 'vantage-peers-mcp/ui-resources/schemas'
+```
+
+### Stream Marker Helpers
+
+When `VP_EMIT_UI_MARKERS=1` is set on your Convex deployment, tool responses automatically embed structured markers:
+
+```
+__VP_TOOL_RESULT__{"kind":"tasks-table","items":[...]}__END__
+```
+
+Parse them with:
+
+```ts
+import { parseToolResult, wrapToolResult } from 'vantage-peers-mcp/ui-resources/stream-marker'
+```
+
+## Prerequisites
+
+<Callout type="info">
+Paradigm B requires `vantage-peers-mcp@2.4.0` or later and `VP_EMIT_UI_MARKERS=1` set in Convex environment variables for auto-emit on tool responses.
+</Callout>
+
+<Steps>
+  <Step>
+    Install or upgrade the MCP server package:
+    ```bash
+    npm install vantage-peers-mcp@^2.4.0
+    ```
+  </Step>
+  <Step>
+    Set the environment variable in your Convex dashboard (Settings → Environment Variables):
+    ```
+    VP_EMIT_UI_MARKERS=1
+    ```
+    See the [environment variables reference](/docs/infrastructure/deploy-keys) for full details.
+  </Step>
+  <Step>
+    Verify the MCP server exposes `ui://` resources by calling `resources/list` — you should see 6 entries with URIs matching `ui://vp/v1/*`.
+  </Step>
+</Steps>
+
+## Section Contents
+
+<Cards>
+  <Card title="UI Resources Reference" href="/docs/paradigm-b/ui-resources" description="All 6 primitives: URI scheme, query params, HTML output, fetch examples." />
+  <Card title="Stream Marker" href="/docs/paradigm-b/stream-marker" description="wrapToolResult / parseToolResult helpers, VpToolResultSchema, the 6 discriminated union kinds." />
+  <Card title="Consumer Guide" href="/docs/paradigm-b/consumer-guide" description="How Hermes, Mu, and Registry consume Paradigm B with code samples." />
+</Cards>

--- a/content/docs/paradigm-b/meta.fr.json
+++ b/content/docs/paradigm-b/meta.fr.json
@@ -1,0 +1,9 @@
+{
+  "title": "Paradigme B",
+  "pages": [
+    "index",
+    "ui-resources",
+    "stream-marker",
+    "consumer-guide"
+  ]
+}

--- a/content/docs/paradigm-b/meta.json
+++ b/content/docs/paradigm-b/meta.json
@@ -1,0 +1,9 @@
+{
+  "title": "Paradigm B",
+  "pages": [
+    "index",
+    "ui-resources",
+    "stream-marker",
+    "consumer-guide"
+  ]
+}

--- a/content/docs/paradigm-b/stream-marker.fr.mdx
+++ b/content/docs/paradigm-b/stream-marker.fr.mdx
@@ -1,0 +1,238 @@
+---
+title: Marqueur de flux
+description: Marqueurs de flux __VP_TOOL_RESULT__ — helpers wrapToolResult / parseToolResult, union discriminée VpToolResultSchema, et quels outils émettent automatiquement des marqueurs.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout'
+import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
+
+# Marqueur de flux
+
+Le marqueur de flux `__VP_TOOL_RESULT__` est un protocole texte léger intégré dans les réponses des outils MCP. Il permet aux consommateurs en aval (Claude Desktop, Hermes, panneau latéral Mu, Registry) de détecter et d'afficher des primitives UI structurées en ligne, sans appel séparé à `resources/read`.
+
+## Format du marqueur
+
+```
+__VP_TOOL_RESULT__<json>__END__
+```
+
+Où `<json>` est un objet JSON sérialisé conforme à `VpToolResultSchema` (une union discriminée Zod avec un discriminateur `kind`). Le JSON est minifié (sans espaces).
+
+**Exemple complet — tasks-table :**
+
+```
+__VP_TOOL_RESULT__{"kind":"tasks-table","items":[{"_id":"j97abc","title":"Corriger le bug d'auth","status":"in_progress","priority":"high","assignedTo":"sigma"}]}__END__
+```
+
+Le marqueur n'est émis que lorsque `VP_EMIT_UI_MARKERS=1` est défini dans l'environnement Convex. Quand la variable est absente (par défaut), les réponses des outils sont en texte brut — les intégrations existantes ne sont pas affectées.
+
+## VpToolResultSchema — Union discriminée
+
+Six types, un par primitive. Importez depuis `vantage-peers-mcp/ui-resources/schemas` :
+
+```ts
+import { VpToolResultSchema } from 'vantage-peers-mcp/ui-resources/schemas'
+import type { VpToolResult } from 'vantage-peers-mcp/ui-resources/schemas'
+```
+
+### Type : `tasks-table`
+
+```ts
+{
+  kind: 'tasks-table',
+  items: Array<{
+    _id: string
+    title: string
+    status: string
+    priority?: string
+    assignedTo?: string
+    _creationTime?: number
+  }>
+}
+```
+
+### Type : `messages-feed`
+
+```ts
+{
+  kind: 'messages-feed',
+  items: Array<{
+    _id: string
+    from: string
+    channel?: string
+    content: string
+    createdAt: number
+  }>
+}
+```
+
+### Type : `diary-entry`
+
+```ts
+{
+  kind: 'diary-entry',
+  item: {
+    _id: string
+    date: string        // YYYY-MM-DD
+    orchestrator: string
+    content: string
+    highlights?: string[]
+    blockers?: string[]
+  }
+}
+```
+
+Note : `diary-entry` utilise `item` (singulier), pas `items`.
+
+### Type : `mission-timeline`
+
+```ts
+{
+  kind: 'mission-timeline',
+  items: Array<{
+    _id: string
+    name: string
+    project?: string
+    status: string
+    pilot?: string
+    priority?: string
+    progress?: number   // 0–100
+  }>
+}
+```
+
+### Type : `briefing-note`
+
+```ts
+{
+  kind: 'briefing-note',
+  item: {
+    _id: string
+    topic: string
+    title: string
+    participants?: string[]
+    content?: string
+    createdBy?: string
+  }
+}
+```
+
+Note : `briefing-note` utilise `item` (singulier).
+
+### Type : `memory-quote`
+
+```ts
+{
+  kind: 'memory-quote',
+  items: Array<{
+    _id: string
+    namespace: string
+    type: string
+    content: string
+    score?: number
+  }>
+}
+```
+
+## Helpers
+
+Importez les deux helpers depuis `vantage-peers-mcp/ui-resources/stream-marker` :
+
+```ts
+import {
+  wrapToolResult,
+  parseToolResult,
+  MARKER_START,
+  MARKER_END,
+} from 'vantage-peers-mcp/ui-resources/stream-marker'
+```
+
+### `wrapToolResult(payload: VpToolResult): string`
+
+Valide `payload` contre `VpToolResultSchema`, puis sérialise au format marqueur. Lève une `TypeError` si la validation échoue.
+
+```ts
+const marker = wrapToolResult({
+  kind: 'tasks-table',
+  items: [
+    { _id: 'j97abc', title: 'Corriger le bug d\'auth', status: 'in_progress', priority: 'high', assignedTo: 'sigma' },
+  ],
+})
+// → "__VP_TOOL_RESULT__{"kind":"tasks-table","items":[...]}__END__"
+```
+
+### `parseToolResult(text: string): VpToolResult | null`
+
+Extrait et valide un marqueur VP depuis `text`. Gère trois cas :
+
+1. `text` **est** le marqueur (brut)
+2. `text` **contient** le marqueur dans du contenu environnant
+3. `text` **ne contient pas** de marqueur — retourne `null`
+
+Retourne le `VpToolResult` validé en cas de succès, ou `null` en cas d'échec. Ne lève jamais d'exception.
+
+```ts
+const result = parseToolResult(toolResponse)
+
+if (result === null) {
+  afficherTexteSimple(toolResponse)
+} else {
+  afficherPrimitive(result)
+}
+```
+
+## Outils à émission automatique
+
+Quand `VP_EMIT_UI_MARKERS=1` est défini, les 6 outils MCP suivants ajoutent automatiquement un marqueur `__VP_TOOL_RESULT__` à leur réponse textuelle :
+
+| Outil | Type émis |
+|---|---|
+| `list_tasks` | `tasks-table` |
+| `list_messages` / `get_messages` | `messages-feed` |
+| `get_diary_entry` | `diary-entry` |
+| `list_missions` | `mission-timeline` |
+| `get_briefing_note` | `briefing-note` |
+| `search_memories` / `recall_memories` | `memory-quote` |
+
+<Callout type="info">
+L'émission automatique est additive — le marqueur est ajouté après la réponse texte lisible par l'humain. Les consommateurs qui n'implémentent pas `parseToolResult` voient le texte brut du marqueur, ce qui est inesthétique mais pas nuisible. Définissez `VP_EMIT_UI_MARKERS=1` uniquement dans les déploiements où au moins un consommateur gère les marqueurs.
+</Callout>
+
+## Patron de rendu par switch
+
+Patron standard pour afficher un résultat parsé :
+
+```ts
+import { parseToolResult, type VpToolResult } from 'vantage-peers-mcp/ui-resources/stream-marker'
+
+function gererReponseOutil(text: string): void {
+  const result = parseToolResult(text)
+  if (!result) {
+    afficherTexteSimple(text)
+    return
+  }
+
+  switch (result.kind) {
+    case 'tasks-table':
+      afficherTableauTaches(result.items)
+      break
+    case 'messages-feed':
+      afficherFilMessages(result.items)
+      break
+    case 'diary-entry':
+      afficherEntreeJournal(result.item)
+      break
+    case 'mission-timeline':
+      afficherTimelineMissions(result.items)
+      break
+    case 'briefing-note':
+      afficherNoteBriefing(result.item)
+      break
+    case 'memory-quote':
+      afficherCitationMemoire(result.items)
+      break
+    default:
+      result satisfies never
+  }
+}
+```

--- a/content/docs/paradigm-b/stream-marker.mdx
+++ b/content/docs/paradigm-b/stream-marker.mdx
@@ -1,0 +1,255 @@
+---
+title: Stream Marker
+description: __VP_TOOL_RESULT__ stream markers — wrapToolResult / parseToolResult helpers, VpToolResultSchema discriminated union, and which tools auto-emit markers.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout'
+import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
+import { TypeTable } from 'fumadocs-ui/components/type-table'
+
+# Stream Marker
+
+The `__VP_TOOL_RESULT__` stream marker is a lightweight text protocol embedded in MCP tool responses. It lets downstream consumers (Claude Desktop, Hermes, Mu sidepanel, Registry) detect and render structured UI primitives inline, without a separate `resources/read` call.
+
+## Marker Format
+
+```
+__VP_TOOL_RESULT__<json>__END__
+```
+
+Where `<json>` is a JSON-serialized object conforming to `VpToolResultSchema` (a Zod discriminated union with a `kind` discriminator). The JSON is minified (no spaces).
+
+**Full example — tasks-table:**
+
+```
+__VP_TOOL_RESULT__{"kind":"tasks-table","items":[{"_id":"j97abc","title":"Fix auth bug","status":"in_progress","priority":"high","assignedTo":"sigma"}]}__END__
+```
+
+The marker is emitted only when `VP_EMIT_UI_MARKERS=1` is set in the Convex environment. When the variable is absent (default), tool responses are plain text — existing integrations are unaffected.
+
+## VpToolResultSchema — Discriminated Union
+
+Six kinds, one per primitive. Import from `vantage-peers-mcp/ui-resources/schemas`:
+
+```ts
+import { VpToolResultSchema } from 'vantage-peers-mcp/ui-resources/schemas'
+import type { VpToolResult } from 'vantage-peers-mcp/ui-resources/schemas'
+```
+
+### Kind: `tasks-table`
+
+```ts
+{
+  kind: 'tasks-table',
+  items: Array<{
+    _id: string
+    title: string
+    status: string
+    priority?: string
+    assignedTo?: string
+    _creationTime?: number
+  }>
+}
+```
+
+### Kind: `messages-feed`
+
+```ts
+{
+  kind: 'messages-feed',
+  items: Array<{
+    _id: string
+    from: string
+    channel?: string
+    content: string
+    createdAt: number
+  }>
+}
+```
+
+### Kind: `diary-entry`
+
+```ts
+{
+  kind: 'diary-entry',
+  item: {
+    _id: string
+    date: string        // YYYY-MM-DD
+    orchestrator: string
+    content: string
+    highlights?: string[]
+    blockers?: string[]
+  }
+}
+```
+
+Note: `diary-entry` uses `item` (singular), not `items`.
+
+### Kind: `mission-timeline`
+
+```ts
+{
+  kind: 'mission-timeline',
+  items: Array<{
+    _id: string
+    name: string
+    project?: string
+    status: string
+    pilot?: string
+    priority?: string
+    progress?: number   // 0–100
+  }>
+}
+```
+
+### Kind: `briefing-note`
+
+```ts
+{
+  kind: 'briefing-note',
+  item: {
+    _id: string
+    topic: string
+    title: string
+    participants?: string[]
+    content?: string
+    createdBy?: string
+  }
+}
+```
+
+Note: `briefing-note` uses `item` (singular).
+
+### Kind: `memory-quote`
+
+```ts
+{
+  kind: 'memory-quote',
+  items: Array<{
+    _id: string
+    namespace: string
+    type: string
+    content: string
+    score?: number
+  }>
+}
+```
+
+## Helpers
+
+Import both helpers from `vantage-peers-mcp/ui-resources/stream-marker`:
+
+```ts
+import {
+  wrapToolResult,
+  parseToolResult,
+  MARKER_START,
+  MARKER_END,
+} from 'vantage-peers-mcp/ui-resources/stream-marker'
+```
+
+### `wrapToolResult(payload: VpToolResult): string`
+
+Validates `payload` against `VpToolResultSchema`, then serializes to the marker format. Throws `TypeError` if validation fails.
+
+```ts
+const marker = wrapToolResult({
+  kind: 'tasks-table',
+  items: [
+    { _id: 'j97abc', title: 'Fix auth bug', status: 'in_progress', priority: 'high', assignedTo: 'sigma' },
+  ],
+})
+// → "__VP_TOOL_RESULT__{"kind":"tasks-table","items":[...]}__END__"
+```
+
+Use `wrapToolResult` when you are building a tool that should always emit a marker regardless of the `VP_EMIT_UI_MARKERS` env var — for example, in a test harness or a custom tool wrapper.
+
+### `parseToolResult(text: string): VpToolResult | null`
+
+Extracts and validates a VP marker from `text`. Handles three cases:
+
+1. `text` **is** the marker (bare)
+2. `text` **contains** the marker embedded in surrounding content
+3. `text` **does not** contain a marker — returns `null`
+
+Returns the validated `VpToolResult` on success, or `null` on any failure (missing marker, malformed JSON, schema violation). Never throws.
+
+```ts
+const result = parseToolResult(toolResponse)
+
+if (result === null) {
+  // Plain text response — render as-is
+  renderText(toolResponse)
+} else {
+  // Structured result — render by kind
+  renderPrimitive(result)
+}
+```
+
+### Constants
+
+```ts
+MARKER_START = "__VP_TOOL_RESULT__"
+MARKER_END   = "__END__"
+```
+
+Keep these in sync with any iframe bridge parser on the consumer side.
+
+## Auto-Emit Tools
+
+When `VP_EMIT_UI_MARKERS=1` is set, the following 6 MCP tools automatically append a `__VP_TOOL_RESULT__` marker to their text response:
+
+| Tool | Kind emitted |
+|---|---|
+| `list_tasks` | `tasks-table` |
+| `list_messages` / `get_messages` | `messages-feed` |
+| `get_diary_entry` | `diary-entry` |
+| `list_missions` | `mission-timeline` |
+| `get_briefing_note` | `briefing-note` |
+| `search_memories` / `recall_memories` | `memory-quote` |
+
+<Callout type="info">
+Auto-emit is additive — the marker is appended after the human-readable text response. Consumers that do not implement `parseToolResult` see the raw marker text, which is ugly but not harmful. Set `VP_EMIT_UI_MARKERS=1` only in deployments where at least one consumer handles markers.
+</Callout>
+
+## Render Switch Pattern
+
+Standard consumer pattern for rendering a parsed result:
+
+```ts
+import { parseToolResult, type VpToolResult } from 'vantage-peers-mcp/ui-resources/stream-marker'
+
+function handleToolResponse(text: string): void {
+  const result = parseToolResult(text)
+  if (!result) {
+    displayPlainText(text)
+    return
+  }
+
+  switch (result.kind) {
+    case 'tasks-table':
+      renderTasksTable(result.items)
+      break
+    case 'messages-feed':
+      renderMessagesFeed(result.items)
+      break
+    case 'diary-entry':
+      renderDiaryEntry(result.item)
+      break
+    case 'mission-timeline':
+      renderMissionTimeline(result.items)
+      break
+    case 'briefing-note':
+      renderBriefingNote(result.item)
+      break
+    case 'memory-quote':
+      renderMemoryQuote(result.items)
+      break
+    default:
+      // TypeScript exhaustiveness check
+      result satisfies never
+  }
+}
+```
+
+TypeScript's exhaustiveness check (`result satisfies never`) ensures you handle all 6 kinds.

--- a/content/docs/paradigm-b/ui-resources.fr.mdx
+++ b/content/docs/paradigm-b/ui-resources.fr.mdx
@@ -1,0 +1,208 @@
+---
+title: Référence des ressources UI
+description: Référence complète des 6 primitives ui:// — schéma URI, paramètres de requête, structure HTML de sortie et exemples de récupération MCP.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout'
+import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
+import { Accordion, Accordions } from 'fumadocs-ui/components/accordion'
+
+# Référence des ressources UI
+
+Toutes les primitives du Paradigme B sont servies via le protocole de ressources MCP `ui://`. Le serveur les enregistre sous `ui://vp/v1/<primitive>` et les clients les récupèrent avec `resources/read`.
+
+## Schéma URI
+
+```
+ui://vp/v1/<primitive>?<paramètres-de-requête>
+```
+
+- **Protocole** : `ui://` (URI personnalisée MCP, pas HTTP)
+- **Espace de noms** : `vp/v1` — versionné pour permettre des changements cassants futurs sous `v2`
+- **Primitive** : l'un des 6 noms enregistrés (voir tableau ci-dessous)
+- **Paramètres de requête** : optionnels, spécifiques à chaque primitive
+
+### Exemples complets d'URI
+
+```
+ui://vp/v1/tasks-table?assignedTo=sigma&status=in_progress&limit=10
+ui://vp/v1/messages-feed?from=pi&channel=fleet&limit=20
+ui://vp/v1/diary-entry?orchestrator=sigma&limit=3&lang=fr
+ui://vp/v1/mission-timeline?pilot=tau&status=active&limit=5
+ui://vp/v1/briefing-note?topic=deployment&limit=3
+ui://vp/v1/memory-quote?namespace=sigma&type=feedback&limit=5
+```
+
+## Récupération via MCP
+
+```ts
+// Récupération client MCP — fonctionne avec toute version MCP SDK >= 1.0
+const result = await client.readResource({
+  uri: 'ui://vp/v1/tasks-table?assignedTo=sigma&status=review&limit=10',
+})
+
+// result.contents[0].text = chaîne HTML
+const html = result.contents[0].text as string
+```
+
+Le `text` retourné est un fragment HTML autonome avec des balises `<style>` intégrées — sécurisé pour une injection dans un Shadow DOM root.
+
+---
+
+## Primitives
+
+### tasks-table
+
+Affiche un tableau HTML compact des tâches VantagePeers.
+
+**URI** : `ui://vp/v1/tasks-table`
+
+**Paramètres de requête** :
+
+| Paramètre | Type | Défaut | Description |
+|---|---|---|---|
+| `assignedTo` | string | — | Filtrer par nom de responsable |
+| `status` | string | — | Statut unique, alias (`open`, `active`, `all`), ou liste séparée par virgules (ex. `todo,in_progress`) |
+| `fields` | `lite` \| `full` | `lite` | `lite` = titre/statut/priorité/responsable ; `full` ajoute la date de création |
+| `limit` | 1–200 | `20` | Nombre maximum de lignes à retourner |
+| `createdBy` | string | — | Filtrer par nom du créateur |
+| `lang` | `en` \| `fr` | `en` | Langue des en-têtes de colonnes |
+
+**Sortie HTML** :
+
+```html
+<div class="vp-tasks-table" role="region" aria-label="Liste des tâches VantagePeers">
+  <style>/* CSS scopé — compatible Shadow DOM */</style>
+  <table>
+    <thead>
+      <tr>
+        <th scope="col">Titre</th>
+        <th scope="col">Statut</th>
+        <th scope="col">Priorité</th>
+        <th scope="col">Attribué à</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Titre de ma tâche</td>
+        <td><span class="vp-status vp-status-in_progress">in_progress</span></td>
+        <td>high</td>
+        <td>sigma</td>
+      </tr>
+    </tbody>
+  </table>
+  <div class="vp-tasks-count" aria-live="polite">3 tâches</div>
+</div>
+```
+
+**Classes des badges de statut** : `vp-status-todo` (bleu), `vp-status-in_progress` (jaune), `vp-status-review` (violet), `vp-status-blocked` (rouge), `vp-status-done` (vert).
+
+---
+
+### messages-feed
+
+Affiche un fil chronologique de messages VantagePeers.
+
+**URI** : `ui://vp/v1/messages-feed`
+
+**Paramètres de requête** :
+
+| Paramètre | Type | Défaut | Description |
+|---|---|---|---|
+| `from` | string | — | Filtrer par nom d'expéditeur |
+| `channel` | string | — | Filtrer par nom de canal |
+| `limit` | 1–200 | `20` | Nombre maximum de messages à retourner |
+| `lang` | `en` \| `fr` | `en` | Langue des libellés UI |
+
+**Sortie HTML** : `<div class="vp-messages-feed">` avec une liste de bulles de messages. Chaque bulle contient l'expéditeur, l'horodatage, le badge de canal (si présent) et le contenu sécurisé contre les XSS.
+
+---
+
+### diary-entry
+
+Affiche une entrée de journal structurée ou une liste d'entrées récentes.
+
+**URI** : `ui://vp/v1/diary-entry`
+
+**Paramètres de requête** :
+
+| Paramètre | Type | Défaut | Description |
+|---|---|---|---|
+| `date` | `YYYY-MM-DD` | — | Récupérer l'entrée pour une date spécifique |
+| `orchestrator` | string | — | Filtrer par nom d'orchestrateur |
+| `limit` | 1–50 | `5` | Nombre maximum d'entrées lors de la récupération d'une liste |
+| `lang` | `en` \| `fr` | `en` | Langue des libellés UI |
+
+**Sortie HTML** : `<div class="vp-diary-entry">` avec en-tête de date, badge d'orchestrateur, bloc de contenu, liste des points forts (si présents) et liste des blocages (si présents).
+
+---
+
+### mission-timeline
+
+Affiche une timeline verticale des missions VantagePeers.
+
+**URI** : `ui://vp/v1/mission-timeline`
+
+**Paramètres de requête** :
+
+| Paramètre | Type | Défaut | Description |
+|---|---|---|---|
+| `pilot` | string | — | Filtrer par pilote (orchestrateur assigné) |
+| `project` | string | — | Filtrer par nom de projet |
+| `status` | string | — | Filtrer par statut de mission |
+| `limit` | 1–100 | `10` | Nombre maximum de missions à retourner |
+| `lang` | `en` \| `fr` | `en` | Langue des libellés UI |
+
+**Sortie HTML** : `<div class="vp-mission-timeline">` avec une timeline verticale. Chaque entrée affiche le nom de la mission, le projet, le badge de statut, le pilote, la puce de priorité et la barre de progression (quand `progress` est défini).
+
+---
+
+### briefing-note
+
+Affiche une seule note de briefing ou une liste compacte de notes récentes.
+
+**URI** : `ui://vp/v1/briefing-note`
+
+**Paramètres de requête** :
+
+| Paramètre | Type | Défaut | Description |
+|---|---|---|---|
+| `noteId` | string | — | Récupérer une note spécifique par ID Convex |
+| `topic` | string | — | Filtrer par sujet lors de la récupération d'une liste |
+| `limit` | 1–50 | `5` | Nombre maximum de notes quand aucun `noteId` n'est fourni |
+| `lang` | `en` \| `fr` | `en` | Langue des libellés UI |
+
+**Sortie HTML** : `<div class="vp-briefing-note">` avec badge de sujet, titre, puces de participants (quand `participants` est défini) et bloc de contenu (quand `content` est défini).
+
+---
+
+### memory-quote
+
+Affiche une liste compacte de citations mémoire depuis un espace de noms.
+
+**URI** : `ui://vp/v1/memory-quote`
+
+**Paramètres de requête** :
+
+| Paramètre | Type | Défaut | Description |
+|---|---|---|---|
+| `namespace` | string | — | Espace de noms mémoire à interroger |
+| `type` | string | — | Filtre de type mémoire (`feedback`, `reference`, etc.) |
+| `limit` | 1–50 | `5` | Nombre maximum de citations à retourner |
+| `lang` | `en` \| `fr` | `en` | Langue des libellés UI |
+
+**Sortie HTML** : `<div class="vp-memory-quote">` avec une liste de style citation. Chaque entrée affiche le badge d'espace de noms, la puce de type, le score de pertinence (quand `score` est défini) et le contenu sécurisé contre les XSS.
+
+---
+
+## Comportement commun à toutes les primitives
+
+- **Sécurité XSS** : tout le contenu fourni par l'utilisateur passe par une fonction d'échappement HTML. Aucune interpolation brute.
+- **Scopage Shadow DOM** : les CSS utilisent des préfixes de classe `.vp-*` pour éviter les collisions avec les styles de la page hôte.
+- **WCAG AA** : tous les tableaux ont des en-têtes `scope="col"` ; les régions interactives utilisent `role` et `aria-label` ; les changements d'état utilisent `aria-live`.
+- **Bilingue** : tous les libellés, compteurs et noms accessibles sont traduits quand `?lang=fr` est passé.
+- **Frontière d'erreur** : si la requête Convex échoue, la primitive retourne un `<div>` d'erreur avec le message — elle ne lève jamais d'exception.
+
+<Callout type="warn">
+Le protocole `ui://` est un schéma URI MCP personnalisé. Les clients HTTP standard (`fetch`, `axios`) ne peuvent pas l'appeler. Seuls les clients SDK MCP avec un gestionnaire `resources/read` enregistré peuvent consommer ces ressources.
+</Callout>

--- a/content/docs/paradigm-b/ui-resources.mdx
+++ b/content/docs/paradigm-b/ui-resources.mdx
@@ -1,0 +1,208 @@
+---
+title: UI Resources Reference
+description: Complete reference for all 6 ui:// primitives — URI scheme, query parameters, HTML output structure, and MCP fetch examples.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout'
+import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
+import { Accordion, Accordions } from 'fumadocs-ui/components/accordion'
+
+# UI Resources Reference
+
+All Paradigm B primitives are served via the `ui://` MCP resource protocol. The server registers them under `ui://vp/v1/<primitive>` and clients fetch them with `resources/read`.
+
+## URI Scheme
+
+```
+ui://vp/v1/<primitive>?<query-params>
+```
+
+- **Protocol**: `ui://` (MCP custom URI, not HTTP)
+- **Namespace**: `vp/v1` — versioned to allow future breaking changes under `v2`
+- **Primitive**: one of the 6 registered names (see table below)
+- **Query params**: optional, primitive-specific filters
+
+### Full URI examples
+
+```
+ui://vp/v1/tasks-table?assignedTo=sigma&status=in_progress&limit=10
+ui://vp/v1/messages-feed?from=pi&channel=fleet&limit=20
+ui://vp/v1/diary-entry?orchestrator=sigma&limit=3&lang=fr
+ui://vp/v1/mission-timeline?pilot=tau&status=active&limit=5
+ui://vp/v1/briefing-note?topic=deployment&limit=3
+ui://vp/v1/memory-quote?namespace=sigma&type=feedback&limit=5
+```
+
+## Fetching via MCP
+
+```ts
+// MCP client fetch — works with any MCP SDK version >= 1.0
+const result = await client.readResource({
+  uri: 'ui://vp/v1/tasks-table?assignedTo=sigma&status=review&limit=10',
+})
+
+// result.contents[0].text = HTML string
+const html = result.contents[0].text as string
+```
+
+The returned `text` is a self-contained HTML fragment with embedded `<style>` tags — safe to inject into a Shadow DOM root.
+
+---
+
+## Primitives
+
+### tasks-table
+
+Renders a compact HTML table of VantagePeers tasks.
+
+**URI**: `ui://vp/v1/tasks-table`
+
+**Query params**:
+
+| Param | Type | Default | Description |
+|---|---|---|---|
+| `assignedTo` | string | — | Filter by assignee name |
+| `status` | string | — | Single status, alias (`open`, `active`, `all`), or comma-separated list (e.g. `todo,in_progress`) |
+| `fields` | `lite` \| `full` | `lite` | `lite` = title/status/priority/assignee; `full` adds creation time |
+| `limit` | 1–200 | `20` | Maximum rows to return |
+| `createdBy` | string | — | Filter by creator name |
+| `lang` | `en` \| `fr` | `en` | Column header language |
+
+**HTML output**:
+
+```html
+<div class="vp-tasks-table" role="region" aria-label="VantagePeers tasks list">
+  <style>/* scoped CSS — Shadow DOM safe */</style>
+  <table>
+    <thead>
+      <tr>
+        <th scope="col">Title</th>
+        <th scope="col">Status</th>
+        <th scope="col">Priority</th>
+        <th scope="col">Assigned to</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>My task title</td>
+        <td><span class="vp-status vp-status-in_progress">in_progress</span></td>
+        <td>high</td>
+        <td>sigma</td>
+      </tr>
+    </tbody>
+  </table>
+  <div class="vp-tasks-count" aria-live="polite">3 tasks</div>
+</div>
+```
+
+**Status badge classes**: `vp-status-todo` (blue), `vp-status-in_progress` (yellow), `vp-status-review` (purple), `vp-status-blocked` (red), `vp-status-done` (green).
+
+---
+
+### messages-feed
+
+Renders a chronological feed of VantagePeers messages.
+
+**URI**: `ui://vp/v1/messages-feed`
+
+**Query params**:
+
+| Param | Type | Default | Description |
+|---|---|---|---|
+| `from` | string | — | Filter by sender name |
+| `channel` | string | — | Filter by channel name |
+| `limit` | 1–200 | `20` | Maximum messages to return |
+| `lang` | `en` \| `fr` | `en` | UI label language |
+
+**HTML output**: `<div class="vp-messages-feed">` with a list of message bubbles. Each bubble contains sender, timestamp, channel badge (if present), and XSS-escaped content.
+
+---
+
+### diary-entry
+
+Renders a structured diary entry or a list of recent entries.
+
+**URI**: `ui://vp/v1/diary-entry`
+
+**Query params**:
+
+| Param | Type | Default | Description |
+|---|---|---|---|
+| `date` | `YYYY-MM-DD` | — | Fetch entry for a specific date |
+| `orchestrator` | string | — | Filter by orchestrator name |
+| `limit` | 1–50 | `5` | Maximum entries when fetching a list |
+| `lang` | `en` \| `fr` | `en` | UI label language |
+
+**HTML output**: `<div class="vp-diary-entry">` with date header, orchestrator badge, content block, highlights list (if present), and blockers list (if present).
+
+---
+
+### mission-timeline
+
+Renders a vertical timeline of VantagePeers missions.
+
+**URI**: `ui://vp/v1/mission-timeline`
+
+**Query params**:
+
+| Param | Type | Default | Description |
+|---|---|---|---|
+| `pilot` | string | — | Filter by pilot (assigned orchestrator) |
+| `project` | string | — | Filter by project name |
+| `status` | string | — | Filter by mission status |
+| `limit` | 1–100 | `10` | Maximum missions to return |
+| `lang` | `en` \| `fr` | `en` | UI label language |
+
+**HTML output**: `<div class="vp-mission-timeline">` with a vertical timeline. Each entry shows mission name, project, status badge, pilot, priority chip, and progress bar (when `progress` is set).
+
+---
+
+### briefing-note
+
+Renders a single briefing note or a compact list of recent notes.
+
+**URI**: `ui://vp/v1/briefing-note`
+
+**Query params**:
+
+| Param | Type | Default | Description |
+|---|---|---|---|
+| `noteId` | string | — | Fetch a specific note by Convex ID |
+| `topic` | string | — | Filter by topic when fetching a list |
+| `limit` | 1–50 | `5` | Maximum notes when no `noteId` is given |
+| `lang` | `en` \| `fr` | `en` | UI label language |
+
+**HTML output**: `<div class="vp-briefing-note">` with topic badge, title, participant chips (when `participants` is set), and content block (when `content` is set).
+
+---
+
+### memory-quote
+
+Renders a compact list of memory quotes from a namespace.
+
+**URI**: `ui://vp/v1/memory-quote`
+
+**Query params**:
+
+| Param | Type | Default | Description |
+|---|---|---|---|
+| `namespace` | string | — | Memory namespace to query |
+| `type` | string | — | Memory type filter (`feedback`, `reference`, etc.) |
+| `limit` | 1–50 | `5` | Maximum quotes to return |
+| `lang` | `en` \| `fr` | `en` | UI label language |
+
+**HTML output**: `<div class="vp-memory-quote">` with a blockquote-style list. Each entry shows namespace badge, type chip, relevance score (when `score` is set), and XSS-escaped content.
+
+---
+
+## Common Behaviour Across All Primitives
+
+- **XSS safety**: all user-supplied content runs through an HTML escape function. No raw interpolation.
+- **Shadow DOM scoping**: CSS uses `.vp-*` class prefixes to avoid collision with host page styles. Intended for Shadow DOM root injection but works in regular DOM too.
+- **WCAG AA**: all tables have `scope="col"` headers; interactive regions use `role` and `aria-label`; status changes use `aria-live`.
+- **Bilingual**: all labels, counts, and accessible names are translated when `?lang=fr` is passed.
+- **Error boundary**: if the Convex query fails, the primitive returns an error `<div>` with the message — it never throws. The MCP `resources/read` call always succeeds with an HTML response.
+
+<Callout type="warn">
+The `ui://` protocol is a custom MCP URI scheme. Standard HTTP clients (`fetch`, `axios`) cannot call it. Only MCP SDK clients with a registered `resources/read` handler can consume these resources.
+</Callout>

--- a/content/docs/toolkit/meta.fr.json
+++ b/content/docs/toolkit/meta.fr.json
@@ -1,0 +1,4 @@
+{
+  "title": "Boîte à outils",
+  "pages": []
+}

--- a/content/docs/toolkit/meta.json
+++ b/content/docs/toolkit/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Toolkit",
+  "pages": []
+}

--- a/content/docs/troubleshooting/common-errors.fr.mdx
+++ b/content/docs/troubleshooting/common-errors.fr.mdx
@@ -1,0 +1,216 @@
+---
+title: Erreurs courantes
+description: Top 10 des erreurs VantagePeers avec diagnostic et étapes de correction — CONVEX_URL manquant, échecs d'authentification, outil introuvable, violations de schéma, et plus.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout'
+import { Accordion, Accordions } from 'fumadocs-ui/components/accordion'
+
+# Erreurs courantes
+
+<Accordions>
+
+<Accordion title="1. CONVEX_URL introuvable / non définie">
+
+**Message d'erreur** :
+```
+Error: CONVEX_URL not found.
+Set it via: export CONVEX_URL=https://your-deployment.convex.cloud
+Or create a .env.local file with CONVEX_URL=...
+```
+
+**Cause** : le serveur MCP n'a pas trouvé d'URL de déploiement Convex dans l'environnement ou le fichier `.env.local`.
+
+**Correction** :
+
+Option A — variable d'environnement :
+```bash
+export CONVEX_URL=https://votre-deploiement.convex.cloud
+```
+
+Option B — fichier `.env.local` dans le répertoire où vous lancez `npx vantage-peers-mcp` :
+```
+CONVEX_URL=https://votre-deploiement.convex.cloud
+```
+
+Trouvez l'URL de votre déploiement dans le [tableau de bord Convex](https://dashboard.convex.dev) → votre projet → Paramètres → URL de déploiement.
+
+</Accordion>
+
+<Accordion title="2. Échec d'authentification Bearer (transport HTTP)">
+
+**Message d'erreur** :
+```
+HTTP 401 Unauthorized
+{"error":"invalid_token","error_description":"Bearer token is missing or invalid"}
+```
+
+**Cause** : le transport HTTP requiert un jeton Bearer dans l'en-tête `Authorization`. Le jeton est soit manquant, soit expiré (OAuth), soit incorrect (non-concordance du token master).
+
+**Correction** :
+
+Pour le Bearer master (admin) :
+```bash
+export BEARER_SECRET_MASTER=votre-secret-ici
+# Puis ajoutez dans la config du client MCP : Authorization: Bearer <votre-secret>
+```
+
+Pour les tokens OAuth : ré-autorisez le client via le flux OAuth. Les tokens d'accès OAuth expirent — vérifiez que votre client se rafraîchit avec le token de rafraîchissement avant expiration.
+
+</Accordion>
+
+<Accordion title="3. Outil introuvable">
+
+**Message d'erreur** :
+```
+MCP error: Tool 'tool_name' not found
+UnknownToolError: No tool registered with name 'tool_name'
+```
+
+**Cause** : le nom d'outil utilisé dans l'appel MCP ne correspond à aucun outil enregistré. Causes courantes :
+- Faute de frappe dans le nom de l'outil (ex. `list_task` au lieu de `list_tasks`)
+- Utilisation d'un outil supprimé dans une version plus récente
+- Ancien client MCP avec une liste d'outils mise en cache
+
+**Correction** :
+
+1. Consultez la [Référence des outils](/docs/tools) pour le nom exact de l'outil
+2. Appelez `tools/list` pour obtenir la liste des outils du serveur actuel
+3. Si vous utilisez Claude Code, redémarrez la connexion au serveur MCP pour rafraîchir le cache
+
+</Accordion>
+
+<Accordion title="4. Erreur de validation Zod sur l'entrée d'un outil">
+
+**Message d'erreur** :
+```
+ZodError: [{"code":"invalid_type","expected":"string","received":"number","path":["assignedTo"]}]
+McpError: Invalid arguments for tool 'create_task'
+```
+
+**Cause** : les arguments passés à l'outil ne correspondent pas au schéma attendu.
+
+**Correction** : consultez le schéma de l'outil dans la [Référence des outils](/docs/tools). Problèmes courants :
+- Passer un nombre là où une chaîne est attendue (ex. `priority: 1` devrait être `priority: "high"`)
+- Passer un tableau comme chaîne JSON — le serveur normalise automatiquement la plupart des paramètres de tableau
+- Champs requis manquants
+
+</Accordion>
+
+<Accordion title="5. Fonction Convex introuvable">
+
+**Message d'erreur** :
+```
+ConvexError: Function "tasks:list" not found
+Error calling Convex: Could not find function with path "memories:search"
+```
+
+**Cause** : le déploiement Convex n'a pas la fonction attendue. Cela se produit quand :
+- Le backend Convex n'est pas déployé ou utilise une ancienne version
+- `npx convex deploy` n'a pas été lancé après une mise à jour du code
+- CONVEX_URL pointe vers le mauvais déploiement
+
+**Correction** :
+
+```bash
+# Depuis la racine du repo vantage-peers :
+npx convex deploy --prod
+```
+
+</Accordion>
+
+<Accordion title="6. Espace de noms mémoire introuvable (résultats vides, pas d'erreur)">
+
+**Symptôme** : `recall_memories` ou `search_memories` retourne un tableau vide, mais vous savez que des mémoires existent.
+
+**Cause** : les espaces de noms sont sensibles à la casse. `sigma` et `Sigma` sont des espaces de noms différents.
+
+**Correction** : utilisez des chaînes d'espaces de noms exactement en minuscules. Tous les orchestrateurs intégrés utilisent des lettres grecques minuscules (`sigma`, `pi`, `tau`, etc.).
+
+</Accordion>
+
+<Accordion title="7. Limite de débit GitHub webhook / API">
+
+**Message d'erreur** :
+```
+GitHub API error: 403 rate limit exceeded
+X-RateLimit-Remaining: 0
+```
+
+**Cause** : la variable d'environnement `GITHUB_TOKEN` n'est pas définie (limite non authentifiée : 60 req/heure) ou la limite de débit du token est épuisée.
+
+**Correction** :
+
+1. Définissez `GITHUB_TOKEN` dans le tableau de bord Convex :
+   - Paramètres → Variables d'environnement → `GITHUB_TOKEN`
+   - Utilisez un token d'accès personnel fin avec les permissions `issues:read` et `issues:write`
+2. Les requêtes authentifiées ont une limite de 5000 req/heure
+
+</Accordion>
+
+<Accordion title="8. Connexion MCP refusée (transport HTTP)">
+
+**Message d'erreur** :
+```
+connect ECONNREFUSED 127.0.0.1:3000
+Error: fetch failed — connection refused
+```
+
+**Cause** : le serveur MCP HTTP ne tourne pas, ou tourne sur un port différent.
+
+**Correction** :
+
+```bash
+cd mcp-server
+PORT=3000 CONVEX_URL=... BEARER_SECRET_MASTER=... node dist/server-http.js
+```
+
+Vérifiez qu'il écoute :
+```bash
+curl http://localhost:3000/health
+```
+
+</Accordion>
+
+<Accordion title="9. Échec de parse VpToolResultSchema (Paradigme B)">
+
+**Message d'erreur** :
+```
+TypeError: [stream-marker] wrapToolResult: invalid payload — ...
+```
+
+Ou `parseToolResult` retourne `null` quand vous attendez un résultat structuré.
+
+**Cause** : le payload n'est pas conforme à `VpToolResultSchema`. Problèmes courants :
+- La valeur de `kind` ne correspond pas à l'une des 6 chaînes autorisées
+- `diary-entry` et `briefing-note` utilisent `item` (singulier), pas `items` — confusion fréquente
+- Champs requis manquants (`_id`, `title` pour les tâches, etc.)
+
+**Correction** :
+
+```ts
+const result = VpToolResultSchema.safeParse(payload)
+if (!result.success) {
+  console.error('Erreur de schéma:', result.error.format())
+}
+```
+
+Consultez la [référence du marqueur de flux](/docs/paradigm-b/stream-marker) pour la définition complète de l'union discriminée.
+
+</Accordion>
+
+<Accordion title="10. VP_EMIT_UI_MARKERS sans effet">
+
+**Symptôme** : `VP_EMIT_UI_MARKERS=1` est défini mais les réponses des outils ne contiennent pas de marqueurs.
+
+**Cause** : la variable d'environnement doit être définie dans le **tableau de bord Convex** (côté serveur), pas dans le fichier `.env.local` local ou l'environnement shell.
+
+**Correction** :
+
+1. Ouvrez le tableau de bord Convex → votre déploiement → Paramètres → Variables d'environnement
+2. Ajoutez `VP_EMIT_UI_MARKERS` avec la valeur `1`
+3. Enregistrez — prend effet au prochain appel de fonction, sans redéploiement
+
+</Accordion>
+
+</Accordions>

--- a/content/docs/troubleshooting/common-errors.mdx
+++ b/content/docs/troubleshooting/common-errors.mdx
@@ -1,0 +1,229 @@
+---
+title: Common Errors
+description: Top 10 VantagePeers errors with diagnosis and fix steps — CONVEX_URL missing, auth failures, tool not found, schema violations, and more.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout'
+import { Accordion, Accordions } from 'fumadocs-ui/components/accordion'
+
+# Common Errors
+
+<Accordions>
+
+<Accordion title="1. CONVEX_URL not found / not set">
+
+**Error message**:
+```
+Error: CONVEX_URL not found.
+Set it via: export CONVEX_URL=https://your-deployment.convex.cloud
+Or create a .env.local file with CONVEX_URL=...
+```
+
+**Cause**: The MCP server could not find a Convex deployment URL in the environment or `.env.local` file.
+
+**Fix**:
+
+Option A — environment variable:
+```bash
+export CONVEX_URL=https://your-deployment.convex.cloud
+```
+
+Option B — `.env.local` file in the directory where you run `npx vantage-peers-mcp`:
+```
+CONVEX_URL=https://your-deployment.convex.cloud
+```
+
+Find your deployment URL in the [Convex dashboard](https://dashboard.convex.dev) → your project → Settings → Deployment URL.
+
+</Accordion>
+
+<Accordion title="2. Bearer auth failure (HTTP transport)">
+
+**Error message**:
+```
+HTTP 401 Unauthorized
+{"error":"invalid_token","error_description":"Bearer token is missing or invalid"}
+```
+
+**Cause**: The HTTP transport requires a bearer token in the `Authorization` header. The token is either missing, expired (OAuth), or incorrect (master token mismatch).
+
+**Fix**:
+
+For master bearer (admin):
+```bash
+export BEARER_SECRET_MASTER=your-secret-here
+# Then add to MCP client config: Authorization: Bearer <your-secret>
+```
+
+For OAuth tokens: re-authorize the client through the OAuth flow. OAuth access tokens expire after a short window — check that your client refreshes using the refresh token before expiry.
+
+For Claude.ai connector: use the `/.well-known/oauth-authorization-server` discovery endpoint to verify redirect URIs match your registered client.
+
+</Accordion>
+
+<Accordion title="3. Tool not found">
+
+**Error message**:
+```
+MCP error: Tool 'tool_name' not found
+UnknownToolError: No tool registered with name 'tool_name'
+```
+
+**Cause**: The tool name used in the MCP call does not match any registered tool. Common causes:
+- Typo in tool name (e.g. `list_task` instead of `list_tasks`)
+- Using a tool that was removed in a newer version
+- Using an old MCP client that cached the tool list
+
+**Fix**:
+
+1. Check the [Tools Reference](/docs/tools) for the exact tool name
+2. Call `tools/list` to get the current server tool list
+3. If using Claude Code, restart the MCP server connection to refresh the tool cache
+
+</Accordion>
+
+<Accordion title="4. Zod validation error on tool input">
+
+**Error message**:
+```
+ZodError: [{"code":"invalid_type","expected":"string","received":"number","path":["assignedTo"]}]
+McpError: Invalid arguments for tool 'create_task'
+```
+
+**Cause**: The arguments passed to the tool do not match the expected schema. VantagePeers tools use strict Zod validation on all inputs.
+
+**Fix**: Review the tool schema in the [Tools Reference](/docs/tools). Common issues:
+- Passing a number where a string is expected (e.g. `priority: 1` should be `priority: "high"`)
+- Passing an array as a JSON string (`"[\"a\",\"b\"]"` instead of `["a","b"]`) — note: the server auto-normalizes this for most array params
+- Missing required fields
+
+</Accordion>
+
+<Accordion title="5. Convex function not found">
+
+**Error message**:
+```
+ConvexError: Function "tasks:list" not found
+Error calling Convex: Could not find function with path "memories:search"
+```
+
+**Cause**: The Convex deployment does not have the expected function. This happens when:
+- The Convex backend is not deployed or is using an older version
+- `npx convex deploy` has not been run after a code update
+- The CONVEX_URL points to the wrong deployment
+
+**Fix**:
+
+```bash
+# From the vantage-peers repo root:
+npx convex deploy --prod
+```
+
+Verify the deployment completed successfully in the Convex dashboard → Functions tab.
+
+</Accordion>
+
+<Accordion title="6. Memory namespace not found (empty results, no error)">
+
+**Symptom**: `recall_memories` or `search_memories` returns an empty array, but you know memories exist.
+
+**Cause**: Namespaces are case-sensitive. `sigma` and `Sigma` are different namespaces.
+
+**Fix**: Use exact lowercase namespace strings. All built-in orchestrators use lowercase Greek letters (`sigma`, `pi`, `tau`, etc.). Verify with:
+
+```
+list_memories({ namespace: "sigma", limit: 5 })
+```
+
+If that returns results, the data exists under the correct namespace. If not, check what namespace the memories were stored under using the Convex dashboard → Data tab → `memories` table.
+
+</Accordion>
+
+<Accordion title="7. Rate limit on GitHub webhook / API">
+
+**Error message**:
+```
+GitHub API error: 403 rate limit exceeded
+X-RateLimit-Remaining: 0
+```
+
+**Cause**: The `GITHUB_TOKEN` environment variable is either not set (unauthenticated rate limit: 60 req/hour) or the token's rate limit is exhausted.
+
+**Fix**:
+
+1. Set `GITHUB_TOKEN` in the Convex dashboard:
+   - Settings → Environment Variables → `GITHUB_TOKEN`
+   - Use a fine-grained personal access token with `issues:read` and `issues:write` permissions
+2. Authenticated requests get 5000 req/hour — sufficient for all normal usage
+
+</Accordion>
+
+<Accordion title="8. MCP connection refused (HTTP transport)">
+
+**Error message**:
+```
+connect ECONNREFUSED 127.0.0.1:3000
+Error: fetch failed — connection refused
+```
+
+**Cause**: The HTTP MCP server is not running, or it's running on a different port.
+
+**Fix**:
+
+1. Start the HTTP server:
+   ```bash
+   cd mcp-server
+   PORT=3000 CONVEX_URL=... BEARER_SECRET_MASTER=... node dist/server-http.js
+   ```
+2. Verify it's listening:
+   ```bash
+   curl http://localhost:3000/health
+   ```
+3. If using Railway, check the deployment logs — the server logs its port on startup
+
+</Accordion>
+
+<Accordion title="9. VpToolResultSchema parse failure (Paradigm B)">
+
+**Error message**:
+```
+TypeError: [stream-marker] wrapToolResult: invalid payload — ...
+```
+
+Or `parseToolResult` returns `null` when you expect a structured result.
+
+**Cause**: The payload does not conform to `VpToolResultSchema`. Common issues:
+- `kind` value does not match one of the 6 allowed strings
+- `diary-entry` and `briefing-note` use `item` (singular), not `items` — easy to confuse
+- Required fields missing (`_id`, `title` for tasks, etc.)
+
+**Fix**: Validate against the schema before wrapping:
+
+```ts
+const result = VpToolResultSchema.safeParse(payload)
+if (!result.success) {
+  console.error('Schema error:', result.error.format())
+}
+```
+
+See the [Stream Marker reference](/docs/paradigm-b/stream-marker) for the full discriminated union definition.
+
+</Accordion>
+
+<Accordion title="10. VP_EMIT_UI_MARKERS has no effect">
+
+**Symptom**: `VP_EMIT_UI_MARKERS=1` is set but tool responses do not contain markers.
+
+**Cause**: The environment variable must be set in the **Convex dashboard** (server-side), not in the local `.env.local` file or shell environment. The MCP server reads its own Node.js environment, but the auto-emit logic runs inside Convex functions.
+
+**Fix**:
+
+1. Open Convex dashboard → your deployment → Settings → Environment Variables
+2. Add `VP_EMIT_UI_MARKERS` with value `1`
+3. Save — takes effect on the next function call, no redeploy needed
+
+Verify by calling any of the 6 auto-emit tools and checking if the response text contains `__VP_TOOL_RESULT__`.
+
+</Accordion>
+
+</Accordions>

--- a/content/docs/troubleshooting/convex-workpool.fr.mdx
+++ b/content/docs/troubleshooting/convex-workpool.fr.mdx
@@ -1,0 +1,107 @@
+---
+title: Erreurs de workpool Convex
+description: Cause racine et correction pour "Couldn't acquire a permit on this funrun" — limites de concurrence de la plateforme Convex et le patron fleet de règle de filtre.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout'
+import { Step, Steps } from 'fumadocs-ui/components/steps'
+
+# Erreurs de workpool Convex
+
+## Message d'erreur
+
+```
+Error: Couldn't acquire a permit on this funrun
+```
+
+Variantes que vous pouvez également rencontrer :
+
+```
+WorkpoolError: All permits are currently in use
+ConvexError: funrun concurrency limit exceeded
+```
+
+## Cause racine
+
+Convex impose une **limite de concurrence par déploiement** sur les exécutions de fonctions (funruns). Chaque déploiement sur l'offre gratuite est limité à un nombre fixe d'exécutions de fonctions simultanées. Lorsque VantagePeers effectue de nombreuses opérations d'agents en parallèle (écritures mémoire, mises à jour de tâches, envois de messages), les slots de concurrence se remplissent et les nouveaux funruns échouent à acquérir un permit.
+
+Il s'agit d'une **contrainte de la plateforme Convex**, pas d'un bug dans VantagePeers.
+
+L'erreur est la plus fréquente lorsque :
+- Plusieurs agents envoient des messages ou écrivent des mémoires simultanément (burst fleet)
+- Un job cron se déclenche en même temps qu'une activité agent intensive
+- Un agent exécute une requête de recherche (vecteur + BM25 hybride) pendant que d'autres écrivent
+
+## Correction : patron de règle de filtre
+
+La correction standard fleet est une **règle de filtre** qui limite ou diffère les opérations quand le workpool est saturé.
+
+<Steps>
+  <Step>
+    **Identifiez les outils à haute fréquence** provoquant le burst. Coupables courants : `store_memory`, `send_message`, `create_task`, `update_task`.
+  </Step>
+  <Step>
+    **Ajoutez un backoff exponentiel** à l'agent appelant ces outils :
+
+    ```ts
+    async function avecBackoff<T>(
+      fn: () => Promise<T>,
+      maxTentatives = 4,
+      delaiBaseMs = 200
+    ): Promise<T> {
+      for (let tentative = 0; tentative <= maxTentatives; tentative++) {
+        try {
+          return await fn()
+        } catch (err) {
+          const estErreurWorkpool =
+            err instanceof Error &&
+            (err.message.includes("Couldn't acquire a permit") ||
+             err.message.includes("WorkpoolError"))
+
+          if (!estErreurWorkpool || tentative === maxTentatives) throw err
+
+          const delai = delaiBaseMs * 2 ** tentative + Math.random() * 100
+          await new Promise((resolve) => setTimeout(resolve, delai))
+        }
+      }
+      throw new Error('inaccessible')
+    }
+    ```
+  </Step>
+  <Step>
+    **Pour les opérations fleet** (beaucoup d'agents écrivant simultanément), utilisez une **règle de filtre** pour sérialiser ou limiter le débit des écritures.
+
+    ```
+    create_filter_rule({
+      pattern: "store_memory|update_task",
+      priority: "low",
+      action: "defer",
+      deferMs: 500
+    })
+    ```
+  </Step>
+  <Step>
+    **Passez à Convex Pro** si vous atteignez régulièrement la limite. Les déploiements Pro ont des limites de concurrence nettement plus élevées. Voir la [page de tarification Convex](https://convex.dev/pricing).
+  </Step>
+</Steps>
+
+## Vérifier l'utilisation actuelle des funruns
+
+Dans votre tableau de bord Convex :
+
+1. Allez dans votre déploiement → onglet **Functions**
+2. Triez par **Duration** — les fonctions longues maintiennent les permits plus longtemps
+3. Vérifiez les **Logs** pour la fréquence des `WorkpoolError`
+
+## Bursts liés aux crons
+
+Les tâches récurrentes VantagePeers s'exécutent sur des actions planifiées Convex. Si vous avez de nombreuses tâches récurrentes avec le même intervalle, elles se déclenchent simultanément et se disputent les permits.
+
+**Correction** : décalez vos planifications de tâches récurrentes.
+- Agent sigma : `cronExpression: "0 * * * *"` (heure pile)
+- Agent tau : `cronExpression: "15 * * * *"` (15 après)
+- Agent phi : `cronExpression: "30 * * * *"` (30 après)
+
+<Callout type="warn">
+N'interceptez pas et n'avalez pas silencieusement les `WorkpoolError`. Si une écriture mémoire ou un envoi de message échoue silencieusement, les agents opèreront sur des données périmées. Réessayez toujours ou remontez l'erreur.
+</Callout>

--- a/content/docs/troubleshooting/convex-workpool.mdx
+++ b/content/docs/troubleshooting/convex-workpool.mdx
@@ -1,0 +1,115 @@
+---
+title: Convex Workpool Errors
+description: Root cause and fix for "Couldn't acquire a permit on this funrun" — Convex platform concurrency limits and the fleet filter-rule pattern.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout'
+import { Step, Steps } from 'fumadocs-ui/components/steps'
+
+# Convex Workpool Errors
+
+## Error message
+
+```
+Error: Couldn't acquire a permit on this funrun
+```
+
+Variants you may also see:
+
+```
+WorkpoolError: All permits are currently in use
+ConvexError: funrun concurrency limit exceeded
+```
+
+## Root cause
+
+Convex enforces a **per-deployment concurrency limit** on function runs (funruns). Each deployment on the free tier is limited to a fixed number of concurrent function executions. When VantagePeers runs many parallel agent operations (memory writes, task updates, message sends) simultaneously, the concurrency slots fill up and new funruns fail to acquire a permit.
+
+This is a **Convex platform constraint**, not a bug in VantagePeers.
+
+The error is most common when:
+- Multiple agents send messages or write memories simultaneously (fleet burst)
+- A cron job fires at the same time as heavy agent activity
+- An agent runs a search query (vector + BM25 hybrid) while others are writing
+
+## Fix: Filter Rule Pattern
+
+The fleet-standard fix is a **filter rule** that throttles or defers operations when the workpool is saturated.
+
+<Steps>
+  <Step>
+    **Identify the high-frequency tools** causing the burst. Common culprits: `store_memory`, `send_message`, `create_task`, `update_task`.
+  </Step>
+  <Step>
+    **Add exponential backoff** to the agent calling those tools:
+
+    ```ts
+    async function withBackoff<T>(
+      fn: () => Promise<T>,
+      maxRetries = 4,
+      baseDelayMs = 200
+    ): Promise<T> {
+      for (let attempt = 0; attempt <= maxRetries; attempt++) {
+        try {
+          return await fn()
+        } catch (err) {
+          const isWorkpoolError =
+            err instanceof Error &&
+            (err.message.includes("Couldn't acquire a permit") ||
+             err.message.includes("WorkpoolError"))
+
+          if (!isWorkpoolError || attempt === maxRetries) throw err
+
+          const delay = baseDelayMs * 2 ** attempt + Math.random() * 100
+          await new Promise((resolve) => setTimeout(resolve, delay))
+        }
+      }
+      throw new Error('unreachable')
+    }
+
+    // Usage
+    await withBackoff(() => mcpClient.callTool({ name: 'store_memory', arguments: { ... } }))
+    ```
+  </Step>
+  <Step>
+    **For fleet operations** (many agents writing at once), use a **filter rule** to serialize or rate-limit writes:
+
+    In VantagePeers, create a filter rule that blocks duplicate or low-priority writes during saturation periods. The `create_filter_rule` tool accepts a regex pattern and a priority threshold — operations matching the pattern are deferred when the permit count exceeds the threshold.
+
+    ```
+    // Example: throttle low-priority memory writes during bursts
+    create_filter_rule({
+      pattern: "store_memory|update_task",
+      priority: "low",
+      action: "defer",
+      deferMs: 500
+    })
+    ```
+  </Step>
+  <Step>
+    **Upgrade to Convex Pro** if you consistently hit the limit. Pro deployments have significantly higher concurrency limits and dedicated funrun capacity. See the [Convex pricing page](https://convex.dev/pricing).
+  </Step>
+</Steps>
+
+## Checking current funrun usage
+
+In your Convex dashboard:
+
+1. Go to your deployment → **Functions** tab
+2. Sort by **Duration** — long-running functions hold permits longer
+3. Check **Logs** for `WorkpoolError` frequency
+
+If you see spikes, correlate them with scheduled cron jobs (`list_recurring_tasks`).
+
+## Cron-related bursts
+
+VantagePeers recurring tasks run on Convex scheduled actions. If you have many recurring tasks set to the same interval, they fire simultaneously and compete for permits.
+
+**Fix**: stagger your recurring task schedules. Instead of all agents using `interval: "1h"`, offset them:
+- Agent sigma: `cronExpression: "0 * * * *"` (top of hour)
+- Agent tau: `cronExpression: "15 * * * *"` (15 past)
+- Agent phi: `cronExpression: "30 * * * *"` (half past)
+
+<Callout type="warn">
+Do not catch and silently swallow `WorkpoolError`. If a memory write or message send fails silently, agents will operate on stale data. Always retry or surface the error.
+</Callout>

--- a/content/docs/troubleshooting/index.fr.mdx
+++ b/content/docs/troubleshooting/index.fr.mdx
@@ -1,0 +1,33 @@
+---
+title: Dépannage
+description: Diagnostiquer et corriger les problèmes courants de VantagePeers — erreurs de workpool Convex, échecs d'embeddings RAG, problèmes de connexion MCP, et plus.
+---
+
+import { Card, Cards } from 'fumadocs-ui/components/card'
+
+# Dépannage
+
+Cette section couvre les problèmes les plus courants rencontrés lors de l'exécution de VantagePeers en production. Chaque guide inclut une analyse de la cause racine et des instructions de correction étape par étape.
+
+## Diagnostic rapide
+
+Avant de plonger dans les guides spécifiques, collectez ces informations :
+
+1. **Version du serveur MCP** : `npm list vantage-peers-mcp` ou vérifiez `package.json`
+2. **Déploiement Convex** : `npx convex dashboard` → Functions → erreurs récentes
+3. **Variables d'environnement** : confirmez que `CONVEX_URL`, `AI_GATEWAY_API_KEY`, et optionnellement `VP_EMIT_UI_MARKERS` sont définies
+4. **Transport** : stdio (Claude Code) ou HTTP (Railway / connecteur Claude.ai)
+
+## Guides
+
+<Cards>
+  <Card title="Erreurs de workpool Convex" href="/docs/troubleshooting/convex-workpool" description="Couldn't acquire a permit on this funrun — cause racine de la limite de concurrence et correction par règle de filtre." />
+  <Card title="Embeddings RAG" href="/docs/troubleshooting/rag-embeddings" description="Configuration text-embedding-3-small, limites de débit, incompatibilités de dimensions et configuration de la clé API." />
+  <Card title="Erreurs courantes" href="/docs/troubleshooting/common-errors" description="Top 10 des erreurs avec diagnostic et étapes de correction — CONVEX_URL manquant, échecs d'auth, outil introuvable, et plus." />
+</Cards>
+
+## Toujours bloqué ?
+
+- Consultez les [issues GitHub](https://github.com/vantageos-agency/vantage-peers/issues) — recherchez votre message d'erreur
+- Consultez le [tableau de bord Convex](https://dashboard.convex.dev) → onglet Logs pour les erreurs côté serveur
+- Ouvrez une nouvelle issue avec votre version du serveur MCP, le type de transport et le message d'erreur exact

--- a/content/docs/troubleshooting/index.mdx
+++ b/content/docs/troubleshooting/index.mdx
@@ -1,0 +1,33 @@
+---
+title: Troubleshooting
+description: Diagnose and fix common VantagePeers issues — Convex workpool errors, RAG embedding failures, MCP connection problems, and more.
+---
+
+import { Card, Cards } from 'fumadocs-ui/components/card'
+
+# Troubleshooting
+
+This section covers the most common issues encountered when running VantagePeers in production. Each guide includes root cause analysis and step-by-step fix instructions.
+
+## Quick diagnosis
+
+Before diving into specific guides, collect this information:
+
+1. **MCP server version**: `npm list vantage-peers-mcp` or check `package.json`
+2. **Convex deployment**: `npx convex dashboard` → Functions → recent errors
+3. **Environment variables**: confirm `CONVEX_URL`, `AI_GATEWAY_API_KEY`, and optionally `VP_EMIT_UI_MARKERS` are set
+4. **Transport**: stdio (Claude Code) or HTTP (Railway / Claude.ai connector)
+
+## Guides
+
+<Cards>
+  <Card title="Convex Workpool Errors" href="/docs/troubleshooting/convex-workpool" description="Couldn't acquire a permit on this funrun — concurrency limit root cause and filter rule fix." />
+  <Card title="RAG Embeddings" href="/docs/troubleshooting/rag-embeddings" description="text-embedding-3-small setup, rate limits, dimension mismatches, and API key configuration." />
+  <Card title="Common Errors" href="/docs/troubleshooting/common-errors" description="Top 10 errors with diagnosis and fix steps — CONVEX_URL missing, auth failures, tool not found, and more." />
+</Cards>
+
+## Still stuck?
+
+- Check the [GitHub issues](https://github.com/vantageos-agency/vantage-peers/issues) — search for your error message
+- Review the [Convex dashboard](https://dashboard.convex.dev) → Logs tab for server-side errors
+- Open a new issue with your MCP server version, transport type, and the exact error message

--- a/content/docs/troubleshooting/meta.fr.json
+++ b/content/docs/troubleshooting/meta.fr.json
@@ -1,0 +1,9 @@
+{
+  "title": "Dépannage",
+  "pages": [
+    "index",
+    "convex-workpool",
+    "rag-embeddings",
+    "common-errors"
+  ]
+}

--- a/content/docs/troubleshooting/meta.json
+++ b/content/docs/troubleshooting/meta.json
@@ -1,0 +1,9 @@
+{
+  "title": "Troubleshooting",
+  "pages": [
+    "index",
+    "convex-workpool",
+    "rag-embeddings",
+    "common-errors"
+  ]
+}

--- a/content/docs/troubleshooting/rag-embeddings.fr.mdx
+++ b/content/docs/troubleshooting/rag-embeddings.fr.mdx
@@ -1,0 +1,136 @@
+---
+title: Embeddings RAG
+description: Configurer text-embedding-3-small (1536 dims), résoudre les limites de débit, les incompatibilités de dimensions et les erreurs de clé API dans la recherche RAG de VantagePeers.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout'
+import { Step, Steps } from 'fumadocs-ui/components/steps'
+import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
+
+# Embeddings RAG
+
+VantagePeers utilise `@convex-dev/rag` avec **text-embedding-3-small** (1536 dimensions) pour la recherche sémantique de mémoires et la recherche hybride (vecteur + BM25).
+
+## Configuration
+
+### Variables d'environnement
+
+À définir dans votre tableau de bord Convex (Paramètres → Variables d'environnement) :
+
+| Variable | Requis | Description |
+|---|---|---|
+| `AI_GATEWAY_API_KEY` | Oui | Clé API compatible OpenAI pour le modèle d'embedding |
+| `AI_GATEWAY_BASE_URL` | Non | Remplacement pour passerelle compatible OpenAI (défaut : API OpenAI) |
+
+<Callout type="info">
+`AI_GATEWAY_API_KEY` accepte les clés API OpenAI standard (`sk-...`) ou toute clé de passerelle compatible OpenAI (ex. Azure OpenAI, OpenRouter). Le nom du modèle d'embedding est codé en dur à `text-embedding-3-small`.
+</Callout>
+
+### Vérifier la configuration
+
+Après avoir défini la clé, testez-la en appelant `search_memories` :
+
+```
+search_memories({ query: "test", namespace: "sigma", limit: 1 })
+```
+
+Si elle retourne des résultats (ou un tableau vide), les embeddings fonctionnent. Si elle lève une exception, consultez les erreurs ci-dessous.
+
+---
+
+## Erreurs courantes
+
+### `AI_GATEWAY_API_KEY` non définie
+
+```
+Error: AI_GATEWAY_API_KEY is not set. Configure it in Convex dashboard → Settings → Environment Variables.
+```
+
+**Correction** :
+
+<Steps>
+  <Step>Ouvrez le [tableau de bord Convex](https://dashboard.convex.dev)</Step>
+  <Step>Sélectionnez votre déploiement → **Paramètres** → **Variables d'environnement**</Step>
+  <Step>Ajoutez `AI_GATEWAY_API_KEY` avec votre valeur de clé API OpenAI</Step>
+  <Step>Enregistrez — la modification prend effet immédiatement, sans redéploiement</Step>
+</Steps>
+
+---
+
+### Limite de débit dépassée
+
+```
+Error: 429 Too Many Requests — Rate limit reached for text-embedding-3-small
+OpenAI error: You exceeded your current quota
+```
+
+**Cause racine** : votre compte OpenAI a atteint sa limite de débit d'embedding. Cela se produit quand de nombreux agents recherchent ou stockent des mémoires simultanément.
+
+**Options de correction** :
+
+<Tabs items={['Réduire le débit', 'Changer de niveau', 'Utiliser une passerelle']}>
+  <Tab value="Réduire le débit">
+    Ajoutez un délai entre les opérations intensives en embedding. Les écritures mémoire (`store_memory`) génèrent un embedding par appel. Regrouper les écritures en chaînes `content` plus grandes réduit le nombre total de requêtes d'embedding.
+
+    ```ts
+    // Au lieu de plusieurs petites mémoires :
+    store_memory({ content: "fait 1", namespace: "sigma" })
+    store_memory({ content: "fait 2", namespace: "sigma" })
+
+    // Combinez en une seule :
+    store_memory({
+      content: "fait 1\n\nfait 2",
+      namespace: "sigma"
+    })
+    ```
+  </Tab>
+  <Tab value="Changer de niveau">
+    Passez votre compte OpenAI au Niveau 2 ou supérieur. Le Niveau 1 (nouveaux comptes) a une limite de 1M tokens/minute pour text-embedding-3-small. Le Niveau 2 l'augmente à 10M tokens/minute.
+  </Tab>
+  <Tab value="Utiliser une passerelle">
+    Routez les embeddings via une passerelle qui gère la limitation de débit pour vous (ex. Azure OpenAI, OpenRouter). Définissez `AI_GATEWAY_BASE_URL` sur l'endpoint de votre passerelle et `AI_GATEWAY_API_KEY` sur votre clé de passerelle.
+  </Tab>
+</Tabs>
+
+---
+
+### Incompatibilité de dimensions
+
+```
+Error: Vector dimension mismatch: expected 1536, got 1024
+ConvexError: Index dimension does not match stored vectors
+```
+
+**Cause racine** : l'index vectoriel Convex pour les mémoires a été créé avec une dimension (ex. 1536 de text-embedding-3-small) mais le modèle d'embedding actuel retourne une dimension différente.
+
+<Callout type="warn">
+Corriger une incompatibilité de dimensions nécessite de ré-embedder toutes les mémoires existantes. Cela ne peut pas se faire sans migration de données.
+</Callout>
+
+**Correction** : vérifiez `AI_GATEWAY_BASE_URL`. Si vous n'avez pas changé de modèle intentionnellement, retirez `AI_GATEWAY_BASE_URL` pour restaurer text-embedding-3-small à 1536 dims.
+
+---
+
+### Délai d'attente d'embedding dépassé
+
+```
+Error: Embedding request timed out after 30000ms
+```
+
+**Cause racine** : l'appel API d'embedding n'a pas répondu dans le délai imparti de la fonction Convex. Rare avec OpenAI direct, mais possible avec des passerelles lentes.
+
+**Correction** : vérifiez la latence de la passerelle. Passez à OpenAI direct si votre passerelle est lente. Réduisez la taille du contenu — gardez chaque mémoire sous 8000 tokens.
+
+---
+
+## Référence du modèle d'embedding
+
+| Propriété | Valeur |
+|---|---|
+| Modèle | `text-embedding-3-small` |
+| Fournisseur | OpenAI (ou passerelle compatible) |
+| Dimensions | **1536** |
+| Entrée maximale | 8191 tokens |
+| Mode de recherche | Similarité cosinus |
+| Type d'index | Index vectoriel Convex |
+| Recherche hybride | Fusion RRF (vecteur + BM25) |

--- a/content/docs/troubleshooting/rag-embeddings.mdx
+++ b/content/docs/troubleshooting/rag-embeddings.mdx
@@ -1,0 +1,159 @@
+---
+title: RAG Embeddings
+description: Configure text-embedding-3-small (1536 dims), troubleshoot rate limits, dimension mismatches, and API key errors in VantagePeers RAG search.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout'
+import { Step, Steps } from 'fumadocs-ui/components/steps'
+import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
+
+# RAG Embeddings
+
+VantagePeers uses `@convex-dev/rag` with **text-embedding-3-small** (1536 dimensions) for semantic memory search and hybrid (vector + BM25) search.
+
+## Configuration
+
+### Environment variables
+
+Set in your Convex dashboard (Settings → Environment Variables):
+
+| Variable | Required | Description |
+|---|---|---|
+| `AI_GATEWAY_API_KEY` | Yes | OpenAI-compatible API key for the embedding model |
+| `AI_GATEWAY_BASE_URL` | No | Override for OpenAI-compatible gateway (default: OpenAI API) |
+
+<Callout type="info">
+`AI_GATEWAY_API_KEY` accepts standard OpenAI API keys (`sk-...`) or any OpenAI-compatible gateway key (e.g. Azure OpenAI, OpenRouter). The embedding model name is hardcoded to `text-embedding-3-small`.
+</Callout>
+
+### Verify configuration
+
+After setting the key, test it by calling `search_memories`:
+
+```
+search_memories({ query: "test", namespace: "sigma", limit: 1 })
+```
+
+If it returns results (or an empty array), embeddings are working. If it throws, see the errors below.
+
+---
+
+## Common Errors
+
+### `AI_GATEWAY_API_KEY` not set
+
+```
+Error: AI_GATEWAY_API_KEY is not set. Configure it in Convex dashboard → Settings → Environment Variables.
+```
+
+**Fix**:
+
+<Steps>
+  <Step>Open the [Convex dashboard](https://dashboard.convex.dev)</Step>
+  <Step>Select your deployment → **Settings** → **Environment Variables**</Step>
+  <Step>Add `AI_GATEWAY_API_KEY` with your OpenAI API key value</Step>
+  <Step>Save — the change takes effect immediately, no redeploy needed</Step>
+</Steps>
+
+---
+
+### Rate limit exceeded
+
+```
+Error: 429 Too Many Requests — Rate limit reached for text-embedding-3-small
+OpenAI error: You exceeded your current quota
+```
+
+**Root cause**: Your OpenAI account has hit its embedding rate limit (tokens per minute or requests per minute). This happens when many agents search or store memories simultaneously.
+
+**Fix options**:
+
+<Tabs items={['Reduce rate', 'Upgrade tier', 'Use gateway']}>
+  <Tab value="Reduce rate">
+    Add a delay between embedding-intensive operations. Memory writes (`store_memory`) generate one embedding per call. Batching writes into larger `content` strings instead of many small calls reduces total embedding requests.
+
+    ```ts
+    // Instead of many small memories:
+    store_memory({ content: "fact 1", namespace: "sigma" })
+    store_memory({ content: "fact 2", namespace: "sigma" })
+
+    // Combine into one:
+    store_memory({
+      content: "fact 1\n\nfact 2",
+      namespace: "sigma"
+    })
+    ```
+  </Tab>
+  <Tab value="Upgrade tier">
+    Upgrade your OpenAI account to Tier 2 or higher. Tier 1 (new accounts) has a 1M token/minute limit for text-embedding-3-small. Tier 2 raises this to 10M tokens/minute. See [OpenAI rate limits](https://platform.openai.com/docs/guides/rate-limits).
+  </Tab>
+  <Tab value="Use gateway">
+    Route embeddings through a gateway that handles rate limiting for you (e.g. Azure OpenAI, OpenRouter). Set `AI_GATEWAY_BASE_URL` to your gateway endpoint and `AI_GATEWAY_API_KEY` to your gateway key.
+  </Tab>
+</Tabs>
+
+---
+
+### Dimension mismatch
+
+```
+Error: Vector dimension mismatch: expected 1536, got 1024
+ConvexError: Index dimension does not match stored vectors
+```
+
+**Root cause**: The Convex vector index for memories was created with one dimension (e.g. 1536 from text-embedding-3-small) but the current embedding model returns a different dimension.
+
+This happens when:
+- The embedding model was changed mid-deployment
+- A custom gateway is configured with a different model
+- An older deployment snapshot was restored
+
+**Fix**:
+
+<Callout type="warn">
+Fixing a dimension mismatch requires re-embedding all existing memories. This cannot be done without data migration.
+</Callout>
+
+<Steps>
+  <Step>Confirm the current model dimension by checking `AI_GATEWAY_BASE_URL`. If it points to a gateway, verify what model the gateway is using and its output dimension.</Step>
+  <Step>If you changed models intentionally, you need to re-index: export all memories, delete the vector index, re-create with the new dimension, and re-embed all content. Contact support or open a GitHub issue for migration tooling.</Step>
+  <Step>If you did not change models, revert `AI_GATEWAY_BASE_URL` to the default (or remove it) to restore text-embedding-3-small at 1536 dims.</Step>
+</Steps>
+
+---
+
+### Embedding timeout
+
+```
+Error: Embedding request timed out after 30000ms
+```
+
+**Root cause**: The embedding API call (OpenAI or gateway) did not respond within the Convex function timeout. This is rare with OpenAI direct but can happen with slow gateway proxies.
+
+**Fix**:
+- Check gateway latency — switch to OpenAI direct if your gateway is slow
+- Reduce content size. Very long content strings take more time to embed. Keep individual memory content under 8000 tokens
+
+---
+
+### Search returns no results (embeddings seem wrong)
+
+If `search_memories` returns empty despite relevant memories existing:
+
+1. Verify the namespace matches exactly — namespaces are case-sensitive (`sigma` != `Sigma`)
+2. Check that the memories were stored with the same API key / model — if the model changed, old vectors are from a different embedding space
+3. Try `recall_memories` with `type` filter instead of semantic search — BM25 text search does not require vector alignment
+
+---
+
+## Embedding model reference
+
+| Property | Value |
+|---|---|
+| Model | `text-embedding-3-small` |
+| Provider | OpenAI (or compatible gateway) |
+| Dimensions | **1536** |
+| Max input | 8191 tokens |
+| Search mode | Cosine similarity |
+| Index type | Convex vector index |
+| Hybrid search | RRF fusion (vector + BM25) |


### PR DESCRIPTION
## Summary
STOP-THE-LINE VOLET A part 2 (mission task k170mmqpx65jmmvzknj5svxgax87nhfj). dev-fumadocs-expert content.

## Changes
### Paradigm B (8 MDX)
- content/docs/paradigm-b/{index,ui-resources,stream-marker,consumer-guide}.mdx + .fr.mdx
- 6 ui:// primitives + URI scheme + Zod schema + 3 reference consumers (Hermes/Mu/Registry)

### Troubleshooting (8 MDX)
- content/docs/troubleshooting/{index,convex-workpool,rag-embeddings,common-errors}.mdx + .fr.mdx
- 10 common errors with diagnosis + fix steps

### CLI (2 MDX)
- content/docs/cli/index.mdx + .fr.mdx
- stdio vs HTTP entry points, env vars, health endpoint

### Root nav
- content/docs/meta.json + meta.fr.json — new sections wired: Deploy & Integrate (self-host + auth + cli) / Reference (tools + api-reference + paradigm-b + toolkit + changelog) / Support (troubleshooting)
- Placeholder meta.json for auth/ + toolkit/ (filled by sibling PR feat/docs-auth-toolkit-final)

## Test plan
- [x] npm run build 0 errors (161 static pages, up from baseline)
- [x] FR full translations
- [ ] Eta APPROVED
- [ ] Pi GO MERGE

## Findings
- vantage-peers-mcp server is fully env-var driven (no CLI flags) — accurately documented from server.ts + server-http.ts source

Reference mission: k170mmqpx65jmmvzknj5svxgax87nhfj

Orchestrator: Sigma — VantageOS Team | 2026-05-29