### PR TITLE
docs(cloud): onboarding v2 — first-steps + UX fixes

### DIFF
--- a/content/docs/cloud/connect.fr.mdx
+++ b/content/docs/cloud/connect.fr.mdx
@@ -38,7 +38,7 @@ Le plan Free permet 1 connecteur custom. Pro, Max, Team et Enterprise en permett
    - **Client Secret** : votre `client_secret`
 6. Cliquez **Ajouter**, puis acceptez le prompt de consentement OAuth.
 7. Dans une conversation, cliquez **+** → activez **vantage-peers**.
-8. Test : *« Liste mes mémoires VantagePeers »* — Claude doit appeler `recall`.
+8. Test : demandez à Claude *« Appelle recall avec query=hello et namespace=global »* — Claude doit appeler `recall`. Un tenant frais retourne un tableau vide, c'est normal. Une fois une mémoire stockée (voir [Premiers pas](./first-steps)), `recall` la retourne.
 
 Utilisez **Advanced + Client ID/Secret**. Le chemin URL-only auto-discovery fonctionne mais est lié à un client enregistré transitoire et obtient le scope par défaut `client-generic`.
 
@@ -53,7 +53,7 @@ Deux chemins selon votre plan :
 3. **URL** : `https://vantage-peers-production.up.railway.app/mcp`.
 4. Enregistrer. ChatGPT découvre le serveur d'auth via `/.well-known/oauth-protected-resource`, exécute PKCE, et vous acceptez le prompt de consentement.
 5. Dans une conversation, sélectionnez le connecteur **vantage-peers**.
-6. Test : *« Liste mes tâches VantagePeers »*.
+6. Test : demandez à ChatGPT *« Appelle list_tasks avec status=todo »*. Un tenant frais retourne un tableau vide (normal). Créez une tâche d'abord via [Premiers pas](./first-steps) pour voir une vraie sortie.
 
 **Developer Mode (beta)** — accepte `client_id` + `client_secret` directement.
 

--- a/content/docs/cloud/connect.mdx
+++ b/content/docs/cloud/connect.mdx
@@ -38,7 +38,7 @@ The Free plan allows 1 custom connector. Pro, Max, Team, and Enterprise allow mu
    - **Client Secret**: your `client_secret`
 6. Click **Add**, then accept the OAuth consent prompt.
 7. In a conversation, click **+** → enable **vantage-peers**.
-8. Test: *"List my VantagePeers memories"* — Claude must call `recall`.
+8. Test: ask Claude *"Call recall with query=hello and namespace=global"* — Claude must call `recall`. A fresh tenant returns an empty array, which is correct. Once you have stored a memory (see [First steps](./first-steps)), recall returns it.
 
 Use **Advanced + Client ID/Secret**. The URL-only auto-discovery path works but is bound to a transient registered client and grants the default `client-generic` scope.
 
@@ -53,7 +53,7 @@ Two paths depending on your plan:
 3. **URL**: `https://vantage-peers-production.up.railway.app/mcp`.
 4. Save. ChatGPT discovers the auth server via `/.well-known/oauth-protected-resource`, runs PKCE, and you accept the consent prompt.
 5. In a conversation, select the **vantage-peers** connector.
-6. Test: *"List my VantagePeers tasks"*.
+6. Test: ask ChatGPT *"Call list_tasks with status=todo"*. A fresh tenant returns an empty array (correct). Create a task first via [First steps](./first-steps) to see real output.
 
 **Developer Mode (beta)** — accepts `client_id` + `client_secret` directly.
 

--- a/content/docs/cloud/first-steps.fr.mdx
+++ b/content/docs/cloud/first-steps.fr.mdx
@@ -1,0 +1,73 @@
+---
+title: Premiers pas après connexion
+description: Enregistrez votre identité d'orchestrateur, stockez votre première mémoire et vérifiez votre workspace Cloud en 5 étapes.
+---
+
+Une fois votre client MCP [connecté à VantagePeers Cloud](./connect), suivez ces 5 étapes pour enregistrer votre identité d'orchestrateur et vérifier que la lecture + l'écriture fonctionnent de bout en bout.
+
+Ces étapes remplacent le runbook self-host "premiers pas" pour les utilisateurs Cloud — Cloud n'a aucune infrastructure à configurer, seulement une identité d'orchestrateur à déclarer.
+
+## 1. Choisissez votre identité d'orchestrateur
+
+Une **identité d'orchestrateur** est le label en minuscules que VantagePeers utilise pour scoper vos mémoires, tâches et messages. Vous la choisissez une fois et la conservez entre les sessions.
+
+Conventions :
+- Utilisez un mot unique en minuscules (par ex. `marie`, `victor`, `acme-research`).
+- Ajoutez un **instance ID** si vous lancez la même identité depuis plusieurs machines (par ex. `marie-laptop`, `marie-vps`).
+
+Le premier ID que vous verrez dans les sorties d'outils est `orchestratorId` ; la variante par machine est `instanceId`.
+
+## 2. Déclarez votre résumé de session
+
+Dans votre client MCP, exécutez :
+
+```text
+set_summary orchestratorId="marie" instanceId="marie-laptop" summary="Onboarding VantagePeers Cloud"
+```
+
+Ce que ça fait : enregistre votre identité dans la table `profiles`, vous rend visible aux autres orchestrateurs via `list_peers`, et fournit un champ `from` par défaut pour tous les appels suivants. Résultat attendu : un objet JSON qui renvoie l'orchestratorId, l'instanceId et le summary envoyés.
+
+## 3. Stockez votre première mémoire
+
+Maintenant, sauvegardez une mémoire dans le namespace de votre tenant :
+
+```text
+store_memory namespace="project/marie-onboarding" type="reference" content="VantagePeers Cloud première mémoire — connexion vérifiée." createdBy="marie"
+```
+
+Ce que ça fait : écrit une ligne dans `memories` avec embedding vectoriel + index BM25, scopée à votre tenant. Résultat attendu : un objet JSON avec un `memoryId` (commence par `m`) et le namespace utilisé. Gardez cet id à portée pour l'étape 4.
+
+## 4. Rappelez ce que vous venez de stocker
+
+Même client, même session :
+
+```text
+recall query="connexion vérifiée" namespace="project/marie-onboarding" limit=5
+```
+
+Ce que ça fait : exécute une recherche hybride (vectoriel + BM25 + RRF fusion) contre le scope de votre tenant. Résultat attendu : un tableau contenant au moins la mémoire stockée en étape 3, avec un score de similarité. Si le tableau est vide, votre scope tenant est vide — refaites l'étape 3, puis réessayez.
+
+Si vous avez lancé `recall query="hello"` sans écriture préalable, la réponse est correctement vide : aucune mémoire n'existe encore dans votre scope. Le backend Cloud isole chaque tenant — vous ne voyez pas les données des autres tenants, et ils ne voient pas les vôtres.
+
+## 5. Vérifiez les peers + parcourez le catalogue d'outils
+
+Pour confirmer que votre identité est visible à la fleet :
+
+```text
+list_peers
+```
+
+Vous devriez apparaître dans la liste retournée avec le summary de l'étape 2.
+
+Pour parcourir tous les outils disponibles, voir le [Tools Reference](/docs/tools) — 84 outils dans 14 catégories, tous appelables à partir de maintenant.
+
+## La suite
+
+Vous êtes maintenant production-ready sur VantagePeers Cloud. À partir d'ici :
+
+- **Créez des tâches** avec `create_task` — assignez du travail à vous-même ou à d'autres orchestrateurs.
+- **Envoyez des messages** avec `send_message` — direct, broadcast par rôle, ou fleet-wide.
+- **Écrivez une entrée de diary** avec `write_diary` — capturez les décisions du jour pour rappel ultérieur.
+- **Parcourez le [journal des modifications](/docs/changelog)** pour les dernières fonctionnalités.
+
+Si quelque chose ne fonctionne pas comme attendu, consultez la [section dépannage de Connect](./connect#dépannage) ou contactez VantageOS via votre canal d'onboarding.

--- a/content/docs/cloud/first-steps.mdx
+++ b/content/docs/cloud/first-steps.mdx
@@ -1,0 +1,73 @@
+---
+title: First steps after connecting
+description: Register your orchestrator identity, store your first memory, and verify your Cloud workspace in 5 steps.
+---
+
+Once your MCP client is [connected to VantagePeers Cloud](./connect), follow these 5 steps to register your orchestrator identity and verify that read + write work end-to-end.
+
+These steps replace the self-host "getting started" runbook for Cloud users — Cloud has no infrastructure to set up, only an orchestrator identity to declare.
+
+## 1. Pick your orchestrator identity
+
+An **orchestrator identity** is the lowercase label that VantagePeers uses to scope your memories, tasks, and messages. You choose it once and keep it across sessions.
+
+Conventions:
+- Use a single lowercase word (e.g. `marie`, `victor`, `acme-research`).
+- Add an **instance ID** if you'll run the same identity from multiple machines (e.g. `marie-laptop`, `marie-vps`).
+
+The first ID you'll see in tool outputs is `orchestratorId`; the per-machine variant is `instanceId`.
+
+## 2. Declare your session summary
+
+In your MCP client, run:
+
+```text
+set_summary orchestratorId="marie" instanceId="marie-laptop" summary="VantagePeers Cloud onboarding"
+```
+
+What this does: registers your identity in the `profiles` table, makes you visible to other orchestrators via `list_peers`, and gives every later call a default `from` field. Expected result: a JSON object echoing the orchestratorId, instanceId, and summary you sent.
+
+## 3. Store your first memory
+
+Now save a memory in your tenant namespace:
+
+```text
+store_memory namespace="project/marie-onboarding" type="reference" content="VantagePeers Cloud first memory — connection verified." createdBy="marie"
+```
+
+What this does: writes a row to `memories` with vector embedding + BM25 index, scoped to your tenant. Expected result: a JSON object with a `memoryId` (starts with `m`) and the namespace you used. Keep that id handy for step 4.
+
+## 4. Recall what you just stored
+
+Same client, same session:
+
+```text
+recall query="connection verified" namespace="project/marie-onboarding" limit=5
+```
+
+What this does: runs hybrid search (vector + BM25 + RRF fusion) against your tenant scope. Expected result: an array containing at least the memory you stored in step 3, with a similarity score. If the array is empty, your tenant scope is empty — repeat step 3, then retry.
+
+If you instead ran `recall query="hello"` with no prior writes, the response is correctly empty: no memory exists yet in your scope. The Cloud backend isolates each tenant, so you do not see other tenants' data and they do not see yours.
+
+## 5. Verify peers + browse the tool catalog
+
+To confirm your identity is visible to the fleet:
+
+```text
+list_peers
+```
+
+You should appear in the returned list with the summary from step 2.
+
+To browse every available tool, see the [Tools Reference](/docs/tools) — 84 tools across 14 categories, all callable from this point onward.
+
+## What's next
+
+You are now production-ready on VantagePeers Cloud. From here:
+
+- **Create tasks** with `create_task` — assign work to yourself or other orchestrators.
+- **Send messages** with `send_message` — direct, role-broadcast, or fleet-wide.
+- **Write a diary entry** with `write_diary` — capture the day's decisions for future recall.
+- **Browse the [changelog](/docs/changelog)** for the latest feature releases.
+
+If something does not work as expected, check the [Connect troubleshooting section](./connect#troubleshooting) or contact VantageOS via your onboarding channel.

--- a/content/docs/cloud/index.fr.mdx
+++ b/content/docs/cloud/index.fr.mdx
@@ -12,13 +12,16 @@ Avec VantagePeers Cloud, vous sautez toutes les étapes de self-host : pas de Do
 Tout ce dont vous avez besoin pour démarrer :
 
 - Un `client_id` et un `client_secret` émis par VantageOS
-- Un client MCP supporté : Claude Code, Claude.ai ou ChatGPT
+- Un client MCP supporté : Claude.ai, ChatGPT, Claude Code ou Codex — et tout autre IDE parlant le protocole MCP.
 
-## 3 chemins pour se connecter
+## Démarrer
 
-Une fois vos identifiants en main, suivez le runbook étape par étape pour votre client :
+Deux pages vous mènent des identifiants à un workspace opérationnel :
 
-- [Se connecter à VantagePeers Cloud](./connect) — instructions Claude Code, Claude.ai et ChatGPT sur une seule page
+1. [Se connecter](./connect) — branchez le client MCP que vous utilisez (Claude.ai, ChatGPT, Claude Code, Codex). Une seule page couvre les quatre.
+2. [Premiers pas](./first-steps) — déclarez votre identité d'orchestrateur, stockez votre première mémoire, vérifiez peers + outils (5 étapes).
+
+Une fois connecté, le [Tools Reference](/docs/tools) liste chaque capacité disponible (84 outils dans 14 catégories).
 
 ## Cloud vs Self-host
 

--- a/content/docs/cloud/index.mdx
+++ b/content/docs/cloud/index.mdx
@@ -12,13 +12,16 @@ With VantagePeers Cloud you skip every self-host step: no Docker, no Railway pro
 All you need to get started:
 
 - A `client_id` and `client_secret` issued by VantageOS
-- One supported MCP client: Claude Code, Claude.ai, or ChatGPT
+- One supported MCP client: Claude.ai, ChatGPT, Claude Code, or Codex — and any other IDE that speaks the MCP protocol.
 
-## 3 paths to connect
+## Get started
 
-Once you have your credentials, follow the step-by-step runbook for your client:
+Two pages get you from credentials to a working workspace:
 
-- [Connect to VantagePeers Cloud](./connect) — Claude Code, Claude.ai, and ChatGPT instructions in a single page
+1. [Connect](./connect) — wire up the MCP client you use (Claude.ai, ChatGPT, Claude Code, Codex). One page covers all four.
+2. [First steps](./first-steps) — declare your orchestrator identity, store your first memory, verify peers + tools (5 steps).
+
+Once connected, the [Tools Reference](/docs/tools) lists every available capability (84 tools across 14 categories).
 
 ## Cloud vs Self-host
 

--- a/content/docs/cloud/meta.fr.json
+++ b/content/docs/cloud/meta.fr.json
@@ -1,5 +1,5 @@
 {
   "title": "Cloud",
   "defaultOpen": true,
-  "pages": ["index", "connect"]
+  "pages": ["index", "connect", "first-steps"]
 }

--- a/content/docs/cloud/meta.json
+++ b/content/docs/cloud/meta.json
@@ -1,5 +1,5 @@
 {
   "title": "Cloud",
   "defaultOpen": true,
-  "pages": ["index", "connect"]
+  "pages": ["index", "connect", "first-steps"]
 }

--- a/content/docs/tools.fr.mdx
+++ b/content/docs/tools.fr.mdx
@@ -1,11 +1,11 @@
 ---
 title: Référence des outils
-description: Les 82 outils MCP répartis en 14 catégories de capacités dans VantagePeers.
+description: Les 84 outils MCP répartis en 14 catégories de capacités dans VantagePeers.
 ---
 
 # Référence des outils
 
-VantagePeers expose 82 outils MCP organisés en 14 catégories de capacités. Chaque outil accepte et retourne du JSON. Toutes les valeurs sont des chaînes en minuscules sauf indication contraire.
+VantagePeers expose 84 outils MCP organisés en 14 catégories de capacités. Chaque outil accepte et retourne du JSON. Toutes les valeurs sont des chaînes en minuscules sauf indication contraire.
 
 ## Catégories d'outils
 

--- a/content/docs/tools.mdx
+++ b/content/docs/tools.mdx
@@ -1,11 +1,11 @@
 ---
 title: Tools Reference
-description: All 82 MCP tools across 14 capability categories in VantagePeers.
+description: All 84 MCP tools across 14 capability categories in VantagePeers.
 ---
 
 # Tools Reference
 
-VantagePeers exposes 82 MCP tools organized into 14 capability categories. Every tool accepts and returns JSON. All values are lowercase strings unless noted.
+VantagePeers exposes 84 MCP tools organized into 14 capability categories. Every tool accepts and returns JSON. All values are lowercase strings unless noted.
 
 ## Tool Categories
 


### PR DESCRIPTION
## Summary

Day 88 — Cloud onboarding v2 per Laurent feedback post-PR #122 merge. 3 UX gaps closed.

## Gaps fixed

1. **No Cloud orchestrator registration flow** → new page `/docs/cloud/first-steps.{mdx,fr.mdx}` (5 steps: pick identity → `set_summary` → `store_memory` → `recall` → `list_peers` + Tools Reference link). Replaces what Self-host getting-started covered, without polluting Cloud with Self-host content (per ABSOLUTE RULE #10).
2. **`recall query="hello"` returns empty on fresh tenant → user confusion** → connect test steps reformulated to set expectation (fresh tenant = empty array is correct) + link to first-steps for real output.
3. **No link to Tools Reference + Tools page stale (82)** → tools.{mdx,fr.mdx} bumped 82 → 84, cloud/index links to it.

## Bonus
- cloud/index "3 paths" wording fixed → 4 MCP clients (Claude.ai/ChatGPT/Claude Code/Codex + "any MCP-supporting IDE").
- meta.{json,fr.json} register new first-steps page in nav.

## Diff
- 10 files, +170/-18
- EN + FR strict parity
- No code changes
- Pure additive on first-steps; rewording on index + connect + tools

## Test plan
- Eta skip (docs-only per Pi directive)
- Laurent visual ack Vercel preview avant merge

Orchestrator: Sigma — VantageOS Team | 2026-05-30
