### PR TITLE
feat(docs): /docs/missions Volet C2 — what/why/how/templates/examples EN/FR

### DIFF
--- a/content/docs/meta.fr.json
+++ b/content/docs/meta.fr.json
@@ -5,6 +5,7 @@
     "getting-started",
     "core-concepts",
     "capabilities",
+    "missions",
     "infrastructure",
     "---Référence---",
     "tools",

--- a/content/docs/meta.json
+++ b/content/docs/meta.json
@@ -5,6 +5,7 @@
     "getting-started",
     "core-concepts",
     "capabilities",
+    "missions",
     "infrastructure",
     "---Reference---",
     "tools",

--- a/content/docs/missions/creating-missions.fr.mdx
+++ b/content/docs/missions/creating-missions.fr.mdx
@@ -1,0 +1,245 @@
+---
+title: Créer des missions
+description: Guide étape par étape pour créer une mission, lier des tâches avec dependsOn, faire avancer le statut, suivre la progression et clôturer avec preuves.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout'
+import { Step, Steps } from 'fumadocs-ui/components/steps'
+import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
+
+# Créer des missions
+
+Cette page couvre le cycle de vie complet d'une mission, de la création à la clôture liée à des preuves. Tous les exemples utilisent les noms d'outils MCP tels qu'ils sont appelés depuis Claude Code.
+
+<Steps>
+  <Step>
+    ## Créer la mission
+
+    Appelez `create_mission` avec l'identité de la mission, le pilote, les agents et le statut initial. Commencez en `plan` sauf si vous ne faites que capturer une idée (utilisez `brainstorm` pour cela).
+
+    ```ts
+    mcp__vantage-peers__create_mission({
+      name: "doc-completion-cedric",
+      description: "Livrer les docs d'onboarding Cedric de bout en bout : audit, écriture, révision, publication.",
+      pilot: "sigma",
+      agents: ["dev-fumadocs-expert", "eta"],
+      status: "plan",
+      priority: "urgent",
+      project: "vantage-peers-site",
+      brief: "Cedric démarre lundi. Les docs doivent couvrir les missions, tâches et la recherche. Eta révise avant publication.",
+      createdBy: "sigma"
+    })
+    // retourne : "k57abc123..."  (le missionId)
+    ```
+
+    Sauvegardez le `missionId` retourné — vous en aurez besoin pour chaque appel ultérieur.
+  </Step>
+  <Step>
+    ## Ajouter des tâches liées à la mission
+
+    Créez une tâche par phase. Définissez `missionId` sur chaque tâche. Utilisez `dependsOn` pour exprimer le séquençage — listez les IDs des tâches qui doivent atteindre `done` avant que cette tâche puisse commencer.
+
+    ```ts
+    // T0 — pas de dépendances, démarre immédiatement
+    const t0 = mcp__vantage-peers__create_task({
+      title: "Auditer les docs existants",
+      description: "Identifier les lacunes dans le contenu /docs actuel. Sortie : liste des pages manquantes.",
+      assignedTo: "sigma",
+      priority: "urgent",
+      project: "vantage-peers-site",
+      missionId: "k57abc123",
+      status: "todo",
+      createdBy: "sigma"
+    })
+    // t0 = "kTASK_T0"
+
+    // T1 — dépend de T0
+    const t1 = mcp__vantage-peers__create_task({
+      title: "Écrire les nouvelles pages",
+      description: "Écrire toutes les pages identifiées lors de l'audit. Fumadocs MDX, EN + FR.",
+      assignedTo: "dev-fumadocs-expert",
+      priority: "urgent",
+      project: "vantage-peers-site",
+      missionId: "k57abc123",
+      dependsOn: ["kTASK_T0"],
+      status: "todo",
+      createdBy: "sigma"
+    })
+    // t1 = "kTASK_T1"
+
+    // T2 — dépend de T1
+    const t2 = mcp__vantage-peers__create_task({
+      title: "Révision Eta",
+      description: "Eta révise toutes les nouvelles pages pour l'exactitude, l'exhaustivité et la parité EN/FR.",
+      assignedTo: "eta",
+      priority: "urgent",
+      project: "vantage-peers-site",
+      missionId: "k57abc123",
+      dependsOn: ["kTASK_T1"],
+      status: "todo",
+      createdBy: "sigma"
+    })
+    // t2 = "kTASK_T2"
+
+    // T3 — dépend de T2
+    const t3 = mcp__vantage-peers__create_task({
+      title: "Publier et annoncer",
+      description: "Fusionner la PR, pousser en prod, annoncer à l'équipe.",
+      assignedTo: "sigma",
+      priority: "urgent",
+      project: "vantage-peers-site",
+      missionId: "k57abc123",
+      dependsOn: ["kTASK_T2"],
+      status: "todo",
+      createdBy: "sigma"
+    })
+    ```
+
+    La chaîne de dépendances : T0 → T1 → T2 → T3. Chaque tâche ne peut commencer qu'après la clôture de son prédécesseur.
+  </Step>
+  <Step>
+    ## Démarrer la mission
+
+    Une fois les tâches définies, faites passer la mission de `plan` à `execute`. Cela signale à tous les agents que le travail actif doit commencer.
+
+    ```ts
+    mcp__vantage-peers__update_mission_status({
+      missionId: "k57abc123",
+      status: "execute"
+    })
+    ```
+  </Step>
+  <Step>
+    ## Déléguer le travail aux sous-agents
+
+    Deux patterns selon que vous déléguez en ligne ou via une nouvelle session d'agent :
+
+    <Tabs items={["Délégation en ligne", "Délégation via Agent tool"]}>
+      <Tab value="Délégation en ligne">
+        Démarrez la première tâche et travaillez-la directement dans la session actuelle :
+
+        ```ts
+        mcp__vantage-peers__start_task({ taskId: "kTASK_T0" })
+        // ... faire le travail ...
+        mcp__vantage-peers__complete_task({
+          taskId: "kTASK_T0",
+          completionNote: "Audit terminé. 6 pages manquantes trouvées : missions/index, missions/what-is-a-mission, missions/when-to-use, missions/creating-missions, missions/templates, missions/examples. Consignées dans analysis/doc-gaps-2026-05-29.md"
+        })
+        ```
+      </Tab>
+      <Tab value="Délégation via Agent tool">
+        Déléguez une phase à un sous-agent en lançant une nouvelle session d'agent avec le contexte de la tâche :
+
+        ```ts
+        // Lancer un agent fumadocs-expert pour écrire les pages
+        Agent({
+          subagent_type: "dev-fumadocs-expert",
+          prompt: `Tu écris la section /docs/missions pour vantage-peers-site.
+    Mission : k57abc123 (doc-completion-cedric)
+    Tâche : kTASK_T1 — Écrire les nouvelles pages.
+    Démarre la tâche avec start_task, complète toutes les pages, puis complete_task avec preuve (PR# ou commit SHA).`
+        })
+        ```
+      </Tab>
+    </Tabs>
+  </Step>
+  <Step>
+    ## Suivre la progression
+
+    Vérifiez l'état de la mission et des tâches liées à tout moment :
+
+    ```ts
+    // Obtenir l'aperçu de la mission
+    mcp__vantage-peers__get_mission({ missionId: "k57abc123" })
+    // retourne : { name, status, progress, pilot, agents, ... }
+
+    // Lister toutes les tâches dans la mission
+    mcp__vantage-peers__list_tasks_by_mission({ missionId: "k57abc123" })
+    // retourne : tableau de docs de tâches avec statut actuel
+
+    // Mettre à jour la progression manuellement après la clôture d'une phase
+    mcp__vantage-peers__update_mission_progress({
+      missionId: "k57abc123",
+      progress: 50
+    })
+    ```
+  </Step>
+  <Step>
+    ## Clôturer avec preuves
+
+    Chaque tâche doit se clôturer avec un `completionNote` citant des preuves vérifiables avant que la mission puisse se compléter. Ensuite, faites passer la mission à `validate` (pour une porte de révision) ou directement à `complete`.
+
+    ```ts
+    // Clôturer la tâche de révision avec preuve
+    mcp__vantage-peers__complete_task({
+      taskId: "kTASK_T2",
+      completionNote: "[ETA-APPROVED] PR #127 révisée. 12 nouveaux fichiers MDX (6 EN + 6 FR). 0 liens cassés. Build vert. Commit sha : a1b2c3d."
+    })
+
+    // Passer la mission à validate
+    mcp__vantage-peers__update_mission_status({
+      missionId: "k57abc123",
+      status: "validate"
+    })
+
+    // Après confirmation finale, clôturer la mission
+    mcp__vantage-peers__update_mission_status({
+      missionId: "k57abc123",
+      status: "complete"
+    })
+
+    // Définir la progression à 100
+    mcp__vantage-peers__update_mission_progress({
+      missionId: "k57abc123",
+      progress: 100
+    })
+    ```
+  </Step>
+</Steps>
+
+## Référence des outils
+
+Les six chemins de fonctions de mission, avec un résumé des arguments et des références croisées.
+
+| Outil | Arguments principaux | Retourne | Notes |
+|-------|---------------------|---------|-------|
+| `create_mission` | `name`, `project`, `status`, `priority`, `pilot`, `agents`, `createdBy` | `missionId` (string) | `brief`, `description`, `startDate`, `targetDate` optionnels |
+| `get_mission` | `missionId` | Doc complet de mission ou `null` | Retourne `null` si non trouvé — vérifiez avant de continuer |
+| `list_missions` | `project?`, `pilot?`, `status?`, `limit?`, `fields?` | Tableau de missions | `fields="lite"` pour projection compacte ; alias `status="open"` supporté |
+| `update_mission` | `missionId` + tout champ mutable | `null` | Mise à jour partielle — seuls les champs fournis sont patchés |
+| `update_mission_status` | `missionId`, `status` | `null` | Raccourci — définit le statut + updatedAt de manière atomique |
+| `update_mission_progress` | `missionId`, `progress` (0–100) | `null` | Raccourci — définit la progression + updatedAt de manière atomique |
+
+Pour le schéma complet des arguments et les types de retour, voir [Référence des outils](/docs/tools).
+
+<Callout type="warn">
+`list_missions` se limite automatiquement à `limit=30` quand `fields="full"` et qu'aucune limite explicite n'est définie. Si vous avez besoin de plus de résultats, passez un `limit` explicite ou utilisez `fields="lite"` (limite par défaut de 50).
+</Callout>
+
+## Utiliser le raccourci de template
+
+Si votre mission correspond à un template connu (ex. résolution d'issue, onboarding, build d'extension Chrome), vous pouvez ignorer la création manuelle des tâches en appelant `instantiate_template_into_mission` :
+
+```ts
+// 1. Créer la coquille de mission
+const missionId = mcp__vantage-peers__create_mission({
+  name: "fix-issue-142",
+  project: "vantage-memory",
+  status: "plan",
+  priority: "high",
+  pilot: "proxima",
+  agents: ["proxima"],
+  createdBy: "proxima"
+})
+
+// 2. Instancier le template IRP (9 tâches, pré-câblées avec dependsOn)
+mcp__vantage-peers__instantiate_template_into_mission({
+  templateName: "issue-resolution-v3",
+  missionId,
+  context: { issueNumber: "142", repo: "vantage-memory" },
+  callerOrchestrator: "proxima"
+})
+// retourne : { taskIds: [...], count: 9 }
+```
+
+Voir [Templates de missions](/docs/missions/templates) pour le catalogue complet des templates.

--- a/content/docs/missions/creating-missions.mdx
+++ b/content/docs/missions/creating-missions.mdx
@@ -1,0 +1,245 @@
+---
+title: Creating Missions
+description: Step-by-step how-to for creating a mission, linking tasks with dependsOn, advancing status, tracking progress, and closing with evidence.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout'
+import { Step, Steps } from 'fumadocs-ui/components/steps'
+import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
+
+# Creating Missions
+
+This page covers the full mission lifecycle from creation to evidence-bound closure. All examples use the MCP tool names as called from Claude Code.
+
+<Steps>
+  <Step>
+    ## Create the mission
+
+    Call `create_mission` with the mission's identity, pilot, agents, and initial status. Start in `plan` unless you are just capturing an idea (use `brainstorm` for that).
+
+    ```ts
+    mcp__vantage-peers__create_mission({
+      name: "doc-completion-cedric",
+      description: "Ship Cedric onboarding docs end-to-end: audit, write, review, publish.",
+      pilot: "sigma",
+      agents: ["dev-fumadocs-expert", "eta"],
+      status: "plan",
+      priority: "urgent",
+      project: "vantage-peers-site",
+      brief: "Cedric onboards Monday. Docs must cover missions, tasks, and search. Eta reviews before publish.",
+      createdBy: "sigma"
+    })
+    // returns: "k57abc123..."  (the missionId)
+    ```
+
+    Save the returned `missionId` — you will need it for every subsequent call.
+  </Step>
+  <Step>
+    ## Add tasks linked to the mission
+
+    Create one task per phase. Set `missionId` on every task. Use `dependsOn` to express sequencing — list the IDs of tasks that must reach `done` before this task can start.
+
+    ```ts
+    // T0 — no dependencies, starts immediately
+    const t0 = mcp__vantage-peers__create_task({
+      title: "Audit existing docs",
+      description: "Identify gaps in current /docs content. Output: list of missing pages.",
+      assignedTo: "sigma",
+      priority: "urgent",
+      project: "vantage-peers-site",
+      missionId: "k57abc123",
+      status: "todo",
+      createdBy: "sigma"
+    })
+    // t0 = "kTASK_T0"
+
+    // T1 — depends on T0
+    const t1 = mcp__vantage-peers__create_task({
+      title: "Write new pages",
+      description: "Write all pages identified in the audit. Fumadocs MDX, EN + FR.",
+      assignedTo: "dev-fumadocs-expert",
+      priority: "urgent",
+      project: "vantage-peers-site",
+      missionId: "k57abc123",
+      dependsOn: ["kTASK_T0"],
+      status: "todo",
+      createdBy: "sigma"
+    })
+    // t1 = "kTASK_T1"
+
+    // T2 — depends on T1
+    const t2 = mcp__vantage-peers__create_task({
+      title: "Eta review",
+      description: "Eta reviews all new pages for accuracy, completeness, and EN/FR parity.",
+      assignedTo: "eta",
+      priority: "urgent",
+      project: "vantage-peers-site",
+      missionId: "k57abc123",
+      dependsOn: ["kTASK_T1"],
+      status: "todo",
+      createdBy: "sigma"
+    })
+    // t2 = "kTASK_T2"
+
+    // T3 — depends on T2
+    const t3 = mcp__vantage-peers__create_task({
+      title: "Publish and announce",
+      description: "Merge PR, push to prod, announce to team.",
+      assignedTo: "sigma",
+      priority: "urgent",
+      project: "vantage-peers-site",
+      missionId: "k57abc123",
+      dependsOn: ["kTASK_T2"],
+      status: "todo",
+      createdBy: "sigma"
+    })
+    ```
+
+    The dependency chain: T0 → T1 → T2 → T3. Each task can only begin after its predecessor closes.
+  </Step>
+  <Step>
+    ## Start the mission
+
+    Once tasks are defined, transition the mission from `plan` to `execute`. This signals to all agents that active work should begin.
+
+    ```ts
+    mcp__vantage-peers__update_mission_status({
+      missionId: "k57abc123",
+      status: "execute"
+    })
+    ```
+  </Step>
+  <Step>
+    ## Dispatch work to subagents
+
+    Two patterns depending on whether you dispatch inline or via a new agent session:
+
+    <Tabs items={["Inline dispatch", "Agent tool dispatch"]}>
+      <Tab value="Inline dispatch">
+        Start the first task and begin working it directly in the current session:
+
+        ```ts
+        mcp__vantage-peers__start_task({ taskId: "kTASK_T0" })
+        // ... do the work ...
+        mcp__vantage-peers__complete_task({
+          taskId: "kTASK_T0",
+          completionNote: "Audit complete. Found 6 missing pages: missions/index, missions/what-is-a-mission, missions/when-to-use, missions/creating-missions, missions/templates, missions/examples. Filed in analysis/doc-gaps-2026-05-29.md"
+        })
+        ```
+      </Tab>
+      <Tab value="Agent tool dispatch">
+        Delegate a phase to a subagent by spawning a new agent session with the task context:
+
+        ```ts
+        // Spawn a fumadocs-expert agent to write the pages
+        Agent({
+          subagent_type: "dev-fumadocs-expert",
+          prompt: `You are writing the /docs/missions section for vantage-peers-site.
+    Mission: k57abc123 (doc-completion-cedric)
+    Task: kTASK_T1 — Write new pages.
+    Start the task with start_task, complete all pages, then complete_task with evidence (PR# or commit SHA).`
+        })
+        ```
+      </Tab>
+    </Tabs>
+  </Step>
+  <Step>
+    ## Track progress
+
+    Check mission state and linked tasks at any time:
+
+    ```ts
+    // Get the mission overview
+    mcp__vantage-peers__get_mission({ missionId: "k57abc123" })
+    // returns: { name, status, progress, pilot, agents, ... }
+
+    // List all tasks in the mission
+    mcp__vantage-peers__list_tasks_by_mission({ missionId: "k57abc123" })
+    // returns: array of task docs with current status
+
+    // Update progress manually after a phase closes
+    mcp__vantage-peers__update_mission_progress({
+      missionId: "k57abc123",
+      progress: 50
+    })
+    ```
+  </Step>
+  <Step>
+    ## Close evidence-bound
+
+    Every task must close with a `completionNote` that cites verifiable evidence before the mission can complete. Then move the mission to `validate` (for a review gate) or directly to `complete`.
+
+    ```ts
+    // Close the review task with evidence
+    mcp__vantage-peers__complete_task({
+      taskId: "kTASK_T2",
+      completionNote: "[ETA-APPROVED] PR #127 reviewed. 12 new MDX files (6 EN + 6 FR). 0 broken links. Build green. Commit sha: a1b2c3d."
+    })
+
+    // Move mission to validate
+    mcp__vantage-peers__update_mission_status({
+      missionId: "k57abc123",
+      status: "validate"
+    })
+
+    // After final confirmation, close the mission
+    mcp__vantage-peers__update_mission_status({
+      missionId: "k57abc123",
+      status: "complete"
+    })
+
+    // Set progress to 100
+    mcp__vantage-peers__update_mission_progress({
+      missionId: "k57abc123",
+      progress: 100
+    })
+    ```
+  </Step>
+</Steps>
+
+## Tool reference
+
+All six mission function paths, with arguments summary and cross-links.
+
+| Tool | Key args | Returns | Notes |
+|------|----------|---------|-------|
+| `create_mission` | `name`, `project`, `status`, `priority`, `pilot`, `agents`, `createdBy` | `missionId` (string) | `brief`, `description`, `startDate`, `targetDate` optional |
+| `get_mission` | `missionId` | Full mission doc or `null` | Returns `null` if not found — check before proceeding |
+| `list_missions` | `project?`, `pilot?`, `status?`, `limit?`, `fields?` | Array of missions | `fields="lite"` for compact projection; `status="open"` alias supported |
+| `update_mission` | `missionId` + any mutable field | `null` | Partial update — only provided fields are patched |
+| `update_mission_status` | `missionId`, `status` | `null` | Shortcut — sets status + updatedAt atomically |
+| `update_mission_progress` | `missionId`, `progress` (0–100) | `null` | Shortcut — sets progress + updatedAt atomically |
+
+For the full argument schema and return types, see [Tools Reference](/docs/tools).
+
+<Callout type="warn">
+`list_missions` auto-clamps to `limit=30` when `fields="full"` and no explicit limit is set. If you need more results, pass an explicit `limit` or use `fields="lite"` (limit=50 default).
+</Callout>
+
+## Using the template shortcut
+
+If your mission matches a known template (e.g. issue resolution, onboarding, chrome extension build), you can skip manual task creation by calling `instantiate_template_into_mission`:
+
+```ts
+// 1. Create the mission shell
+const missionId = mcp__vantage-peers__create_mission({
+  name: "fix-issue-142",
+  project: "vantage-memory",
+  status: "plan",
+  priority: "high",
+  pilot: "proxima",
+  agents: ["proxima"],
+  createdBy: "proxima"
+})
+
+// 2. Instantiate the IRP template (9 tasks, pre-wired with dependsOn)
+mcp__vantage-peers__instantiate_template_into_mission({
+  templateName: "issue-resolution-v3",
+  missionId,
+  context: { issueNumber: "142", repo: "vantage-memory" },
+  callerOrchestrator: "proxima"
+})
+// returns: { taskIds: [...], count: 9 }
+```
+
+See [Mission Templates](/docs/missions/templates) for the full template catalog.

--- a/content/docs/missions/examples.fr.mdx
+++ b/content/docs/missions/examples.fr.mdx
@@ -1,0 +1,403 @@
+---
+title: Exemples de missions
+description: Trois exemples de missions entièrement travaillés — lancement client, déploiement de fonctionnalité par sprints, et un audit système multi-agents avec tâches parallèles.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout'
+import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
+
+# Exemples de missions
+
+---
+
+## Exemple 1 : Lancement client (petite mission, 4 tâches)
+
+**Scénario :** Intégrer le client Acme Corp — appel de lancement, document de périmètre, premier livrable, rapport de statut.
+
+**Profil de mission :** 4 tâches séquentielles, pilote unique.
+
+### Séquençage
+
+```
+T0  appel-de-lancement   [pas de dépendances]
+  ↓
+T1  document-perimetre   [dependsOn: T0]
+  ↓
+T2  premier-livrable     [dependsOn: T1]
+  ↓
+T3  rapport-statut       [dependsOn: T2]
+```
+
+### Appels d'outils
+
+```ts
+// 1. Créer la mission
+const missionId = mcp__vantage-peers__create_mission({
+  name: "kickoff-client-acme",
+  description: "Intégrer Acme Corp : appel de lancement, doc de périmètre, premier livrable, rapport de statut.",
+  pilot: "sigma",
+  agents: ["sigma", "dev-general"],
+  status: "plan",
+  priority: "high",
+  project: "acme-corp",
+  brief: "Contact Acme : Marie. Lancement confirmé. Premier livrable = wireframe landing page.",
+  createdBy: "sigma"
+})
+// missionId = "kMISS_ACME"
+
+// 2. Créer les tâches
+const t0 = mcp__vantage-peers__create_task({
+  title: "Appel de lancement avec Acme",
+  description: "Animer 1h d'appel de lancement. Enregistrer les résultats. Noter les bloqueurs et questions ouvertes.",
+  assignedTo: "sigma",
+  priority: "high",
+  project: "acme-corp",
+  missionId: "kMISS_ACME",
+  status: "todo",
+  createdBy: "sigma"
+})
+// t0 = "kT_ACME_0"
+
+const t1 = mcp__vantage-peers__create_task({
+  title: "Rédiger le document de périmètre",
+  description: "Basé sur les notes de lancement : objectifs, livrables, calendrier, budget, hors périmètre.",
+  assignedTo: "sigma",
+  priority: "high",
+  project: "acme-corp",
+  missionId: "kMISS_ACME",
+  dependsOn: ["kT_ACME_0"],
+  status: "todo",
+  createdBy: "sigma"
+})
+
+const t2 = mcp__vantage-peers__create_task({
+  title: "Livrer le wireframe landing page",
+  description: "Wireframe Figma couvrant hero, fonctionnalités, pricing, CTA. Approbation client requise.",
+  assignedTo: "dev-general",
+  priority: "high",
+  project: "acme-corp",
+  missionId: "kMISS_ACME",
+  dependsOn: ["kT_ACME_1"],
+  status: "todo",
+  createdBy: "sigma"
+})
+
+const t3 = mcp__vantage-peers__create_task({
+  title: "Envoyer le rapport de statut Semaine 1",
+  description: "Rapport email : ce qui a été fait, la suite, les éventuels bloqueurs.",
+  assignedTo: "sigma",
+  priority: "medium",
+  project: "acme-corp",
+  missionId: "kMISS_ACME",
+  dependsOn: ["kT_ACME_2"],
+  status: "todo",
+  createdBy: "sigma"
+})
+
+// 3. Démarrer l'exécution
+mcp__vantage-peers__update_mission_status({
+  missionId: "kMISS_ACME",
+  status: "execute"
+})
+```
+
+### Sortie attendue après la clôture de T0
+
+```ts
+mcp__vantage-peers__complete_task({
+  taskId: "kT_ACME_0",
+  completionNote: "Appel de lancement terminé le 2026-05-29. Notes dans acme/kickoff-notes-2026-05-29.md. Résultat clé : livraison du wireframe landing page confirmée, budget 5k€."
+})
+
+mcp__vantage-peers__update_mission_progress({ missionId: "kMISS_ACME", progress: 25 })
+```
+
+---
+
+## Exemple 2 : Déployer une fonctionnalité produit (mission moyenne, 12 tâches par phases)
+
+**Scénario :** Déployer la fonctionnalité "recherches sauvegardées" pour VantagePeers — spec, backend, frontend, tests, révision, déploiement.
+
+**Profil de mission :** 12 tâches en 5 phases, 2 agents (dev + eta).
+
+### Structure des phases
+
+```
+Phase 1 — Plan (1 tâche)
+  T0  feature-spec            [pas de dépendances]
+
+Phase 2 — Build (4 tâches)
+  T1  backend-schema          [dependsOn: T0]
+  T2  backend-mutations       [dependsOn: T1]
+  T3  frontend-ui             [dependsOn: T0]   ← parallèle avec T1, T2
+  T4  frontend-integration    [dependsOn: T2, T3]
+
+Phase 3 — Test (2 tâches)
+  T5  unit-tests              [dependsOn: T4]
+  T6  integration-tests       [dependsOn: T4]
+
+Phase 4 — Révision (2 tâches)
+  T7  code-review-eta         [dependsOn: T5, T6]   ← barrière : les deux tâches de test doivent d'abord se fermer
+  T8  address-review-feedback [dependsOn: T7]
+
+Phase 5 — Déploiement (3 tâches)
+  T9   deploy-staging         [dependsOn: T8]
+  T10  qa-staging             [dependsOn: T9]
+  T11  deploy-production      [dependsOn: T10]
+```
+
+### Mise en place de la mission
+
+```ts
+const missionId = mcp__vantage-peers__create_mission({
+  name: "sigma-saved-searches-v1",
+  description: "Déployer la fonctionnalité de recherches sauvegardées : mutations backend + UI frontend + tests + révision + déploiement.",
+  pilot: "sigma",
+  agents: ["zeta", "eta"],
+  status: "plan",
+  priority: "high",
+  project: "vantage-peers",
+  brief: "Recherches sauvegardées : l'utilisateur peut sauvegarder une requête de recherche avec un nom et la rappeler depuis un menu déroulant. Backend : nouvelle table savedSearches + mutations CRUD. Frontend : menu déroulant React dans la barre de recherche.",
+  createdBy: "sigma"
+})
+```
+
+### Transitions de statut
+
+```ts
+// Plan → Execute quand T0 est terminé
+mcp__vantage-peers__update_mission_status({ missionId, status: "execute" })
+mcp__vantage-peers__update_mission_progress({ missionId, progress: 10 })
+
+// Après la complétion de la Phase 2 (T1–T4 terminés)
+mcp__vantage-peers__update_mission_progress({ missionId, progress: 40 })
+
+// Après la complétion de la Phase 3 (T5, T6 terminés) — passer à validate
+mcp__vantage-peers__update_mission_status({ missionId, status: "validate" })
+mcp__vantage-peers__update_mission_progress({ missionId, progress: 60 })
+
+// Après T11 — clôturer la mission
+mcp__vantage-peers__complete_task({
+  taskId: "kT11",
+  completionNote: "Déployé en prod le 2026-06-03. PR #211 fusionnée. 47/47 tests passent. Fonctionnalité live à /search?saved=true. Smoke test confirmé."
+})
+mcp__vantage-peers__update_mission_status({ missionId, status: "complete" })
+mcp__vantage-peers__update_mission_progress({ missionId, progress: 100 })
+```
+
+### Comment les agents se mappent aux tâches
+
+```
+sigma    → T0 (spec), T8 (corriger les retours de révision), T11 (déploiement prod)
+zeta     → T1–T4 (construction), T5–T6 (tests), T9 (déploiement staging), T10 (QA)
+eta      → T7 (revue de code)
+```
+
+Le tableau `agents: ["zeta", "eta"]` de la mission déclare qui sera déployé. Le pilote (sigma) coordonne les transferts entre les phases.
+
+---
+
+## Exemple 3 : Audit système + remédiation (grande mission, parallèle multi-agents)
+
+**Scénario :** Auditer la flotte VantageOS (3 dépôts) et déployer tous les correctifs critiques. Trois tâches d'audit parallèles s'exécutent simultanément, puis une barrière, puis des tâches de correctif séquentielles, puis la QA finale.
+
+**Profil de mission :** 11 tâches, 3 orchestrateurs (proxima × auditeur, zeta × correcteur, eta × réviseur).
+
+### Architecture : pattern parallèle-puis-barrière
+
+```
+T0  audit-vantage-memory     [pas de dépendances]  ─┐
+T1  audit-vantage-starter    [pas de dépendances]  ─┤→ (phase d'audit parallèle)
+T2  audit-myreeldream        [pas de dépendances]  ─┘
+                                                      ↓ BARRIÈRE (les 3 doivent se fermer)
+T3  compile-findings         [dependsOn: T0, T1, T2]
+                                                      ↓
+T4  fix-critical-memory      [dependsOn: T3]  ─┐
+T5  fix-critical-starter     [dependsOn: T3]  ─┤→ (phase de correctifs parallèle)
+T6  fix-critical-reel        [dependsOn: T3]  ─┘
+                                                      ↓ BARRIÈRE (les 3 correctifs doivent se fermer)
+T7  regression-tests-all     [dependsOn: T4, T5, T6]
+T8  code-review-eta          [dependsOn: T7]
+T9  deploy-all-fixes         [dependsOn: T8]
+T10 final-qa-report          [dependsOn: T9]
+```
+
+### Mise en place de la mission
+
+```ts
+const missionId = mcp__vantage-peers__create_mission({
+  name: "audit-fleet-2026-05",
+  description: "Auditer 3 dépôts VantageOS pour les problèmes critiques, corriger tous les résultats P0/P1, QA et déploiement.",
+  pilot: "sigma",
+  agents: ["proxima", "zeta", "eta"],
+  status: "plan",
+  priority: "urgent",
+  project: "vantageos-fleet",
+  brief: "Audit mensuel de la flotte. Périmètre : vantage-memory, vantage-starter, myreeldream. P0 = perte de données ou sécurité. P1 = fonctionnalités cassées. Corriger tous les P0/P1 avant la porte QA.",
+  createdBy: "sigma"
+})
+```
+
+### Tâches d'audit parallèles (pas de dependsOn entre elles)
+
+```ts
+const t0 = mcp__vantage-peers__create_task({
+  title: "Auditer vantage-memory",
+  description: "Audit complet : schéma, mutations, logs d'erreurs, issues ouvertes. Sortie : findings-vantage-memory.md",
+  assignedTo: "proxima",
+  priority: "urgent",
+  project: "vantageos-fleet",
+  missionId,
+  status: "todo",
+  createdBy: "sigma"
+})
+// Note : pas de dependsOn — démarre immédiatement en parallèle
+
+const t1 = mcp__vantage-peers__create_task({
+  title: "Auditer vantage-starter",
+  description: "Audit complet : dépendances, config de déploiement, issues ouvertes. Sortie : findings-vantage-starter.md",
+  assignedTo: "zeta",
+  priority: "urgent",
+  project: "vantageos-fleet",
+  missionId,
+  status: "todo",
+  createdBy: "sigma"
+  // pas de dependsOn — parallèle avec T0
+})
+
+const t2 = mcp__vantage-peers__create_task({
+  title: "Auditer myreeldream",
+  description: "Audit complet : intégrations API, taux d'erreur, issues ouvertes. Sortie : findings-myreeldream.md",
+  assignedTo: "proxima",
+  priority: "urgent",
+  project: "vantageos-fleet",
+  missionId,
+  status: "todo",
+  createdBy: "sigma"
+  // pas de dependsOn — parallèle avec T0, T1
+})
+```
+
+### Tâche barrière
+
+```ts
+const t3 = mcp__vantage-peers__create_task({
+  title: "Compiler les résultats d'audit",
+  description: "Fusionner les 3 docs de résultats. Prioriser P0/P1. Assigner les correctifs aux agents. Sortie : audit-consolidated-2026-05.md",
+  assignedTo: "sigma",
+  priority: "urgent",
+  project: "vantageos-fleet",
+  missionId,
+  dependsOn: [t0, t1, t2],  // BARRIÈRE — les 3 audits doivent se terminer d'abord
+  status: "todo",
+  createdBy: "sigma"
+})
+```
+
+### Tâches de correctifs parallèles (même barrière, pas de dependsOn mutuels)
+
+```ts
+// T4, T5, T6 dépendent tous de T3 (la barrière) mais PAS les uns des autres
+const t4 = mcp__vantage-peers__create_task({
+  title: "Corriger P0/P1 dans vantage-memory",
+  description: "Traiter tous les résultats P0/P1 de l'audit. PR requise. Protocole IRP applicable.",
+  assignedTo: "proxima",
+  priority: "urgent",
+  project: "vantageos-fleet",
+  missionId,
+  dependsOn: [t3],
+  status: "todo",
+  createdBy: "sigma"
+})
+
+const t5 = mcp__vantage-peers__create_task({
+  title: "Corriger P0/P1 dans vantage-starter",
+  description: "Traiter tous les résultats P0/P1 de l'audit. PR requise.",
+  assignedTo: "zeta",
+  priority: "urgent",
+  project: "vantageos-fleet",
+  missionId,
+  dependsOn: [t3],  // même barrière, PAS dependsOn T4
+  status: "todo",
+  createdBy: "sigma"
+})
+
+const t6 = mcp__vantage-peers__create_task({
+  title: "Corriger P0/P1 dans myreeldream",
+  description: "Traiter tous les résultats P0/P1 de l'audit. PR requise.",
+  assignedTo: "proxima",
+  priority: "urgent",
+  project: "vantageos-fleet",
+  missionId,
+  dependsOn: [t3],  // même barrière, PAS dependsOn T4 ou T5
+  status: "todo",
+  createdBy: "sigma"
+})
+```
+
+### Deuxième barrière + chaîne QA
+
+```ts
+const t7 = mcp__vantage-peers__create_task({
+  title: "Exécuter les tests de régression sur les 3 dépôts",
+  description: "Suite de tests complète sur les 3 dépôts. Zéro régression. Documenter les résultats.",
+  assignedTo: "zeta",
+  priority: "urgent",
+  project: "vantageos-fleet",
+  missionId,
+  dependsOn: [t4, t5, t6],  // deuxième barrière — les 3 correctifs doivent se fermer
+  status: "todo",
+  createdBy: "sigma"
+})
+
+const t8 = mcp__vantage-peers__create_task({
+  title: "Revue de code de toutes les PRs de correctifs",
+  description: "Eta révise les 3 PRs de correctifs. Traiter les retours bloquants. Documenter [ETA-APPROVED].",
+  assignedTo: "eta",
+  priority: "urgent",
+  project: "vantageos-fleet",
+  missionId,
+  dependsOn: [t7],
+  status: "todo",
+  createdBy: "sigma"
+})
+
+const t9 = mcp__vantage-peers__create_task({
+  title: "Déployer tous les correctifs en production",
+  description: "Fusionner toutes les PRs. Déployer. Smoke test sur chaque dépôt.",
+  assignedTo: "sigma",
+  priority: "urgent",
+  project: "vantageos-fleet",
+  missionId,
+  dependsOn: [t8],
+  status: "todo",
+  createdBy: "sigma"
+})
+
+const t10 = mcp__vantage-peers__create_task({
+  title: "Rédiger le rapport QA final",
+  description: "Documenter tous les correctifs déployés, tests exécutés et état de la flotte. Stocker dans analysis/fleet-audit-2026-05-report.md",
+  assignedTo: "sigma",
+  priority: "high",
+  project: "vantageos-fleet",
+  missionId,
+  dependsOn: [t9],
+  status: "todo",
+  createdBy: "sigma"
+})
+```
+
+### Explication du pattern clé
+
+Les tâches au même niveau avec le même `dependsOn` s'exécutent en **parallèle** — pas d'ordre entre elles. Les tâches qui listent plusieurs prédécesseurs dans `dependsOn` sont des **barrières** — elles bloquent jusqu'à ce que chaque prédécesseur soit `done`.
+
+```
+Parallèle :  T0, T1, T2 n'ont PAS de dependsOn entre eux → fan out
+Barrière :   T3 dependsOn [T0, T1, T2]  → attend les trois → fan in
+Parallèle :  T4, T5, T6 partagent dependsOn [T3] uniquement → fan out à nouveau
+Barrière :   T7 dependsOn [T4, T5, T6]  → deuxième fan in
+```
+
+<Callout type="info">
+Le pattern parallèle-puis-barrière est la façon standard de distribuer le travail entre les agents et de synchroniser avant une porte de révision. Utilisez-le chaque fois que vous avez du travail indépendant qui doit tout se terminer avant qu'une prochaine phase commence.
+</Callout>

--- a/content/docs/missions/examples.mdx
+++ b/content/docs/missions/examples.mdx
@@ -1,0 +1,403 @@
+---
+title: Mission Examples
+description: Three fully worked mission examples — client kickoff, feature ship across sprints, and a multi-agent system audit with parallel tasks.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout'
+import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
+
+# Mission Examples
+
+---
+
+## Example 1: Client kickoff (small mission, 4 tasks)
+
+**Scenario:** Onboard client Acme Corp — kickoff call, scope document, first deliverable, status report.
+
+**Mission profile:** 4 sequential tasks, single pilot.
+
+### Sequencing
+
+```
+T0  onboarding-call      [no deps]
+  ↓
+T1  scope-document       [dependsOn: T0]
+  ↓
+T2  first-deliverable    [dependsOn: T1]
+  ↓
+T3  status-report        [dependsOn: T2]
+```
+
+### Tool calls
+
+```ts
+// 1. Create the mission
+const missionId = mcp__vantage-peers__create_mission({
+  name: "kickoff-client-acme",
+  description: "Onboard Acme Corp: kickoff call, scope doc, first deliverable, status report.",
+  pilot: "sigma",
+  agents: ["sigma", "dev-general"],
+  status: "plan",
+  priority: "high",
+  project: "acme-corp",
+  brief: "Acme contact: Marie. Kickoff confirmed. First deliverable = landing page wireframe.",
+  createdBy: "sigma"
+})
+// missionId = "kMISS_ACME"
+
+// 2. Create tasks
+const t0 = mcp__vantage-peers__create_task({
+  title: "Onboarding call with Acme",
+  description: "Run 1h kickoff call. Record outcomes. Note blockers and open questions.",
+  assignedTo: "sigma",
+  priority: "high",
+  project: "acme-corp",
+  missionId: "kMISS_ACME",
+  status: "todo",
+  createdBy: "sigma"
+})
+// t0 = "kT_ACME_0"
+
+const t1 = mcp__vantage-peers__create_task({
+  title: "Write scope document",
+  description: "Based on kickoff notes: goals, deliverables, timeline, budget, out-of-scope.",
+  assignedTo: "sigma",
+  priority: "high",
+  project: "acme-corp",
+  missionId: "kMISS_ACME",
+  dependsOn: ["kT_ACME_0"],
+  status: "todo",
+  createdBy: "sigma"
+})
+
+const t2 = mcp__vantage-peers__create_task({
+  title: "Deliver landing page wireframe",
+  description: "Figma wireframe covering hero, features, pricing, CTA. Client approval required.",
+  assignedTo: "dev-general",
+  priority: "high",
+  project: "acme-corp",
+  missionId: "kMISS_ACME",
+  dependsOn: ["kT_ACME_1"],
+  status: "todo",
+  createdBy: "sigma"
+})
+
+const t3 = mcp__vantage-peers__create_task({
+  title: "Send Week 1 status report",
+  description: "Email report: what was done, what is next, any blockers.",
+  assignedTo: "sigma",
+  priority: "medium",
+  project: "acme-corp",
+  missionId: "kMISS_ACME",
+  dependsOn: ["kT_ACME_2"],
+  status: "todo",
+  createdBy: "sigma"
+})
+
+// 3. Start execution
+mcp__vantage-peers__update_mission_status({
+  missionId: "kMISS_ACME",
+  status: "execute"
+})
+```
+
+### Expected output after T0 closes
+
+```ts
+mcp__vantage-peers__complete_task({
+  taskId: "kT_ACME_0",
+  completionNote: "Kickoff call completed 2026-05-29. Notes in acme/kickoff-notes-2026-05-29.md. Key outcome: landing page wireframe delivery confirmed, budget €5k."
+})
+
+mcp__vantage-peers__update_mission_progress({ missionId: "kMISS_ACME", progress: 25 })
+```
+
+---
+
+## Example 2: Ship a product feature (medium mission, 12 tasks across phases)
+
+**Scenario:** Ship the "saved searches" feature for VantagePeers — spec, backend, frontend, tests, review, deploy.
+
+**Mission profile:** 12 tasks in 5 phases, 2 agents (dev + eta).
+
+### Phase structure
+
+```
+Phase 1 — Plan (1 task)
+  T0  feature-spec            [no deps]
+
+Phase 2 — Build (4 tasks)
+  T1  backend-schema          [dependsOn: T0]
+  T2  backend-mutations       [dependsOn: T1]
+  T3  frontend-ui             [dependsOn: T0]   ← parallel with T1, T2
+  T4  frontend-integration    [dependsOn: T2, T3]
+
+Phase 3 — Test (2 tasks)
+  T5  unit-tests              [dependsOn: T4]
+  T6  integration-tests       [dependsOn: T4]
+
+Phase 4 — Review (2 tasks)
+  T7  code-review-eta         [dependsOn: T5, T6]   ← barrier: both test tasks must close first
+  T8  address-review-feedback [dependsOn: T7]
+
+Phase 5 — Ship (3 tasks)
+  T9   deploy-staging         [dependsOn: T8]
+  T10  qa-staging             [dependsOn: T9]
+  T11  deploy-production      [dependsOn: T10]
+```
+
+### Mission setup
+
+```ts
+const missionId = mcp__vantage-peers__create_mission({
+  name: "sigma-saved-searches-v1",
+  description: "Ship saved searches feature: backend mutations + frontend UI + tests + review + deploy.",
+  pilot: "sigma",
+  agents: ["zeta", "eta"],
+  status: "plan",
+  priority: "high",
+  project: "vantage-peers",
+  brief: "Saved searches: user can save a search query with a name and recall it from a dropdown. Backend: new savedSearches table + CRUD mutations. Frontend: React dropdown in the search bar.",
+  createdBy: "sigma"
+})
+```
+
+### Status transitions
+
+```ts
+// Plan → Execute when T0 is done
+mcp__vantage-peers__update_mission_status({ missionId, status: "execute" })
+mcp__vantage-peers__update_mission_progress({ missionId, progress: 10 })
+
+// After Phase 2 completes (T1–T4 done)
+mcp__vantage-peers__update_mission_progress({ missionId, progress: 40 })
+
+// After Phase 3 completes (T5, T6 done) — move to validate
+mcp__vantage-peers__update_mission_status({ missionId, status: "validate" })
+mcp__vantage-peers__update_mission_progress({ missionId, progress: 60 })
+
+// After T11 — close the mission
+mcp__vantage-peers__complete_task({
+  taskId: "kT11",
+  completionNote: "Deployed to prod 2026-06-03. PR #211 merged. 47/47 tests pass. Feature live at /search?saved=true. Smoke test confirmed."
+})
+mcp__vantage-peers__update_mission_status({ missionId, status: "complete" })
+mcp__vantage-peers__update_mission_progress({ missionId, progress: 100 })
+```
+
+### How agents map to tasks
+
+```
+sigma    → T0 (spec), T8 (address feedback), T11 (deploy prod)
+zeta     → T1–T4 (build), T5–T6 (tests), T9 (deploy staging), T10 (QA)
+eta      → T7 (code review)
+```
+
+The mission's `agents: ["zeta", "eta"]` array declares who will be dispatched. The pilot (sigma) coordinates handoffs between phases.
+
+---
+
+## Example 3: System audit + remediation (large mission, multi-agent parallel)
+
+**Scenario:** Audit the VantageOS fleet (3 repos) and ship all critical fixes. Three parallel audit tasks run simultaneously, then a barrier, then sequential fix tasks, then final QA.
+
+**Mission profile:** 11 tasks, 3 orchestrators (proxima × auditor, zeta × fixer, eta × reviewer).
+
+### Architecture: parallel-then-barrier pattern
+
+```
+T0  audit-vantage-memory     [no deps]  ─┐
+T1  audit-vantage-starter    [no deps]  ─┤→ (parallel audit phase)
+T2  audit-myreeldream        [no deps]  ─┘
+                                          ↓ BARRIER (all 3 must close)
+T3  compile-findings         [dependsOn: T0, T1, T2]
+                                          ↓
+T4  fix-critical-memory      [dependsOn: T3]  ─┐
+T5  fix-critical-starter     [dependsOn: T3]  ─┤→ (parallel fix phase)
+T6  fix-critical-reel        [dependsOn: T3]  ─┘
+                                          ↓ BARRIER (all 3 fixes must close)
+T7  regression-tests-all     [dependsOn: T4, T5, T6]
+T8  code-review-eta          [dependsOn: T7]
+T9  deploy-all-fixes         [dependsOn: T8]
+T10 final-qa-report          [dependsOn: T9]
+```
+
+### Mission setup
+
+```ts
+const missionId = mcp__vantage-peers__create_mission({
+  name: "audit-fleet-2026-05",
+  description: "Audit 3 VantageOS repos for critical issues, fix all P0/P1 findings, QA and deploy.",
+  pilot: "sigma",
+  agents: ["proxima", "zeta", "eta"],
+  status: "plan",
+  priority: "urgent",
+  project: "vantageos-fleet",
+  brief: "Monthly fleet audit. Scope: vantage-memory, vantage-starter, myreeldream. P0 = data loss or security. P1 = broken features. Fix all P0/P1 before QA gate.",
+  createdBy: "sigma"
+})
+```
+
+### Parallel audit tasks (no dependsOn between siblings)
+
+```ts
+const t0 = mcp__vantage-peers__create_task({
+  title: "Audit vantage-memory",
+  description: "Run full audit: schema, mutations, error logs, open issues. Output: findings-vantage-memory.md",
+  assignedTo: "proxima",
+  priority: "urgent",
+  project: "vantageos-fleet",
+  missionId,
+  status: "todo",
+  createdBy: "sigma"
+})
+// Note: no dependsOn — starts immediately in parallel
+
+const t1 = mcp__vantage-peers__create_task({
+  title: "Audit vantage-starter",
+  description: "Run full audit: dependencies, deployment config, open issues. Output: findings-vantage-starter.md",
+  assignedTo: "zeta",
+  priority: "urgent",
+  project: "vantageos-fleet",
+  missionId,
+  status: "todo",
+  createdBy: "sigma"
+  // no dependsOn — parallel with T0
+})
+
+const t2 = mcp__vantage-peers__create_task({
+  title: "Audit myreeldream",
+  description: "Run full audit: API integrations, error rates, open issues. Output: findings-myreeldream.md",
+  assignedTo: "proxima",
+  priority: "urgent",
+  project: "vantageos-fleet",
+  missionId,
+  status: "todo",
+  createdBy: "sigma"
+  // no dependsOn — parallel with T0, T1
+})
+```
+
+### Barrier task
+
+```ts
+const t3 = mcp__vantage-peers__create_task({
+  title: "Compile audit findings",
+  description: "Merge all 3 findings docs. Prioritize P0/P1. Assign fixes to agents. Output: audit-consolidated-2026-05.md",
+  assignedTo: "sigma",
+  priority: "urgent",
+  project: "vantageos-fleet",
+  missionId,
+  dependsOn: [t0, t1, t2],  // BARRIER — all 3 audits must complete first
+  status: "todo",
+  createdBy: "sigma"
+})
+```
+
+### Parallel fix tasks (same barrier, no mutual dependsOn)
+
+```ts
+// T4, T5, T6 all depend on T3 (the barrier) but NOT on each other — they run in parallel
+const t4 = mcp__vantage-peers__create_task({
+  title: "Fix P0/P1 in vantage-memory",
+  description: "Address all P0/P1 findings from audit. PR required. IRP protocol applies.",
+  assignedTo: "proxima",
+  priority: "urgent",
+  project: "vantageos-fleet",
+  missionId,
+  dependsOn: [t3],
+  status: "todo",
+  createdBy: "sigma"
+})
+
+const t5 = mcp__vantage-peers__create_task({
+  title: "Fix P0/P1 in vantage-starter",
+  description: "Address all P0/P1 findings from audit. PR required.",
+  assignedTo: "zeta",
+  priority: "urgent",
+  project: "vantageos-fleet",
+  missionId,
+  dependsOn: [t3],  // same barrier, NOT dependsOn T4
+  status: "todo",
+  createdBy: "sigma"
+})
+
+const t6 = mcp__vantage-peers__create_task({
+  title: "Fix P0/P1 in myreeldream",
+  description: "Address all P0/P1 findings from audit. PR required.",
+  assignedTo: "proxima",
+  priority: "urgent",
+  project: "vantageos-fleet",
+  missionId,
+  dependsOn: [t3],  // same barrier, NOT dependsOn T4 or T5
+  status: "todo",
+  createdBy: "sigma"
+})
+```
+
+### Second barrier + QA chain
+
+```ts
+const t7 = mcp__vantage-peers__create_task({
+  title: "Run regression tests across all 3 repos",
+  description: "Full test suite on all 3 repos. Zero regressions. Document results.",
+  assignedTo: "zeta",
+  priority: "urgent",
+  project: "vantageos-fleet",
+  missionId,
+  dependsOn: [t4, t5, t6],  // second barrier — all 3 fixes must close
+  status: "todo",
+  createdBy: "sigma"
+})
+
+const t8 = mcp__vantage-peers__create_task({
+  title: "Code review all fix PRs",
+  description: "Eta reviews all 3 fix PRs. Address blocking feedback. Document [ETA-APPROVED].",
+  assignedTo: "eta",
+  priority: "urgent",
+  project: "vantageos-fleet",
+  missionId,
+  dependsOn: [t7],
+  status: "todo",
+  createdBy: "sigma"
+})
+
+const t9 = mcp__vantage-peers__create_task({
+  title: "Deploy all fixes to production",
+  description: "Merge all PRs. Deploy. Smoke test each repo.",
+  assignedTo: "sigma",
+  priority: "urgent",
+  project: "vantageos-fleet",
+  missionId,
+  dependsOn: [t8],
+  status: "todo",
+  createdBy: "sigma"
+})
+
+const t10 = mcp__vantage-peers__create_task({
+  title: "Write final QA report",
+  description: "Document all fixes shipped, tests run, and fleet status. Store in analysis/fleet-audit-2026-05-report.md",
+  assignedTo: "sigma",
+  priority: "high",
+  project: "vantageos-fleet",
+  missionId,
+  dependsOn: [t9],
+  status: "todo",
+  createdBy: "sigma"
+})
+```
+
+### Key pattern explained
+
+Tasks at the same level with the same `dependsOn` run in **parallel** — no ordering between them. Tasks that list multiple predecessors in `dependsOn` are **barriers** — they block until every predecessor is `done`.
+
+```
+Parallel:  T0, T1, T2 have NO dependsOn between each other → fan out
+Barrier:   T3 dependsOn [T0, T1, T2]  → waits for all three → fan in
+Parallel:  T4, T5, T6 share dependsOn [T3] only → fan out again
+Barrier:   T7 dependsOn [T4, T5, T6]  → second fan in
+```
+
+<Callout type="info">
+The parallel-then-barrier pattern is the standard way to fan out work across agents and synchronize before a review gate. Use it any time you have independent work that must all complete before a next phase begins.
+</Callout>

--- a/content/docs/missions/index.fr.mdx
+++ b/content/docs/missions/index.fr.mdx
@@ -1,0 +1,77 @@
+---
+title: Missions
+description: Corps de travail orchestrés en plusieurs étapes — templates, tâches séquencées et complétion liée à des preuves pour votre flotte d'agents IA.
+---
+
+import { Card, Cards } from 'fumadocs-ui/components/card'
+import { Callout } from 'fumadocs-ui/components/callout'
+
+# Missions
+
+Une mission est un corps de travail orchestré — un template + brief + tâches séquencées avec dépendances, géré par un pilote orchestrateur, suivi par statut.
+
+Là où une tâche est une action atomique unique ("corriger ce bug"), une mission est une livraison de bout en bout ("investiguer, corriger, tester et déployer ce bug en 9 étapes structurées"). Les missions donnent à votre flotte d'agents un cadre de référence commun : tout le monde connaît l'objectif, la séquence et la progression actuelle.
+
+## Quand utiliser les missions
+
+Utilisez une mission lorsqu'au moins deux des conditions suivantes sont vraies :
+
+- **Travail en plusieurs étapes** — l'objectif nécessite plus d'une action distincte, et certaines étapes doivent précéder d'autres.
+- **Coordination multi-agents** — différents orchestrateurs ou types de sous-agents gèrent différentes phases (dev, review, QA, déploiement).
+- **Complétion liée à des preuves requise** — les livrables doivent citer un commit SHA, numéro de PR, ratio de tests ou chemin de fichier avant que la mission puisse se fermer.
+- **Les livrables s'étendent sur 3 jours ou plus** — un effort longue durée nécessite un objet de suivi persistant pour que la progression survive aux redémarrages de session.
+
+## Quand NE PAS utiliser les missions
+
+Si le travail est une seule étape qu'un agent peut accomplir en une session, utilisez une tâche. Les missions impliquent une surcharge — attribution de pilote, cycle de vie du statut, suivi de la progression — qui est inutile pour les actions atomiques.
+
+```
+Action unique, un agent, une session   →  create_task
+Multi-étapes, multi-agents, 3+ jours  →  create_mission + tâches liées
+```
+
+## Exemple rapide
+
+Sigma lance une mission "doc-completion-cedric" avec 4 tâches de phase (audit / écriture / révision / publication). Chaque tâche porte un `missionId` la reliant à la mission et un `dependsOn` pointant vers son prédécesseur. Le statut de la mission passe par `plan → execute → validate → complete` au fur et à mesure que les tâches se ferment. La progression est un pourcentage manuel mis à jour via `update_mission_progress`.
+
+```
+Mission : doc-completion-cedric  [execute, 50%]
+  T0  audit-existing-docs        [done]
+  T1  write-new-pages            [in_progress]  dependsOn: [T0]
+  T2  review-by-eta              [todo]         dependsOn: [T1]
+  T3  publish-and-announce       [todo]         dependsOn: [T2]
+```
+
+## Pages de cette section
+
+<Cards>
+  <Card
+    title="Qu'est-ce qu'une mission ?"
+    description="Anatomie d'une mission : chaque champ, le cycle de vie du statut, et en quoi les missions diffèrent des tâches."
+    href="/docs/missions/what-is-a-mission"
+  />
+  <Card
+    title="Quand utiliser les missions"
+    description="Guide de décision et signaux pour escalader d'une tâche vers une mission."
+    href="/docs/missions/when-to-use"
+  />
+  <Card
+    title="Créer des missions"
+    description="Guide étape par étape : create_mission, lier des tâches avec dependsOn, faire avancer le statut, suivre la progression, clôturer avec preuves."
+    href="/docs/missions/creating-missions"
+  />
+  <Card
+    title="Templates de missions"
+    description="Système de templates VR — squelettes de mission pré-construits que vous pouvez instancier en un seul appel."
+    href="/docs/missions/templates"
+  />
+  <Card
+    title="Exemples"
+    description="Trois exemples complets : lancement client, déploiement de fonctionnalité et audit système."
+    href="/docs/missions/examples"
+  />
+</Cards>
+
+<Callout type="info">
+Toutes les opérations de mission sont disponibles comme outils MCP. Voir [Référence API : Missions](/docs/tools) pour la liste complète des arguments.
+</Callout>

--- a/content/docs/missions/index.mdx
+++ b/content/docs/missions/index.mdx
@@ -1,0 +1,77 @@
+---
+title: Missions
+description: Orchestrated multi-step bodies of work — templates, sequenced tasks, and evidence-bound completion for your AI agent fleet.
+---
+
+import { Card, Cards } from 'fumadocs-ui/components/card'
+import { Callout } from 'fumadocs-ui/components/callout'
+
+# Missions
+
+A mission is an orchestrated body of work — a template + brief + sequenced tasks with dependencies, owned by a pilot orchestrator, tracked by status.
+
+Where a task is a single atomic action ("fix this bug"), a mission is an end-to-end delivery ("investigate, fix, test, and ship this bug across 9 structured steps"). Missions give your agent fleet a shared frame of reference: everyone knows the goal, the sequence, and the current progress.
+
+## When to use missions
+
+Use a mission when at least two of the following are true:
+
+- **Multi-step work** — the goal requires more than one distinct action, and some steps must happen before others.
+- **Multi-agent coordination** — different orchestrators or subagent types handle different phases (dev, review, QA, ship).
+- **Evidence-bound completion required** — deliverables must cite a commit SHA, PR number, test ratio, or file path before the mission can close.
+- **Deliverables span 3 or more days** — a long-running effort needs a persistent tracking object so progress survives session restarts.
+
+## When NOT to use missions
+
+If the work is a single step that one agent can complete in one session, use a task. Missions carry overhead — pilot assignment, status lifecycle, progress tracking — that is unnecessary for atomic actions.
+
+```
+Single action, one agent, one session  →  create_task
+Multi-step, multi-agent, 3+ days       →  create_mission + linked tasks
+```
+
+## Quick example
+
+Sigma launches a "doc-completion-cedric" mission with 4 phase tasks (audit / write / review / publish). Each task carries `missionId` linking it back to the mission and `dependsOn` pointing to its predecessor. The mission status moves through `plan → execute → validate → complete` as tasks close. Progress is a manual percentage updated via `update_mission_progress`.
+
+```
+Mission: doc-completion-cedric  [execute, 50%]
+  T0  audit-existing-docs       [done]
+  T1  write-new-pages           [in_progress]  dependsOn: [T0]
+  T2  review-by-eta             [todo]         dependsOn: [T1]
+  T3  publish-and-announce      [todo]         dependsOn: [T2]
+```
+
+## Pages in this section
+
+<Cards>
+  <Card
+    title="What is a mission?"
+    description="Anatomy of a mission: every field, the status lifecycle, and how missions differ from tasks."
+    href="/docs/missions/what-is-a-mission"
+  />
+  <Card
+    title="When to use missions"
+    description="Decision guide and signals to escalate from a task to a mission."
+    href="/docs/missions/when-to-use"
+  />
+  <Card
+    title="Creating missions"
+    description="Step-by-step how-to: create_mission, link tasks with dependsOn, advance status, track progress, close evidence-bound."
+    href="/docs/missions/creating-missions"
+  />
+  <Card
+    title="Mission templates"
+    description="VR template system — pre-built mission skeletons you can instantiate in one call."
+    href="/docs/missions/templates"
+  />
+  <Card
+    title="Examples"
+    description="Three fully worked examples: client kickoff, feature ship, and system audit."
+    href="/docs/missions/examples"
+  />
+</Cards>
+
+<Callout type="info">
+All mission operations are available as MCP tools. See [API Reference: Missions](/docs/tools) for the complete argument list.
+</Callout>

--- a/content/docs/missions/meta.fr.json
+++ b/content/docs/missions/meta.fr.json
@@ -1,0 +1,12 @@
+{
+  "title": "Missions",
+  "defaultOpen": true,
+  "pages": [
+    "index",
+    "what-is-a-mission",
+    "when-to-use",
+    "creating-missions",
+    "templates",
+    "examples"
+  ]
+}

--- a/content/docs/missions/meta.json
+++ b/content/docs/missions/meta.json
@@ -1,0 +1,12 @@
+{
+  "title": "Missions",
+  "defaultOpen": true,
+  "pages": [
+    "index",
+    "what-is-a-mission",
+    "when-to-use",
+    "creating-missions",
+    "templates",
+    "examples"
+  ]
+}

--- a/content/docs/missions/templates.fr.mdx
+++ b/content/docs/missions/templates.fr.mdx
@@ -1,0 +1,192 @@
+---
+title: Templates de missions
+description: Système de templates de missions VR — squelettes de mission pré-construits que vous pouvez instancier en un seul appel pour obtenir N tâches pré-câblées avec dependsOn.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout'
+import { Card, Cards } from 'fumadocs-ui/components/card'
+
+# Templates de missions
+
+## Qu'est-ce qu'un template de mission ?
+
+Un template de mission est un squelette pré-défini : une liste nommée d'étapes, chacune avec un titre, une description, un `assignedTo` optionnel et un `dependsOn` optionnel (exprimé sous forme d'index d'étapes). Lorsque vous instanciez un template dans une mission, chaque étape devient une vraie tâche avec `missionId` défini et `dependsOn` résolu en IDs de tâches réels.
+
+Les templates vivent dans la table `missionTemplates` et sont gérés par l'équipe VantageOS. Les clients auto-hébergés peuvent définir leurs propres templates en utilisant la mutation `upsert_mission_template`.
+
+## Pourquoi utiliser des templates ?
+
+- **Cohérence** — chaque résolution d'issue suit le même protocole en 9 étapes, quel que soit l'orchestrateur qui le déclenche.
+- **Rapidité** — un seul appel `instantiate_template_into_mission` crée N tâches avec le séquençage correct. Pas de câblage manuel de `dependsOn`.
+- **Moins d'erreurs** — les étapes encodent des leçons chèrement apprises (exécuter les tests AVANT de corriger, écrire le test de régression EN PREMIER, créer la PR dans la même étape que le push).
+- **Traçabilité** — chaque tâche cite sa lignée de template via le `name` de la mission et le `name` du template.
+
+## Catalogue des templates
+
+### `issue-resolution-v3` (défaut)
+
+Le protocole canonique de résolution d'issues. 9 étapes (T0–T8), couvrant l'accusé de réception jusqu'à la revue de code. Auto-semé à chaque déploiement.
+
+**Objectif :** Résolution structurée et liée à des preuves des issues GitHub.
+
+**Quand utiliser :** Toute issue GitHub assignée à un orchestrateur. Le bot auto-IRP déclenche ce template automatiquement quand un log d'erreur crée une nouvelle issue.
+
+**Étapes :**
+| Étape | Titre | Exigence clé |
+|-------|-------|-------------|
+| T0 | Acknowledge | Poster automatiquement un commentaire GitHub confirmant la réception |
+| T1 | KB Search | Rechercher `fixPatterns` + épisodes ; documenter le résultat |
+| T2 | Identify & Run Tests | Exécuter les tests existants ; documenter PASS/FAIL |
+| T3 | Write Missing Tests | Écrire le test de régression en échec ; le committer |
+| T4 | Fix | Appliquer le correctif ; le test T3 doit passer |
+| T5 | Run ALL Tests | Suite complète ; zéro régression |
+| T6 | Deploy Dev + Push | `convex dev --once` ; push de la branche ; créer la PR immédiatement |
+| T7 | Verification Preview | Tester sur le preview ; demander la validation humaine |
+| T8 | Code Review | Agent reviewer + mise à jour KB avec le pattern de correctif |
+
+```ts
+mcp__vantage-peers__instantiate_template_into_mission({
+  templateName: "issue-resolution-v3",
+  missionId: "k57xxx",
+  context: {
+    issueNumber: "142",
+    repo: "vantage-memory"
+  },
+  callerOrchestrator: "proxima"
+})
+```
+
+### `mission-generic-v1`
+
+Un template vierge pour les missions qui ne correspondent pas à un template plus spécifique. Fournit un échafaudage minimal plan / execute / validate / complete avec 4 tâches génériques.
+
+**Objectif :** Démarrer n'importe quelle mission avec une structure standard quand aucun template spécialisé ne s'applique.
+
+**Quand utiliser :** Lancement client, démarrage de projet interne, livrable orchestré ponctuel.
+
+### `chrome-extension-mission-v1`
+
+Construire et publier une extension Chrome de zéro. Couvre la spec, l'implémentation Manifest V3, les content scripts, le service worker en arrière-plan, l'UI popup, le packaging et la soumission au store.
+
+**Objectif :** Développement structuré d'extension Chrome de zéro à publiée.
+
+**Quand utiliser :** Tout nouveau projet d'extension Chrome assigné à Zeta ou un agent dev.
+
+### `pricing-research-v1`
+
+Mission de recherche tarifaire concurrentielle. Couvre le scan de marché, la matrice concurrentielle, l'analyse du modèle de tarification, le document de recommandation et la révision par les parties prenantes.
+
+**Objectif :** Produire une recommandation tarifaire défendable soutenue par des données de marché.
+
+**Quand utiliser :** Avant tout changement de prix ou lancement d'un nouveau palier de produit.
+
+### `repo-fix-v1`
+
+Correctif ciblé pour un bug connu dans un dépôt spécifique. Plus court que `issue-resolution-v3` — pas d'étapes d'accusé de réception automatique ou de recherche KB. À utiliser pour des correctifs rapides et bien délimités dont la cause racine est déjà connue.
+
+**Objectif :** Appliquer un correctif connu, écrire le test de régression, déployer la PR.
+
+**Quand utiliser :** Patterns de correctif déjà documentés dans `fixPatterns` ; cause racine confirmée.
+
+### `new-website-build`
+
+Construction complète d'un site web du brief de design au go-live. Couvre les wireframes, la sélection de stack technique, le contenu, l'implémentation, la révision SEO, la QA en staging et le lancement.
+
+**Objectif :** Livraison de site web de bout en bout avec une checklist de transfert claire.
+
+**Quand utiliser :** Nouveau site client ou refonte majeure.
+
+### `gui-iframe-embed-v1`
+
+Construire le flux d'intégration iframe GUI pour VantagePeers (pattern SEP-1865). Couvre le registre de sessions backend, la validation d'origine, les composants UI, les tests d'intégration et le déploiement.
+
+**Objectif :** Implémenter l'architecture standard d'intégration iframe VP Gen UI.
+
+**Quand utiliser :** Tout client nécessitant un VP Gen UI intégré dans sa propre app.
+
+## Comment instancier un template
+
+Les templates sont instanciés via `instantiate_template_into_mission`. Cela crée une tâche par étape, patche `dependsOn` sur chaque tâche et retourne tous les IDs de tâches.
+
+```ts
+// Étape 1 : créer la coquille de mission
+const missionId = mcp__vantage-peers__create_mission({
+  name: "fix-issue-255-vantage-memory",
+  project: "vantage-memory",
+  status: "plan",
+  priority: "high",
+  pilot: "proxima",
+  agents: ["proxima"],
+  createdBy: "proxima"
+})
+
+// Étape 2 : instancier le template
+const result = mcp__vantage-peers__instantiate_template_into_mission({
+  templateName: "issue-resolution-v3",
+  missionId,
+  context: {
+    issueNumber: "255",
+    repo: "vantage-memory"
+  },
+  titlePrefix: "IRP-255",    // optionnel : préfixe pour chaque titre de tâche
+  callerOrchestrator: "proxima"
+})
+// result = { taskIds: ["kT0", "kT1", ..., "kT8"], count: 9 }
+
+// Étape 3 : démarrer la mission
+mcp__vantage-peers__update_mission_status({
+  missionId,
+  status: "execute"
+})
+```
+
+### Interpolation de contexte
+
+Les descriptions des étapes de template peuvent contenir des espaces réservés `{{key}}`. Passez un objet `context` et ils seront remplacés au moment de l'instanciation :
+
+```ts
+// Description d'étape du template :
+// "Exécutez `npx convex dev --once` sur le dépôt {{repo}} pour vérifier la compilation."
+
+// Contexte :
+context: { repo: "vantage-memory", issueNumber: "255" }
+
+// Résultat dans la description de la tâche :
+// "Exécutez `npx convex dev --once` sur le dépôt vantage-memory pour vérifier la compilation."
+```
+
+## Créer vos propres templates
+
+Les clients auto-hébergés peuvent définir des templates personnalisés en utilisant `upsert_mission_template` :
+
+```ts
+mcp__vantage-peers__upsert_mission_template({
+  name: "mon-template-personnalise-v1",
+  description: "Template de livraison personnalisé en 3 étapes.",
+  steps: [
+    {
+      title: "Périmètre",
+      description: "Définir le périmètre et les critères d'acceptation.",
+      assignedTo: "sigma"
+    },
+    {
+      title: "Construction",
+      description: "Implémenter le livrable.",
+      assignedTo: "zeta",
+      dependsOn: [0]  // dépend de l'étape 0 (Périmètre)
+    },
+    {
+      title: "Déploiement",
+      description: "Réviser, fusionner, déployer.",
+      assignedTo: "sigma",
+      dependsOn: [1]  // dépend de l'étape 1 (Construction)
+    }
+  ],
+  isDefault: false,
+  createdBy: "sigma"
+})
+```
+
+<Callout type="info">
+Les templates sont stockés par déploiement. Si vous auto-hébergez VantagePeers, vos templates vivent dans votre propre déploiement Convex et ne sont pas partagés avec l'instance cloud VantageOS.
+</Callout>

--- a/content/docs/missions/templates.mdx
+++ b/content/docs/missions/templates.mdx
@@ -1,0 +1,192 @@
+---
+title: Mission Templates
+description: VR mission template system — pre-built mission skeletons you can instantiate in one call to get N tasks, pre-wired with dependsOn.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout'
+import { Card, Cards } from 'fumadocs-ui/components/card'
+
+# Mission Templates
+
+## What are mission templates?
+
+A mission template is a pre-defined skeleton: a named list of steps, each with a title, description, optional `assignedTo`, and optional `dependsOn` (expressed as step indexes). When you instantiate a template into a mission, every step becomes a real task with `missionId` set and `dependsOn` resolved to actual task IDs.
+
+Templates live in the `missionTemplates` table and are managed by the VantageOS team. Self-host clients can define their own templates using the `upsert_mission_template` mutation.
+
+## Why use templates?
+
+- **Consistency** — every issue resolution follows the same 9-step protocol, regardless of which orchestrator triggers it.
+- **Speed** — one `instantiate_template_into_mission` call creates N tasks with correct sequencing. No manual wiring of `dependsOn`.
+- **Fewer mistakes** — the steps encode hard-won lessons (run tests BEFORE fixing, write the regression test FIRST, create the PR in the same step as the push).
+- **Traceability** — every task cites its template lineage via the mission's `name` and the template's `name`.
+
+## Template catalog
+
+### `issue-resolution-v3` (default)
+
+The canonical Issue Resolution Protocol. 9 steps (T0–T8), covering acknowledgement through code review. Auto-seeded on every deployment.
+
+**Purpose:** Structured, evidence-bound resolution of GitHub issues.
+
+**When to use:** Any GitHub issue assigned to an orchestrator. The auto-IRP bot triggers this template automatically when an error log creates a new issue.
+
+**Steps:**
+| Step | Title | Key requirement |
+|------|-------|-----------------|
+| T0 | Acknowledge | Auto-post GitHub comment confirming receipt |
+| T1 | KB Search | Search `fixPatterns` + episodes; document outcome |
+| T2 | Identify & Run Tests | Run existing tests; document PASS/FAIL |
+| T3 | Write Missing Tests | Write failing regression test; commit it |
+| T4 | Fix | Apply fix; T3 test must pass |
+| T5 | Run ALL Tests | Full suite; zero regressions |
+| T6 | Deploy Dev + Push | `convex dev --once`; push branch; create PR immediately |
+| T7 | Verification Preview | Test on preview; request human sign-off |
+| T8 | Code Review | Reviewer agent + update KB with fix pattern |
+
+```ts
+mcp__vantage-peers__instantiate_template_into_mission({
+  templateName: "issue-resolution-v3",
+  missionId: "k57xxx",
+  context: {
+    issueNumber: "142",
+    repo: "vantage-memory"
+  },
+  callerOrchestrator: "proxima"
+})
+```
+
+### `mission-generic-v1`
+
+A blank-slate template for missions that don't fit a more specific template. Provides a minimal plan / execute / validate / complete scaffold with 4 generic tasks.
+
+**Purpose:** Kickstart any mission with a standard structure when no specialized template applies.
+
+**When to use:** Client kickoff, internal project start, one-off orchestrated deliverable.
+
+### `chrome-extension-mission-v1`
+
+Build and publish a Chrome extension from scratch. Covers spec, Manifest V3 implementation, content scripts, background service worker, popup UI, packaging, and store submission.
+
+**Purpose:** Structured Chrome extension development from zero to published.
+
+**When to use:** Any new Chrome extension project assigned to Zeta or a dev agent.
+
+### `pricing-research-v1`
+
+Competitive pricing research mission. Covers market scan, competitor matrix, pricing model analysis, recommendation doc, and stakeholder review.
+
+**Purpose:** Produce a defensible pricing recommendation backed by market data.
+
+**When to use:** Before any pricing change or new product tier launch.
+
+### `repo-fix-v1`
+
+Focused fix for a known bug in a specific repo. Shorter than `issue-resolution-v3` — no auto-acknowledge or KB search steps. Use for quick, well-scoped fixes where the root cause is already known.
+
+**Purpose:** Apply a known fix, write the regression test, ship the PR.
+
+**When to use:** Fix patterns already documented in `fixPatterns`; root cause confirmed.
+
+### `new-website-build`
+
+Full website build from design brief to go-live. Covers wireframes, tech stack selection, content, implementation, SEO review, staging QA, and launch.
+
+**Purpose:** End-to-end website delivery with a clear hand-off checklist.
+
+**When to use:** New client site or major redesign.
+
+### `gui-iframe-embed-v1`
+
+Build the GUI iframe embed flow for VantagePeers (SEP-1865 pattern). Covers backend session registry, origin validation, UI components, integration tests, and deployment.
+
+**Purpose:** Implement the standard VantagePeers iframe embed architecture.
+
+**When to use:** Any client needing embedded VP Gen UI in their own app.
+
+## How to instantiate a template
+
+Templates are instantiated via `instantiate_template_into_mission`. This creates one task per step, patches `dependsOn` on each task, and returns all task IDs.
+
+```ts
+// Step 1: create the mission shell
+const missionId = mcp__vantage-peers__create_mission({
+  name: "fix-issue-255-vantage-memory",
+  project: "vantage-memory",
+  status: "plan",
+  priority: "high",
+  pilot: "proxima",
+  agents: ["proxima"],
+  createdBy: "proxima"
+})
+
+// Step 2: instantiate the template
+const result = mcp__vantage-peers__instantiate_template_into_mission({
+  templateName: "issue-resolution-v3",
+  missionId,
+  context: {
+    issueNumber: "255",
+    repo: "vantage-memory"
+  },
+  titlePrefix: "IRP-255",    // optional: prepended to each task title
+  callerOrchestrator: "proxima"
+})
+// result = { taskIds: ["kT0", "kT1", ..., "kT8"], count: 9 }
+
+// Step 3: start the mission
+mcp__vantage-peers__update_mission_status({
+  missionId,
+  status: "execute"
+})
+```
+
+### Context interpolation
+
+Template step descriptions can contain `{{key}}` placeholders. Pass a `context` object and they will be replaced at instantiation time:
+
+```ts
+// Template step description:
+// "Run `npx convex dev --once` on repo {{repo}} to verify compilation."
+
+// Context:
+context: { repo: "vantage-memory", issueNumber: "255" }
+
+// Result in task description:
+// "Run `npx convex dev --once` on repo vantage-memory to verify compilation."
+```
+
+## Creating your own templates
+
+Self-host clients can define custom templates using `upsert_mission_template`:
+
+```ts
+mcp__vantage-peers__upsert_mission_template({
+  name: "my-custom-template-v1",
+  description: "Custom 3-step delivery template.",
+  steps: [
+    {
+      title: "Scope",
+      description: "Define scope and acceptance criteria.",
+      assignedTo: "sigma"
+    },
+    {
+      title: "Build",
+      description: "Implement the deliverable.",
+      assignedTo: "zeta",
+      dependsOn: [0]  // depends on step 0 (Scope)
+    },
+    {
+      title: "Ship",
+      description: "Review, merge, deploy.",
+      assignedTo: "sigma",
+      dependsOn: [1]  // depends on step 1 (Build)
+    }
+  ],
+  isDefault: false,
+  createdBy: "sigma"
+})
+```
+
+<Callout type="info">
+Templates are stored per-deployment. If you self-host VantagePeers, your templates live in your own Convex deployment and are not shared with the VantageOS cloud instance.
+</Callout>

--- a/content/docs/missions/what-is-a-mission.fr.mdx
+++ b/content/docs/missions/what-is-a-mission.fr.mdx
@@ -1,0 +1,142 @@
+---
+title: Qu'est-ce qu'une mission ?
+description: Anatomie d'une mission VantagePeers — chaque champ, le cycle de vie du statut, et la différence entre missions et tâches.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout'
+import { TypeTable } from 'fumadocs-ui/components/type-table'
+
+# Qu'est-ce qu'une mission ?
+
+Une mission est un corps de travail persistant et orchestré stocké dans VantagePeers. Elle regroupe des tâches liées sous un seul objet de suivi avec un pilote, un cycle de vie du statut, un indicateur de progression et une lignée de template optionnelle.
+
+## Anatomie des champs
+
+<TypeTable
+  type={{
+    name: {
+      description: 'Identifiant de type slug pour la mission. Utilisez le kebab-case avec un préfixe pilote pour l\'unicité (ex. sigma-doc-completion-cedric).',
+      type: 'string',
+      default: 'requis',
+    },
+    description: {
+      description: 'Ce que la mission livre — l\'état final, pas le processus. Une phrase suffit.',
+      type: 'string',
+      default: 'optionnel',
+    },
+    project: {
+      description: 'Périmètre du dépôt ou produit auquel cette mission appartient (ex. "vantage-peers-site", "myreeldream").',
+      type: 'string',
+      default: 'requis',
+    },
+    pilot: {
+      description: 'L\'orchestrateur qui possède la coordination de bout en bout. Le pilote est responsable des transitions de statut et de la preuve finale.',
+      type: 'string (nom d\'orchestrateur)',
+      default: 'requis',
+    },
+    agents: {
+      description: 'Tableau des types de sous-agents ou rôles d\'orchestrateur qui seront déployés pendant l\'exécution (ex. ["dev-fumadocs-expert", "eta"]).',
+      type: 'string[]',
+      default: 'requis',
+    },
+    status: {
+      description: 'Phase actuelle du cycle de vie. Voir Cycle de vie du statut ci-dessous.',
+      type: '"brainstorm" | "plan" | "execute" | "validate" | "complete"',
+      default: 'requis',
+    },
+    priority: {
+      description: 'Niveau d\'urgence, cohérent avec les priorités des tâches.',
+      type: '"urgent" | "high" | "medium" | "low"',
+      default: 'requis',
+    },
+    brief: {
+      description: 'Brief de mission en texte libre — contexte, contraintes, critères d\'acceptation. Markdown supporté.',
+      type: 'string',
+      default: 'optionnel',
+    },
+    startDate: {
+      description: 'Horodatage Unix (ms) quand le travail a commencé ou est prévu de commencer.',
+      type: 'number',
+      default: 'optionnel',
+    },
+    targetDate: {
+      description: 'Délai en horodatage Unix (ms). Utilisé pour le suivi SLA.',
+      type: 'number',
+      default: 'optionnel',
+    },
+    progress: {
+      description: 'Pourcentage de complétion (0–100). Mis à jour manuellement via update_mission_progress.',
+      type: 'number',
+      default: 'optionnel',
+    },
+    createdBy: {
+      description: 'Orchestrateur qui a créé la mission.',
+      type: 'string',
+      default: 'requis',
+    },
+  }}
+/>
+
+## Cycle de vie du statut
+
+Les statuts de mission passent de l'idéation à la complétion. Chaque transition doit être pilotée explicitement par le pilote via `update_mission_status`.
+
+```
+brainstorm  →  plan  →  execute  →  validate  →  complete
+```
+
+| Statut | Signification |
+|--------|---------------|
+| `brainstorm` | Idée capturée, pas encore planifiée. Aucune tâche requise. |
+| `plan` | Tâches définies et séquencées. Le pilote prépare la charge de travail. |
+| `execute` | Travail actif en cours. Les sous-agents sont déployés. |
+| `validate` | Toutes les tâches terminées. Le pilote ou un évaluateur vérifie les preuves. |
+| `complete` | Mission clôturée avec preuves. Aucun changement ultérieur attendu. |
+
+**Alias de statut** (pour les requêtes uniquement, pas pour les écritures) :
+
+- `"open"` — s'étend en `["brainstorm", "plan", "execute", "validate"]`
+- `"active"` — s'étend en `["plan", "execute"]`
+
+<Callout type="info">
+Il n'y a pas de statut `blocked` ou `cancelled` sur les missions. Pour mettre en pause une mission, laissez-la en `plan` ou `execute` et ajoutez une note dans le `brief`. Pour l'abandonner, passez à `complete` et documentez la raison dans le brief.
+</Callout>
+
+## Comment les tâches se lient aux missions
+
+Chaque tâche possède un champ optionnel `missionId`. Lorsqu'il est défini, la tâche fait partie de la charge de travail de cette mission. Les tâches ont également `dependsOn` — un tableau d'IDs de tâches qui doivent atteindre le statut `done` avant que cette tâche puisse commencer.
+
+```
+Mission  ──┬──  Tâche A  (pas de dépendances)
+           ├──  Tâche B  dependsOn: [Tâche A]
+           ├──  Tâche C  dependsOn: [Tâche A]
+           └──  Tâche D  dependsOn: [Tâche B, Tâche C]  ← barrière
+```
+
+La combinaison `missionId + dependsOn` vous donne un séquençage DAG complet dans une mission.
+
+## Mission vs Tâche — tableau comparatif
+
+| Aspect | Tâche | Mission |
+|--------|-------|---------|
+| Périmètre | Étape atomique unique | Corps de travail orchestré en plusieurs étapes |
+| Suivi | Statut uniquement | Statut + % de progression + agents + pilote + brief |
+| Séquençage | Aucun (les tâches sont indépendantes) | `dependsOn` chaîne les tâches dans un DAG |
+| Templates | Aucun | Templates de mission VR — instancier N tâches en un appel |
+| Idéal pour | Corriger un bug, écrire un fichier, exécuter une vérification | Livraison de bout en bout sur plusieurs jours ou équipes |
+| Cycle de vie | `todo → in_progress → review → done` | `brainstorm → plan → execute → validate → complete` |
+| Preuve | `completionNote` sur la tâche | Preuve sur chaque tâche liée + transition de statut finale |
+
+## Suivi de la progression
+
+La progression est un entier `0–100` géré manuellement. Le pilote le met à jour après des jalons significatifs (ex. après la clôture de chaque phase). Elle ne se calcule pas automatiquement à partir des statuts des tâches — le pilote est l'autorité.
+
+```ts
+// Mettre à jour la progression après la clôture d'une phase
+mcp__vantage-peers__update_mission_progress({
+  missionId: "k57xxxxx",
+  progress: 50
+})
+```
+
+Une convention courante : définir la progression par multiples de 25 pour une mission à 4 phases (25 / 50 / 75 / 100).

--- a/content/docs/missions/what-is-a-mission.mdx
+++ b/content/docs/missions/what-is-a-mission.mdx
@@ -1,0 +1,142 @@
+---
+title: What is a Mission?
+description: Anatomy of a VantagePeers mission — every field, the status lifecycle, and the difference between missions and tasks.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout'
+import { TypeTable } from 'fumadocs-ui/components/type-table'
+
+# What is a Mission?
+
+A mission is a persistent, orchestrated body of work stored in VantagePeers. It groups related tasks under a single tracking object with a pilot, a status lifecycle, a progress indicator, and optional template lineage.
+
+## Field anatomy
+
+<TypeTable
+  type={{
+    name: {
+      description: 'Slug-like identifier for the mission. Use kebab-case with a pilot prefix for uniqueness (e.g. sigma-doc-completion-cedric).',
+      type: 'string',
+      default: 'required',
+    },
+    description: {
+      description: 'What the mission delivers — the end state, not the process. One sentence is enough.',
+      type: 'string',
+      default: 'optional',
+    },
+    project: {
+      description: 'Repo or product scope this mission belongs to (e.g. "vantage-peers-site", "myreeldream").',
+      type: 'string',
+      default: 'required',
+    },
+    pilot: {
+      description: 'The orchestrator who owns end-to-end coordination. The pilot is accountable for status transitions and final evidence.',
+      type: 'string (orchestrator name)',
+      default: 'required',
+    },
+    agents: {
+      description: 'Array of subagent types or orchestrator roles that will be dispatched during execution (e.g. ["dev-fumadocs-expert", "eta"]).',
+      type: 'string[]',
+      default: 'required',
+    },
+    status: {
+      description: 'Current lifecycle phase. See Status Lifecycle below.',
+      type: '"brainstorm" | "plan" | "execute" | "validate" | "complete"',
+      default: 'required',
+    },
+    priority: {
+      description: 'Urgency level, consistent with task priorities.',
+      type: '"urgent" | "high" | "medium" | "low"',
+      default: 'required',
+    },
+    brief: {
+      description: 'Free-text mission brief — context, constraints, acceptance criteria. Markdown supported.',
+      type: 'string',
+      default: 'optional',
+    },
+    startDate: {
+      description: 'Unix timestamp (ms) when work began or is planned to begin.',
+      type: 'number',
+      default: 'optional',
+    },
+    targetDate: {
+      description: 'Unix timestamp (ms) deadline. Used for SLA tracking.',
+      type: 'number',
+      default: 'optional',
+    },
+    progress: {
+      description: 'Completion percentage (0–100). Updated manually via update_mission_progress.',
+      type: 'number',
+      default: 'optional',
+    },
+    createdBy: {
+      description: 'Orchestrator that created the mission.',
+      type: 'string',
+      default: 'required',
+    },
+  }}
+/>
+
+## Status lifecycle
+
+Mission statuses flow from ideation to completion. Each transition must be driven by the pilot explicitly via `update_mission_status`.
+
+```
+brainstorm  →  plan  →  execute  →  validate  →  complete
+```
+
+| Status | Meaning |
+|--------|---------|
+| `brainstorm` | Idea captured, not yet planned. No tasks required. |
+| `plan` | Tasks defined and sequenced. Pilot is preparing the workload. |
+| `execute` | Active work underway. Subagents are dispatched. |
+| `validate` | All tasks done. Pilot or a reviewer is checking evidence. |
+| `complete` | Mission closed with evidence. No further changes expected. |
+
+**Status aliases** (for queries only, not for writes):
+
+- `"open"` — expands to `["brainstorm", "plan", "execute", "validate"]`
+- `"active"` — expands to `["plan", "execute"]`
+
+<Callout type="info">
+There is no `blocked` or `cancelled` status on missions. To pause a mission, leave it in `plan` or `execute` and add a note to the `brief`. To abandon, move to `complete` and document the reason in the brief.
+</Callout>
+
+## How tasks link to missions
+
+Every task has an optional `missionId` field. When set, the task is part of that mission's workload. Tasks also have `dependsOn` — an array of task IDs that must reach `done` status before this task can start.
+
+```
+Mission  ──┬──  Task A  (no deps)
+           ├──  Task B  dependsOn: [Task A]
+           ├──  Task C  dependsOn: [Task A]
+           └──  Task D  dependsOn: [Task B, Task C]  ← barrier
+```
+
+The combination of `missionId + dependsOn` gives you full DAG sequencing within a mission.
+
+## Mission vs Task — comparison table
+
+| Aspect | Task | Mission |
+|--------|------|---------|
+| Scope | Single atomic step | Multi-step orchestrated body of work |
+| Tracking | Status only | Status + progress % + agents + pilot + brief |
+| Sequencing | None (tasks are independent) | `dependsOn` chains tasks in a DAG |
+| Templates | None | VR mission templates — instantiate N tasks in one call |
+| Best for | Fix a bug, write a file, run a check | End-to-end delivery spanning days or teams |
+| Lifecycle | `todo → in_progress → review → done` | `brainstorm → plan → execute → validate → complete` |
+| Evidence | `completionNote` on the task | Evidence on each linked task + final status transition |
+
+## Progress tracking
+
+Progress is a manually managed `0–100` integer. The pilot updates it after meaningful milestones (e.g. after each phase completes). It does not auto-compute from task statuses — the pilot is the authority.
+
+```ts
+// Update progress after a phase closes
+mcp__vantage-peers__update_mission_progress({
+  missionId: "k57xxxxx",
+  progress: 50
+})
+```
+
+A common convention: set progress in multiples of 25 for a 4-phase mission (25 / 50 / 75 / 100).

--- a/content/docs/missions/when-to-use.fr.mdx
+++ b/content/docs/missions/when-to-use.fr.mdx
@@ -1,0 +1,87 @@
+---
+title: Quand utiliser les missions
+description: Guide de décision pour choisir entre une tâche et une mission, plus les signaux pour escalader d'une tâche vers une mission en cours.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout'
+import { Step, Steps } from 'fumadocs-ui/components/steps'
+
+# Quand utiliser les missions
+
+## Le test de décision
+
+Parcourez ces quatre questions. Si deux réponses ou plus sont "oui", créez une mission. Si zéro ou une, créez une tâche.
+
+<Steps>
+  <Step>
+    **Le travail comporte-t-il plus d'une étape avec des contraintes de séquençage ?**
+
+    L'objectif nécessite-t-il des phases distinctes où la phase B ne peut pas démarrer avant la fin de la phase A ? Une mission vous donne `dependsOn` pour exprimer cette contrainte. Une tâche simple n'a pas de mécanisme de séquençage.
+
+    Exemples oui : auditer puis écrire puis réviser ; spécifier puis construire puis tester puis déployer.
+    Exemples non : "Mettre à jour le README", "Corriger une faute de frappe à la ligne 42".
+  </Step>
+  <Step>
+    **Cela nécessite-t-il plusieurs types de sous-agents travaillant en série ou en parallèle ?**
+
+    Si un agent dev écrit du code, un agent reviewer le vérifie, et un agent QA le valide — vous avez trois rôles distincts. Le tableau `agents` d'une mission les déclare tous dès le départ, indiquant clairement qui est impliqué et en quelle capacité.
+
+    Exemples oui : dev + eta + qa ; fumadocs-expert + railway-expert ; auditeur + correcteur.
+    Exemples non : un seul agent fait tout ; un seul appel d'outil suffit.
+  </Step>
+  <Step>
+    **Y a-t-il un livrable mesurable et vérifiable ?**
+
+    Une mission se ferme avec des preuves : un numéro de PR, un commit SHA, un ratio de tests ou une URL déployée. Si la sortie est ambiguë ("les choses vont mieux maintenant"), une tâche avec `completionNote` suffit. Si la sortie doit être vérifiable indépendamment, utilisez une mission et appliquez des preuves sur chaque tâche liée.
+
+    Exemples oui : déployer une PR, lancer une fonctionnalité, publier un rapport.
+    Exemples non : "Examiner l'erreur", "Vérifier si X fonctionne".
+  </Step>
+  <Step>
+    **Va-t-il s'étendre sur plusieurs jours ou plusieurs sessions ?**
+
+    Les sessions se terminent ; le contexte se réinitialise. Une mission persiste dans VantagePeers à travers les sessions. Le pilote peut reprendre exactement là où il s'était arrêté en appelant `get_mission` et `list_tasks_by_mission`. Une tâche qui s'étend sur plus d'une session risque d'être perdue à moins de faire partie d'une mission.
+
+    Exemples oui : construction de fonctionnalité sur 3 jours, audit d'une semaine, élément de roadmap multi-sprint.
+    Exemples non : "Corriger et pousser dans cette session", "Exécution de script ponctuelle".
+  </Step>
+</Steps>
+
+## Matrice de décision rapide
+
+| Scénario | Verdict |
+|----------|---------|
+| Agent unique, une session, résultat atomique | Tâche |
+| Deux agents, un transfert, même journée | Tâche (ou mission si preuve requise) |
+| Trois phases, deux agents, 2 jours | Mission |
+| Fonctionnalité complète de la spec au déploiement | Mission |
+| Correction de bug (1 fichier, pattern connu) | Tâche |
+| Correction de bug nécessitant audit + fix + test de régression + revue PR | Mission (utilisez le template `issue-resolution-v3`) |
+| Note de standup hebdomadaire | Tâche (ou tâche récurrente) |
+| Intégration d'un nouveau client | Mission |
+
+## Signaux pour escalader d'une tâche vers une mission
+
+Parfois, vous démarrez avec une tâche et découvrez en cours de route qu'elle a grandi. Voici les signaux pour vous arrêter, créer une mission et relier la tâche originale sous celle-ci :
+
+**Dérive du périmètre** — La description de la tâche a été modifiée trois fois ou plus, chaque fois en élargissant le périmètre. L'estimation originale n'est plus réaliste.
+
+**Plusieurs PRs nécessaires** — La tâche nécessite maintenant des changements sur plus d'un dépôt ou plus de deux fichiers. Une seule `completionNote` ne peut pas capturer la piste de preuves complète.
+
+**Dépendance bloquante** — Une autre tâche ou personne attend ce travail. Le statut d'une mission rend la relation de blocage visible pour toute l'équipe.
+
+**Porte de révision requise** — La sortie doit être vérifiée par Eta ou un autre orchestrateur avant de se fermer. Une mission vous permet de modéliser l'étape de validation explicitement plutôt que de laisser la révision implicite dans un commentaire de tâche.
+
+**Des jours ont passé sans clôture** — Si une tâche est `in_progress` depuis plus de 48 heures, elle cache probablement des sous-étapes qui devraient être explicites. Convertissez-la en mission et exposez ces étapes comme tâches liées.
+
+<Callout type="warn">
+L'escalade d'une tâche vers une mission ne nécessite pas de supprimer la tâche originale. Créez la mission, définissez `missionId` sur la tâche originale, puis créez les tâches restantes comme éléments frères. La tâche originale devient T0 dans la nouvelle mission.
+</Callout>
+
+## Anti-patterns à éviter
+
+**Mission pour chaque tâche** — Toutes les actions n'ont pas besoin de la surcharge d'orchestration. La sur-utilisation des missions crée du bruit et enterre les vrais signaux. Réservez les missions pour les travaux qui nécessitent véritablement du séquençage, de la coordination multi-agents ou de la persistance multi-jours.
+
+**Mission sans brief** — Une mission sans `brief` ni `description` est une boîte noire. Quiconque la reprend à froid n'a aucune idée de ce à quoi ressemble le succès. Écrivez toujours au moins une phrase.
+
+**Dérive du pilote** — Une mission qui commence avec un pilote et est silencieusement transférée à un autre sans appel `update_mission` perd sa responsabilité. Mettez à jour `pilot` explicitement lors du transfert de propriété.

--- a/content/docs/missions/when-to-use.mdx
+++ b/content/docs/missions/when-to-use.mdx
@@ -1,0 +1,87 @@
+---
+title: When to Use Missions
+description: Decision guide for choosing between a task and a mission, plus signals to escalate from a task to a mission mid-flight.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout'
+import { Step, Steps } from 'fumadocs-ui/components/steps'
+
+# When to Use Missions
+
+## The decision test
+
+Work through these four questions. If two or more answers are "yes", create a mission. If zero or one, create a task.
+
+<Steps>
+  <Step>
+    **Is the work more than one step with sequencing constraints?**
+
+    Does the goal require distinct phases where phase B cannot start until phase A finishes? A mission gives you `dependsOn` to express that constraint. A plain task has no sequencing mechanism.
+
+    Yes examples: audit then write then review; spec then build then test then ship.
+    No examples: "Update the README", "Fix typo in line 42".
+  </Step>
+  <Step>
+    **Does it require multiple subagent types working in series or parallel?**
+
+    If a dev agent writes code, a reviewer agent checks it, and a QA agent verifies it — you have three distinct roles. A mission's `agents` array declares all of them upfront, making it clear who is involved and in what capacity.
+
+    Yes examples: dev + eta + qa; fumadocs-expert + railway-expert; auditor + fixer.
+    No examples: one agent does everything; a single tool call is sufficient.
+  </Step>
+  <Step>
+    **Does it have a measurable, verifiable deliverable?**
+
+    A mission closes with evidence: a PR number, commit SHA, test ratio, or deployed URL. If the output is ambiguous ("things are better now"), a task with a `completionNote` is enough. If the output must be independently verifiable, use a mission and enforce evidence on each linked task.
+
+    Yes examples: ship a PR, deploy a feature, publish a report.
+    No examples: "Look into the error", "Check if X is working".
+  </Step>
+  <Step>
+    **Will it span multiple days or multiple sessions?**
+
+    Sessions end; context resets. A mission persists in VantagePeers across sessions. The pilot can pick up exactly where they left off by calling `get_mission` and `list_tasks_by_mission`. A task that spans more than one session risks being dropped unless it is part of a mission.
+
+    Yes examples: 3-day feature build, week-long audit, multi-sprint roadmap item.
+    No examples: "Fix and push in this session", "One-shot script run".
+  </Step>
+</Steps>
+
+## Quick decision matrix
+
+| Scenario | Verdict |
+|----------|---------|
+| Single-agent, one session, atomic result | Task |
+| Two agents, one hand-off, same day | Task (or mission if evidence required) |
+| Three phases, two agents, 2 days | Mission |
+| Full feature from spec to ship | Mission |
+| Bug fix (1 file, known pattern) | Task |
+| Bug fix requiring audit + fix + regression test + PR review | Mission (use `issue-resolution-v3` template) |
+| Weekly standup note | Task (or recurring task) |
+| Onboard a new client | Mission |
+
+## Signals to escalate from a task to a mission
+
+Sometimes you start with a task and discover mid-flight that it has grown. These are the signals to stop, create a mission, and re-link the original task under it:
+
+**Scope creep** — The task description has been edited three or more times, each time expanding the scope. The original estimate is no longer realistic.
+
+**Multiple PRs needed** — The task now requires changes across more than one repository or more than two files. A single `completionNote` cannot capture the full evidence trail.
+
+**Blocking dependency** — Another task or person is waiting on this work. A mission's status makes the blocking relationship visible to the whole team.
+
+**Review gate required** — The output must be checked by Eta or another orchestrator before it can close. A mission lets you model the validate step explicitly rather than leaving the review implicit in a task comment.
+
+**Days have passed with no closure** — If a task has been `in_progress` for more than 48 hours, it is likely hiding sub-steps that should be explicit. Convert it to a mission and surface those steps as linked tasks.
+
+<Callout type="warn">
+Escalating from task to mission does not require deleting the original task. Create the mission, set `missionId` on the original task, then create the remaining tasks as siblings. The original task becomes T0 in the new mission.
+</Callout>
+
+## Anti-patterns to avoid
+
+**Mission for every task** — Not every action needs orchestration overhead. Over-using missions creates noise and buries the real signals. Reserve missions for work that genuinely needs sequencing, multi-agent coordination, or multi-day persistence.
+
+**Mission without a brief** — A mission with no `brief` and no `description` is a black box. Anyone picking it up cold has no idea what success looks like. Always write at least one sentence.
+
+**Pilot drift** — A mission that starts with one pilot and is silently transferred to another without a `update_mission` call loses accountability. Update `pilot` explicitly when ownership transfers.


### PR DESCRIPTION
## Summary
STOP-THE-LINE VOLET C2 (mission task k170mmqpx65jmmvzknj5svxgax87nhfj). Pi 09h25 directive: 'les missions: on a rien dans la doc — c'est honteux'.

## Changes (16 files, ~2200 lines)
content/docs/missions/:
- index.mdx + .fr.mdx — overview + when to use
- what-is-a-mission.mdx + .fr.mdx — anatomy + mission-vs-task table
- when-to-use.mdx + .fr.mdx — decision tree + escalation signals
- creating-missions.mdx + .fr.mdx — 6-step how-to + all 6 fn-paths
- templates.mdx + .fr.mdx — VR template system + issue-resolution-v3 walkthrough
- examples.mdx + .fr.mdx — 3 worked examples (client kickoff / 5-sprint ship / fleet audit parallel-then-barrier)
- meta.json + meta.fr.json

content/docs/meta.json + meta.fr.json — added 'missions' slug between capabilities + infrastructure (preserved existing nav).

## Coverage
- All 6 missions fn-paths (create / get / list / update / updateStatus / updateProgress)
- issue-resolution-v3 template fully documented
- instantiate_template_into_mission documented
- Status lifecycle + aliases
- Parallel-then-barrier DAG pattern in Example 3

## Test plan
- [x] npm run build 0 errors, 12 SSG pages confirmed
- [x] FR full translations
- [ ] Eta APPROVED
- [ ] Pi GO MERGE
- [ ] Cédric onboarding gate

Reference mission: k170mmqpx65jmmvzknj5svxgax87nhfj

Orchestrator: Sigma — VantageOS Team | 2026-05-29