### PR TITLE
feat(docs): Connect to VP Cloud runbook EN+FR — Marie onboarding (Day 88)

### DIFF
--- a/content/docs/getting-started/connect-cloud.fr.mdx
+++ b/content/docs/getting-started/connect-cloud.fr.mdx
@@ -1,0 +1,91 @@
+---
+title: Se connecter à VantagePeers Cloud
+description: Connectez VantagePeers Cloud (hébergé) à Claude Code, Claude.ai ou ChatGPT avec vos identifiants client.
+---
+
+Si vous avez reçu un `client_id` et un `client_secret` VantagePeers Cloud, cette page vous guide pour vous connecter via l'un des trois clients MCP supportés. Choisissez celui que vous utilisez. Aucun déploiement de votre côté.
+
+## Avant de commencer
+
+Vous avez besoin de :
+
+- Votre `client_id` et votre `client_secret`, transmis hors-bande par VantageOS
+- L'URL du serveur : `https://vantage-peers-production.up.railway.app/mcp`
+- L'un des clients suivants installé : Claude Code, Claude.ai (web), ou ChatGPT
+
+Gardez votre `client_secret` confidentiel. Il ne sera jamais redemandé. Si vous le perdez, contactez VantageOS pour en régénérer un.
+
+## Path A — Claude Code
+
+1. Ouvrez le dossier de votre workspace dans un terminal
+2. Créez (ou ouvrez) le fichier `.mcp.json` à la racine
+3. Collez la configuration suivante :
+
+```json
+{
+  "mcpServers": {
+    "vantage-peers": {
+      "type": "http",
+      "url": "https://vantage-peers-production.up.railway.app/mcp",
+      "headers": {
+        "Authorization": "Bearer VOTRE_CLIENT_SECRET"
+      }
+    }
+  }
+}
+```
+
+4. Remplacez `VOTRE_CLIENT_SECRET` par la valeur reçue
+5. Redémarrez Claude Code
+6. Lancez `/mcp` pour vérifier que `vantage-peers` est listé et connecté
+7. Testez avec : `recall query="hello"` — doit retourner une réponse JSON
+
+## Path B — Claude.ai (web)
+
+Le plan Free permet 1 connecteur custom. Pro, Max, Team et Enterprise en permettent plusieurs.
+
+1. Ouvrez claude.ai
+2. Cliquez sur votre avatar → **Customize** → **Connectors**
+3. Cliquez sur **+** puis **Add custom connector**
+4. **URL** : `https://vantage-peers-production.up.railway.app/mcp`
+5. Cliquez sur **Advanced** et collez :
+   - **Client ID** : votre `client_id`
+   - **Client Secret** : votre `client_secret`
+6. Cliquez sur **Add**
+7. Acceptez les permissions OAuth quand demandé
+8. Dans une conversation, cliquez sur **+** → activez **vantage-peers**
+9. Testez : « Lis mes mémoires VantagePeers » — Claude doit appeler `recall`
+
+Important : utilisez bien Advanced + Client ID/Secret. N'utilisez pas l'option auto-discovery sans Advanced — elle attribue un scope plus large que prévu.
+
+## Path C — ChatGPT (Developer Mode)
+
+ChatGPT Developer Mode permet d'ajouter un connecteur MCP custom sans soumission au registre public. La feature est disponible selon votre plan (vérifiez avec OpenAI).
+
+1. Ouvrez ChatGPT
+2. Settings → **Beta features** → activez **Developer Mode** (si disponible)
+3. Settings → **Connectors** → **Create a Connector**
+4. **URL** : `https://vantage-peers-production.up.railway.app/mcp`
+5. Authentification : collez votre `client_secret` (Bearer)
+6. Sauvegardez
+7. Dans une conversation, sélectionnez le connecteur **vantage-peers**
+8. Testez : « Liste mes tâches VantagePeers »
+
+Note : l'expérience UX peut classer les outils de façon plus prudente que dans Claude Code / Claude.ai (demandes de confirmation supplémentaires sur les écritures). C'est normal pour le mode beta actuel.
+
+## Vérifier votre installation
+
+Quel que soit le path, ces trois appels doivent fonctionner :
+
+- `recall query="VantagePeers"` — recherche sémantique
+- `list_tasks` — vos tâches assignées
+- `list_memories namespace="global"` — mémoires globales
+
+Si l'un échoue avec `401 Unauthorized` : votre `client_secret` est incorrect ou expiré. Contactez VantageOS.
+
+Si l'un échoue avec `403 Forbidden` : votre scope ne couvre pas cette ressource. Normal pour les namespaces hors de votre périmètre.
+
+## Aide
+
+- Documentation : [vantagepeers.com/docs](https://vantagepeers.com/docs)
+- Support : par le canal convenu avec VantageOS lors de votre onboarding

--- a/content/docs/getting-started/connect-cloud.mdx
+++ b/content/docs/getting-started/connect-cloud.mdx
@@ -1,0 +1,91 @@
+---
+title: Connect to VantagePeers Cloud
+description: Connect VantagePeers Cloud (hosted) to Claude Code, Claude.ai, or ChatGPT using your client credentials.
+---
+
+If you have received a `client_id` and `client_secret` for VantagePeers Cloud, this page walks you through connecting via one of the three supported MCP clients. Choose the one you use. No deployment on your side.
+
+## Before you start
+
+You need:
+
+- Your `client_id` and `client_secret`, sent out-of-band by VantageOS
+- The server URL: `https://vantage-peers-production.up.railway.app/mcp`
+- One of the following clients installed: Claude Code, Claude.ai (web), or ChatGPT
+
+Keep your `client_secret` confidential. It will never be shown again. If you lose it, contact VantageOS to issue a new one.
+
+## Path A — Claude Code
+
+1. Open your workspace folder in a terminal
+2. Create (or open) a `.mcp.json` file at the root
+3. Paste the following configuration:
+
+```json
+{
+  "mcpServers": {
+    "vantage-peers": {
+      "type": "http",
+      "url": "https://vantage-peers-production.up.railway.app/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_CLIENT_SECRET"
+      }
+    }
+  }
+}
+```
+
+4. Replace `YOUR_CLIENT_SECRET` with the value you received
+5. Restart Claude Code
+6. Run `/mcp` to verify `vantage-peers` is listed and connected
+7. Test with: `recall query="hello"` — must return a JSON response
+
+## Path B — Claude.ai (web)
+
+The Free plan allows 1 custom connector. Pro, Max, Team, and Enterprise allow multiple.
+
+1. Open claude.ai
+2. Click your avatar → **Customize** → **Connectors**
+3. Click **+** then **Add custom connector**
+4. **URL**: `https://vantage-peers-production.up.railway.app/mcp`
+5. Click **Advanced** and paste:
+   - **Client ID**: your `client_id`
+   - **Client Secret**: your `client_secret`
+6. Click **Add**
+7. Accept the OAuth permissions when prompted
+8. In a conversation, click **+** → enable **vantage-peers**
+9. Test: "List my VantagePeers memories" — Claude must call `recall`
+
+Important: use Advanced + Client ID/Secret. Do not use auto-discovery without Advanced — it grants broader scope than intended.
+
+## Path C — ChatGPT (Developer Mode)
+
+ChatGPT Developer Mode lets you add a custom MCP connector without public registry submission. Availability depends on your plan (check with OpenAI).
+
+1. Open ChatGPT
+2. Settings → **Beta features** → enable **Developer Mode** (if available)
+3. Settings → **Connectors** → **Create a Connector**
+4. **URL**: `https://vantage-peers-production.up.railway.app/mcp`
+5. Authentication: paste your `client_secret` (Bearer)
+6. Save
+7. In a conversation, select the **vantage-peers** connector
+8. Test: "List my VantagePeers tasks"
+
+Note: the ChatGPT UX may classify tools more cautiously than Claude Code / Claude.ai (extra confirmation prompts on writes). This is expected in the current beta.
+
+## Verify your install
+
+Whichever path you used, these three calls must work:
+
+- `recall query="VantagePeers"` — semantic search
+- `list_tasks` — your assigned tasks
+- `list_memories namespace="global"` — global memories
+
+If one fails with `401 Unauthorized`: your `client_secret` is invalid or expired. Contact VantageOS.
+
+If one fails with `403 Forbidden`: your scope does not cover that resource. Expected for namespaces outside your perimeter.
+
+## Help
+
+- Documentation: [vantagepeers.com/docs](https://vantagepeers.com/docs)
+- Support: via the channel agreed with VantageOS during your onboarding

--- a/content/docs/getting-started/meta.fr.json
+++ b/content/docs/getting-started/meta.fr.json
@@ -1,5 +1,5 @@
 {
   "title": "Démarrage",
   "defaultOpen": true,
-  "pages": ["index", "quickstart", "add-orchestrator", "supported-tools"]
+  "pages": ["index", "quickstart", "connect-cloud", "add-orchestrator", "supported-tools"]
 }

--- a/content/docs/getting-started/meta.json
+++ b/content/docs/getting-started/meta.json
@@ -1,5 +1,5 @@
 {
   "title": "Getting Started",
   "defaultOpen": true,
-  "pages": ["index", "quickstart", "deploy-keys", "add-orchestrator", "supported-tools"]
+  "pages": ["index", "quickstart", "connect-cloud", "deploy-keys", "add-orchestrator", "supported-tools"]
 }


### PR DESCRIPTION
## Summary
- New page `getting-started/connect-cloud` EN + FR covering 3 paths:
  - Path A: Claude Code `.mcp.json` Bearer
  - Path B: Claude.ai Custom Connector (Advanced Client ID/Secret, Free=1 connector OK)
  - Path C: ChatGPT Developer Mode
- Added page to getting-started nav in `meta.json` + `meta.fr.json`
- Steers Path B users explicitly to Advanced + Client ID/Secret, NOT auto-discovery (avoids DCR scope escalation pending fix)

## Why
Marie onboarding RDV imminent (Day 88). Pi miss reconnu: 3 paths cloud sont natifs, pas un seul. Companion gap report in vantage-memory `analysis/marie-3-paths-gap-analysis-2026-05-30.md`.

## Test plan
- [x] EN page renders
- [x] FR page renders
- [x] Both pages appear in getting-started sidebar nav
- [ ] Eta dim 12 review
- [ ] Live smoke Path A/B/C with Marie creds (post Pi provision)

## Refs
- Task k1782egjnjfjav8wtgp9kf8w5d87p53w
- Pi msg jn76ahha8szp2jdec1vecmzj8h87qsff
- Gap analysis vantage-memory commit d9ac487
- Audit Day 84 vantage-memory analysis/vp-cloud-onboarding-state-2026-05-28.md

Orchestrator: Sigma — VantageOS Team | 2026-05-30