### PR TITLE
docs(changelog): add v2.4.0 + v2.4.1 entries (EN + FR)

### DIFF
--- a/content/docs/changelog.fr.mdx
+++ b/content/docs/changelog.fr.mdx
@@ -5,6 +5,36 @@ description: Historique des versions de vantage-peers-mcp.
 
 # Journal des modifications
 
+## v2.4.1 — 2026-05-30
+
+### Corrigé
+
+- **Régression 401 sur le chemin d'auth DCR** ([#556](https://github.com/vantageos-agency/vantage-peers/issues/556) / [#557](https://github.com/vantageos-agency/vantage-peers/pull/557)) — `oauthDcr:validateAccessToken` était déclaré `internalQuery` et inaccessible via le client HTTP, le Path 3 DCR retournait 401 même avec un token valide. Maintenant exposé en `query` publique. Les connecteurs custom Claude.ai via DCR fonctionnent de bout en bout.
+- **Format du header `WWW-Authenticate`** ([#557](https://github.com/vantageos-agency/vantage-peers/pull/557)) — émet `Bearer resource_metadata="..."` selon la spec MCP §Protected Resource Metadata Discovery. L'ancienne forme `Bearer resource="..."` cassait le bootstrap PRM de Claude.ai sur 401.
+
+### Ajouté
+
+- **Annotations d'outils ChatGPT Apps SDK** ([#555](https://github.com/vantageos-agency/vantage-peers/pull/555)) — les 84 outils MCP embarquent désormais `readOnlyHint`, `openWorldHint` et `destructiveHint`. 34 read-only + 41 write + 9 destructive. Les connecteurs custom ChatGPT n'affichent les prompts de confirmation que sur les opérations d'écriture/destructives.
+- **Isolation de scope DCR** ([#554](https://github.com/vantageos-agency/vantage-peers/pull/554)) — nouveau profil `public-readonly` + tests cross-tenant. Le flux DCR auto-discovery résout vers `scopeProfile=client-generic` (jamais `master`), même si un legacy token row porte `scope="mcp:full"`.
+- **Documentation VantagePeers Cloud** ([site #120](https://github.com/vantageos-agency/vantage-peers-site/pull/120)) — section `/docs/cloud/` dédiée à la version hébergée multi-tenant. Multi-client MCP : Claude.ai, ChatGPT, Claude Code, Codex, tout IDE supportant MCP.
+
+### Liens
+
+- Release GitHub : [v2.4.1](https://github.com/vantageos-agency/vantage-peers/releases/tag/v2.4.1)
+- npm : [vantage-peers-mcp@2.4.1](https://www.npmjs.com/package/vantage-peers-mcp)
+
+## v2.4.0 — 2026-05-29
+
+### Ajouté
+
+- **Table `iframeEmbedSessions` + marqueur de stream `__VP_TOOL_RESULT__`** ([#545](https://github.com/vantageos-agency/vantage-peers/pull/545)) — jalon M3. Primitive UI ack-checklist embarquée. 24 tests.
+- **httpAction `credentials:issueBearerFromClerk`** ([#546](https://github.com/vantageos-agency/vantage-peers/pull/546)) — émission de bearer côté serveur liée à une identité Clerk, avec audit log. Corrections P1 iter 2.
+
+### Liens
+
+- Release GitHub : [v2.4.0](https://github.com/vantageos-agency/vantage-peers/releases/tag/v2.4.0)
+- npm : [vantage-peers-mcp@2.4.0](https://www.npmjs.com/package/vantage-peers-mcp)
+
 ## v2.3.1 — 2026-05-26
 
 ### Ajouté

--- a/content/docs/changelog.mdx
+++ b/content/docs/changelog.mdx
@@ -5,6 +5,36 @@ description: Release history for vantage-peers-mcp.
 
 # Changelog
 
+## v2.4.1 — 2026-05-30
+
+### Fixed
+
+- **DCR auth path 401 regression** ([#556](https://github.com/vantageos-agency/vantage-peers/issues/556) / [#557](https://github.com/vantageos-agency/vantage-peers/pull/557)) — `oauthDcr:validateAccessToken` was declared `internalQuery` and unreachable via the HTTP client, so Path 3 DCR returned 401 even with a valid token. Now exposed as a public `query`. Claude.ai Custom Connectors via DCR works end-to-end.
+- **`WWW-Authenticate` header format** ([#557](https://github.com/vantageos-agency/vantage-peers/pull/557)) — emits `Bearer resource_metadata="..."` per MCP spec §Protected Resource Metadata Discovery. The prior `Bearer resource="..."` broke Claude.ai PRM bootstrap on 401.
+
+### Added
+
+- **ChatGPT Apps SDK tool annotations** ([#555](https://github.com/vantageos-agency/vantage-peers/pull/555)) — all 84 MCP tools now ship with `readOnlyHint`, `openWorldHint`, and `destructiveHint`. 34 read-only + 41 write + 9 destructive. ChatGPT custom connectors render confirmation prompts only on writes/destructive ops.
+- **DCR scope isolation** ([#554](https://github.com/vantageos-agency/vantage-peers/pull/554)) — new `public-readonly` profile + cross-tenant assertion tests. The DCR auto-discovery flow now resolves to `scopeProfile=client-generic` (never `master`), even if a legacy token row carries `scope="mcp:full"`.
+- **VantagePeers Cloud documentation** ([site #120](https://github.com/vantageos-agency/vantage-peers-site/pull/120)) — dedicated `/docs/cloud/` section for the hosted, multi-tenant version. Multi-client MCP: Claude.ai, ChatGPT, Claude Code, Codex, any MCP-supporting IDE.
+
+### Links
+
+- GitHub release: [v2.4.1](https://github.com/vantageos-agency/vantage-peers/releases/tag/v2.4.1)
+- npm: [vantage-peers-mcp@2.4.1](https://www.npmjs.com/package/vantage-peers-mcp)
+
+## v2.4.0 — 2026-05-29
+
+### Added
+
+- **`iframeEmbedSessions` table + `__VP_TOOL_RESULT__` stream marker** ([#545](https://github.com/vantageos-agency/vantage-peers/pull/545)) — M3 milestone. Embedded ack-checklist UI primitive. 24 tests.
+- **`credentials:issueBearerFromClerk` httpAction** ([#546](https://github.com/vantageos-agency/vantage-peers/pull/546)) — server-side bearer issuance bound to a Clerk identity, with audit log. Iter 2 P1 fixes.
+
+### Links
+
+- GitHub release: [v2.4.0](https://github.com/vantageos-agency/vantage-peers/releases/tag/v2.4.0)
+- npm: [vantage-peers-mcp@2.4.0](https://www.npmjs.com/package/vantage-peers-mcp)
+
 ## v2.3.1 — 2026-05-26
 
 ### Added


### PR DESCRIPTION
## Summary

Day 88 — backfill v2.4.0 (Day 86) + add v2.4.1 (Day 88) changelog entries on the public docs site. EN + FR mirrored.

The changelog was last updated for v2.3.1 (2026-05-26). v2.4.0 shipped 2026-05-29 (M3 milestone) and v2.4.1 shipped today 2026-05-30 — both missing from public docs.

## v2.4.1 (today)
- fix(dcr) `validateAccessToken` `internalQuery`→`query` (#556 / #557)
- fix(dcr) `WWW-Authenticate: Bearer resource_metadata="..."` per MCP spec (#557)
- feat(mcp) 84 tools ChatGPT Apps SDK annotations (#555)
- security(dcr) `public-readonly` profile + cross-tenant tests (#554)
- docs(cloud) dedicated `/docs/cloud/` section (#120)

## v2.4.0 (M3)
- feat(m3) `iframeEmbedSessions` + `__VP_TOOL_RESULT__` stream marker (#545)
- feat(v0.0.2-auth) `credentials:issueBearerFromClerk` httpAction (#546)

## Test plan
- 2 files: `content/docs/changelog.mdx` + `content/docs/changelog.fr.mdx`
- Pure additive — no existing content modified
- EN + FR semantically aligned

Orchestrator: Sigma — VantageOS Team | 2026-05-30
