### PR TITLE
docs(cloud): Laurent fix — accurate Claude.ai + ChatGPT steps + Skills + first-steps rewrite

### DIFF
--- a/content/docs/cloud/connect.fr.mdx
+++ b/content/docs/cloud/connect.fr.mdx
@@ -27,43 +27,50 @@ Le `client_secret` n'est **pas** un bearer token. Il est présenté au endpoint 
 
 ## Claude.ai (web)
 
-Le plan Free permet 1 connecteur custom. Pro, Max, Team et Enterprise en permettent plusieurs.
+Le plan Free autorise 1 connecteur custom. Pro, Max, Team et Enterprise en autorisent plusieurs.
 
 1. Ouvrez [claude.ai](https://claude.ai).
-2. Cliquez votre avatar → **Personnaliser** → **Connecteurs**.
-3. Cliquez **+** puis **Ajouter un connecteur custom**.
-4. **URL** : `https://vantage-peers-production.up.railway.app/mcp`.
-5. Cliquez **Advanced** et collez :
-   - **Client ID** : votre `client_id`
-   - **Client Secret** : votre `client_secret`
-6. Cliquez **Ajouter**, puis acceptez le prompt de consentement OAuth.
-7. Dans une conversation, cliquez **+** → activez **vantage-peers**.
-8. Test : demandez à Claude *« Appelle recall avec query=hello et namespace=global »* — Claude doit appeler `recall`. Un tenant frais retourne un tableau vide, c'est normal. Une fois une mémoire stockée (voir [Premiers pas](./first-steps)), `recall` la retourne.
+2. Dans la sidebar de gauche, cliquez **Personnaliser**.
+3. Cliquez **Connecteurs**.
+4. Cliquez le bouton **+** en haut à droite de la liste des connecteurs, puis sélectionnez **Ajouter un connecteur personnalisé**.
+5. Dans la modale **Ajouter un connecteur personnalisé**, renseignez :
+   - **Nom** : `VantagePeers` (ou tout label de votre choix — c'est ce qui apparaîtra dans vos conversations).
+   - **URL du serveur MCP distant** : `https://vantage-peers-production.up.railway.app/mcp`
+6. Déployez **Paramètres avancés** et collez :
+   - **ID client OAuth** : votre `client_id`
+   - **Secret client OAuth** : votre `client_secret`
+7. Cliquez **Ajouter**. Un onglet navigateur s'ouvre pour le consentement OAuth — acceptez.
+8. Dans une conversation, cliquez **+** dans la zone de saisie → activez **VantagePeers** (ou le nom donné à l'étape 5).
+9. Test en langage naturel : *« Utilise vantage-peers pour récupérer ce que tu trouves sur VantagePeers dans le namespace global. »* Claude route vers l'outil `recall`. Un tenant tout neuf ne renvoie rien — c'est normal (voir [Premiers pas](./first-steps) pour peupler votre workspace).
 
-Utilisez **Advanced + Client ID/Secret**. Le chemin URL-only auto-discovery fonctionne mais est lié à un client enregistré transitoire et obtient le scope par défaut `client-generic`.
+Utilisez les Paramètres avancés avec Client ID + Secret. Le chemin URL-only auto-discovery fonctionne aussi mais vous attache à un client transitoire et au scope par défaut `client-generic`.
 
 ## ChatGPT
 
-Deux chemins selon votre plan :
+Le support MCP end-to-end ChatGPT est documenté par OpenAI dans [Apps SDK — Connect from ChatGPT](https://developers.openai.com/apps-sdk/deploy/connect-chatgpt). Depuis le 13/11/2025, **Apps & Connectors sont disponibles sur tous les plans payants (Plus, Pro, Business, Enterprise, Education)**.
 
-**Custom Connectors (Pro/Business/Enterprise)** — utilise la PRM discovery DCR, sans champ de credentials.
+### Activer Developer Mode (une fois)
 
 1. Ouvrez [chatgpt.com](https://chatgpt.com).
-2. Settings → **Connectors** → **Create a Connector**.
-3. **URL** : `https://vantage-peers-production.up.railway.app/mcp`.
-4. Enregistrer. ChatGPT découvre le serveur d'auth via `/.well-known/oauth-protected-resource`, exécute PKCE, et vous acceptez le prompt de consentement.
-5. Dans une conversation, sélectionnez le connecteur **vantage-peers**.
-6. Test : demandez à ChatGPT *« Appelle list_tasks avec status=todo »*. Un tenant frais retourne un tableau vide (normal). Créez une tâche d'abord via [Premiers pas](./first-steps) pour voir une vraie sortie.
+2. **Settings** → **Apps & Connectors** → **Advanced settings**.
+3. Activez **Developer mode**. Si votre politique organisationnelle le bloque, contactez votre admin.
 
-**Developer Mode (beta)** — accepte `client_id` + `client_secret` directement.
+### Ajouter VantagePeers Cloud
 
-1. Settings → **Beta features** → activez **Developer Mode** (si disponible sur votre compte).
-2. Settings → **Connectors** → **Create a Connector**.
-3. **URL** : `https://vantage-peers-production.up.railway.app/mcp`.
-4. **Auth** : collez vos `client_id` et `client_secret`.
-5. Enregistrer et sélectionner le connecteur dans une conversation.
+1. De retour dans **Settings → Apps & Connectors**, cliquez **Create**. La modale **New App** s'ouvre.
+2. Renseignez :
+   - **Icon** (optionnel) : uploadez une icône VantagePeers si vous en avez une.
+   - **Name** : `VantagePeers`
+   - **Description** (optionnel) : `Mémoire partagée, tâches et messagerie pour équipes d'agents IA.`
+   - **Connection** → laissez **Server URL** sélectionné.
+   - **Server URL** : `https://vantage-peers-production.up.railway.app/mcp`
+   - **Authentication** : sélectionnez **OAuth**.
+3. Déployez **Advanced OAuth settings**. Sous **Client registration**, choisissez **Dynamic Client Registration (DCR)** — le serveur l'annonce ; CIMD n'est pas supporté, User-Defined OAuth Client est une alternative si vous voulez réutiliser un `client_id`+`client_secret` fixe.
+4. Cochez **I understand and want to continue** (warning OpenAI sur les serveurs MCP custom) et cliquez **Create**. Le flux de consentement navigateur s'exécute ; acceptez.
+5. Dans une nouvelle conversation, cliquez **+** dans la zone de saisie → **More** → sélectionnez **VantagePeers**.
+6. Test en langage naturel : *« Utilise VantagePeers pour lister mes tâches ouvertes. »* ChatGPT appelle `list_tasks`. Un tenant tout neuf renvoie une liste vide — peuplez-le via [Premiers pas](./first-steps).
 
-Les outils d'écriture/destructifs (`create_*`, `delete_*`, `update_*`) déclenchent des prompts de confirmation dans ChatGPT — comportement attendu piloté par l'annotation `destructiveHint`.
+Les outils d'écriture et destructifs (`create_*`, `update_*`, `delete_*`) déclenchent des prompts de confirmation avant exécution. C'est piloté par les annotations `readOnlyHint` et `destructiveHint` portées par chaque outil — comportement attendu, pas un bug.
 
 ## Claude Code
 

--- a/content/docs/cloud/connect.mdx
+++ b/content/docs/cloud/connect.mdx
@@ -30,40 +30,47 @@ The `client_secret` is **not** a bearer token. It is presented to the `/token` e
 The Free plan allows 1 custom connector. Pro, Max, Team, and Enterprise allow multiple.
 
 1. Open [claude.ai](https://claude.ai).
-2. Click your avatar → **Customize** → **Connectors**.
-3. Click **+** then **Add custom connector**.
-4. **URL**: `https://vantage-peers-production.up.railway.app/mcp`.
-5. Click **Advanced** and paste:
-   - **Client ID**: your `client_id`
-   - **Client Secret**: your `client_secret`
-6. Click **Add**, then accept the OAuth consent prompt.
-7. In a conversation, click **+** → enable **vantage-peers**.
-8. Test: ask Claude *"Call recall with query=hello and namespace=global"* — Claude must call `recall`. A fresh tenant returns an empty array, which is correct. Once you have stored a memory (see [First steps](./first-steps)), recall returns it.
+2. In the left sidebar, click **Customize** (in French: **Personnaliser**).
+3. Click **Connectors** (in French: **Connecteurs**).
+4. Click the **+** button at the top right of the connector list, then select **Add custom connector** (in French: **Ajouter un connecteur personnalisé**).
+5. In the modal **Add custom connector**, fill in:
+   - **Name** (in French: **Nom**): `VantagePeers` (any label you want — this is what will appear in your conversations).
+   - **Remote MCP server URL** (in French: **URL du serveur MCP distant**): `https://vantage-peers-production.up.railway.app/mcp`
+6. Expand **Advanced settings** (in French: **Paramètres avancés**) and paste:
+   - **OAuth Client ID** (in French: **ID client OAuth**): your `client_id`
+   - **OAuth Client Secret** (in French: **Secret client OAuth**): your `client_secret`
+7. Click **Add** (in French: **Ajouter**). A browser tab opens for OAuth consent — accept.
+8. In a conversation, click **+** in the composer → toggle **VantagePeers** on (or whatever name you used in step 5).
+9. Test in natural language: *"Use vantage-peers to recall anything you find about VantagePeers in the global namespace."* Claude routes the request to the `recall` tool. A brand-new tenant returns nothing — that is correct (see [First steps](./first-steps) to populate your workspace).
 
-Use **Advanced + Client ID/Secret**. The URL-only auto-discovery path works but is bound to a transient registered client and grants the default `client-generic` scope.
+Use Advanced settings with your Client ID + Secret. The URL-only auto-discovery path also works but binds you to a transient registered client and the default `client-generic` scope.
 
 ## ChatGPT
 
-Two paths depending on your plan:
+End-to-end ChatGPT MCP support is documented by OpenAI in [Apps SDK — Connect from ChatGPT](https://developers.openai.com/apps-sdk/deploy/connect-chatgpt). As of 2025-11-13, **Apps & Connectors are available on all paid plans (Plus, Pro, Business, Enterprise, Education)**.
 
-**Custom Connectors (Pro/Business/Enterprise)** — uses DCR PRM discovery, no creds field.
+### Enable Developer Mode (one-time)
 
 1. Open [chatgpt.com](https://chatgpt.com).
-2. Settings → **Connectors** → **Create a Connector**.
-3. **URL**: `https://vantage-peers-production.up.railway.app/mcp`.
-4. Save. ChatGPT discovers the auth server via `/.well-known/oauth-protected-resource`, runs PKCE, and you accept the consent prompt.
-5. In a conversation, select the **vantage-peers** connector.
-6. Test: ask ChatGPT *"Call list_tasks with status=todo"*. A fresh tenant returns an empty array (correct). Create a task first via [First steps](./first-steps) to see real output.
+2. Go to **Settings** → **Apps & Connectors** → **Advanced settings**.
+3. Toggle **Developer mode** on. If your org policy blocks this, contact your admin.
 
-**Developer Mode (beta)** — accepts `client_id` + `client_secret` directly.
+### Add VantagePeers Cloud
 
-1. Settings → **Beta features** → enable **Developer Mode** (if available on your account).
-2. Settings → **Connectors** → **Create a Connector**.
-3. **URL**: `https://vantage-peers-production.up.railway.app/mcp`.
-4. **Auth**: paste your `client_id` and `client_secret`.
-5. Save and select the connector in a conversation.
+1. Back in **Settings → Apps & Connectors**, click **Create**. The **New App** modal opens.
+2. Fill in:
+   - **Icon** (optional): upload a VantagePeers icon if you have one.
+   - **Name**: `VantagePeers`
+   - **Description** (optional): `Shared memory, tasks and messaging for AI agent teams.`
+   - **Connection** → keep **Server URL** selected.
+   - **Server URL**: `https://vantage-peers-production.up.railway.app/mcp`
+   - **Authentication**: select **OAuth**.
+3. Expand **Advanced OAuth settings**. Under **Client registration**, choose **Dynamic Client Registration (DCR)** — the server advertises it; CIMD is not supported, User-Defined OAuth Client is an alternative if you want to reuse your fixed `client_id`+`client_secret`.
+4. Tick **I understand and want to continue** (the OpenAI risk warning for custom MCP servers) and click **Create**. A browser consent flow runs; accept.
+5. In a new conversation, click **+** in the composer → **More** → select **VantagePeers**.
+6. Test in natural language: *"Use VantagePeers to list my open tasks."* ChatGPT calls `list_tasks`. A brand-new tenant returns an empty list — populate it via [First steps](./first-steps).
 
-Write/destructive tools (`create_*`, `delete_*`, `update_*`) trigger confirmation prompts in ChatGPT — this is the expected behavior driven by the `destructiveHint` annotation.
+Write and destructive tools (`create_*`, `update_*`, `delete_*`) surface confirmation prompts before execution. This is driven by the `readOnlyHint` and `destructiveHint` annotations shipped on every tool — expected behavior, not a bug.
 
 ## Claude Code
 

--- a/content/docs/cloud/first-steps.fr.mdx
+++ b/content/docs/cloud/first-steps.fr.mdx
@@ -1,73 +1,51 @@
 ---
 title: Premiers pas après connexion
-description: Enregistrez votre identité d'orchestrateur, stockez votre première mémoire et vérifiez votre workspace Cloud en 5 étapes.
+description: Un parcours en 5 étapes en langage naturel pour enregistrer votre identité, écrire votre première mémoire et confirmer que VantagePeers Cloud fonctionne.
 ---
 
-Une fois votre client MCP [connecté à VantagePeers Cloud](./connect), suivez ces 5 étapes pour enregistrer votre identité d'orchestrateur et vérifier que la lecture + l'écriture fonctionnent de bout en bout.
+Votre client MCP est [connecté](./connect). Vous parlez maintenant à l'assistant en langage naturel — vous ne tapez **pas** de noms d'outils comme `set_summary` ni de JSON. L'assistant choisit le bon outil VantagePeers pour chaque demande.
 
-Ces étapes remplacent le runbook self-host "premiers pas" pour les utilisateurs Cloud — Cloud n'a aucune infrastructure à configurer, seulement une identité d'orchestrateur à déclarer.
+Remplacez `<votre-nom>` ci-dessous par le label en minuscules que vous voulez utiliser (un mot court). VantagePeers s'en sert pour scoper vos mémoires, tâches et messages à vous.
 
-## 1. Choisissez votre identité d'orchestrateur
+## 1. Dites à l'assistant qui vous êtes
 
-Une **identité d'orchestrateur** est le label en minuscules que VantagePeers utilise pour scoper vos mémoires, tâches et messages. Vous la choisissez une fois et la conservez entre les sessions.
+Dans votre conversation, dites :
 
-Conventions :
-- Utilisez un mot unique en minuscules (par ex. `marie`, `victor`, `acme-research`).
-- Ajoutez un **instance ID** si vous lancez la même identité depuis plusieurs machines (par ex. `marie-laptop`, `marie-vps`).
+> *« Utilise VantagePeers. Enregistre-moi comme orchestrateur `<votre-nom>` avec le summary `démarrage`. »*
 
-Le premier ID que vous verrez dans les sorties d'outils est `orchestratorId` ; la variante par machine est `instanceId`.
+L'assistant appelle `set_summary`. Vous devez obtenir une courte confirmation contenant votre nom. C'est votre identité — chaque mémoire et tâche que vous créerez ensuite y sera attachée.
 
-## 2. Déclarez votre résumé de session
+## 2. Sauvegardez votre première mémoire
 
-Dans votre client MCP, exécutez :
+> *« Sauvegarde dans VantagePeers, dans le namespace `project/<votre-nom>-onboarding`, une mémoire de type reference : 'Ma première mémoire — connexion confirmée.' »*
 
-```text
-set_summary orchestratorId="marie" instanceId="marie-laptop" summary="Onboarding VantagePeers Cloud"
-```
+L'assistant appelle `store_memory`. Vous obtenez en retour un memory id (un code court commençant par `m`). Cette ligne est maintenant dans votre tenant privé.
 
-Ce que ça fait : enregistre votre identité dans la table `profiles`, vous rend visible aux autres orchestrateurs via `list_peers`, et fournit un champ `from` par défaut pour tous les appels suivants. Résultat attendu : un objet JSON qui renvoie l'orchestratorId, l'instanceId et le summary envoyés.
+## 3. Retrouvez-la
 
-## 3. Stockez votre première mémoire
+> *« Utilise VantagePeers pour rappeler tout ce qui parle de 'connexion' dans `project/<votre-nom>-onboarding`. »*
 
-Maintenant, sauvegardez une mémoire dans le namespace de votre tenant :
+L'assistant appelle `recall`. Vous devez voir votre phrase de l'étape 2 dans les résultats. Si le résultat est vide, refaites l'étape 2 — parfois la requête est traitée sans outil ; reformuler par *« appelle l'outil recall »* force l'appel.
 
-```text
-store_memory namespace="project/marie-onboarding" type="reference" content="VantagePeers Cloud première mémoire — connexion vérifiée." createdBy="marie"
-```
+## 4. Créez une première tâche
 
-Ce que ça fait : écrit une ligne dans `memories` avec embedding vectoriel + index BM25, scopée à votre tenant. Résultat attendu : un objet JSON avec un `memoryId` (commence par `m`) et le namespace utilisé. Gardez cet id à portée pour l'étape 4.
+> *« Utilise VantagePeers pour créer une tâche assignée à `<votre-nom>` : titre 'Tester les tâches VantagePeers', priorité medium. »*
 
-## 4. Rappelez ce que vous venez de stocker
+L'assistant appelle `create_task`. Vous obtenez un task id. Vous avez utilisé les trois capacités principales — écriture mémoire, lecture mémoire, création de tâche.
 
-Même client, même session :
+## 5. Découvrez le reste
 
-```text
-recall query="connexion vérifiée" namespace="project/marie-onboarding" limit=5
-```
+> *« Liste les outils VantagePeers disponibles pour moi. »*
 
-Ce que ça fait : exécute une recherche hybride (vectoriel + BM25 + RRF fusion) contre le scope de votre tenant. Résultat attendu : un tableau contenant au moins la mémoire stockée en étape 3, avec un score de similarité. Si le tableau est vide, votre scope tenant est vide — refaites l'étape 3, puis réessayez.
+L'assistant renvoie la liste — 84 outils pour mémoire, messagerie, tâches, missions, journal, notes de briefing, recherche, fix patterns, composants, et plus. Référence complète : [Tools](/docs/tools).
 
-Si vous avez lancé `recall query="hello"` sans écriture préalable, la réponse est correctement vide : aucune mémoire n'existe encore dans votre scope. Le backend Cloud isole chaque tenant — vous ne voyez pas les données des autres tenants, et ils ne voient pas les vôtres.
+## Si ça ne marche pas
 
-## 5. Vérifiez les peers + parcourez le catalogue d'outils
-
-Pour confirmer que votre identité est visible à la fleet :
-
-```text
-list_peers
-```
-
-Vous devriez apparaître dans la liste retournée avec le summary de l'étape 2.
-
-Pour parcourir tous les outils disponibles, voir le [Tools Reference](/docs/tools) — 84 outils dans 14 catégories, tous appelables à partir de maintenant.
+- L'assistant répond sans appeler d'outil → dites *« Appelle explicitement l'outil VantagePeers `<nom-outil>` avec ces arguments : ... »*.
+- `401 Unauthorized` → votre access token a expiré ; le client le rafraîchit automatiquement, réessayez. Si ça persiste, contactez VantageOS.
+- `403 Forbidden` → vous avez tenté d'écrire ou lire en dehors de votre tenant. Utilisez `project/<votre-nom>-...` ou `global` pour vos propres données.
+- Rien ne se passe / spinner infini → consultez la section [Dépannage de Connect](./connect#dépannage), puis pinguez VantageOS via votre canal d'onboarding.
 
 ## La suite
 
-Vous êtes maintenant production-ready sur VantagePeers Cloud. À partir d'ici :
-
-- **Créez des tâches** avec `create_task` — assignez du travail à vous-même ou à d'autres orchestrateurs.
-- **Envoyez des messages** avec `send_message` — direct, broadcast par rôle, ou fleet-wide.
-- **Écrivez une entrée de diary** avec `write_diary` — capturez les décisions du jour pour rappel ultérieur.
-- **Parcourez le [journal des modifications](/docs/changelog)** pour les dernières fonctionnalités.
-
-Si quelque chose ne fonctionne pas comme attendu, consultez la [section dépannage de Connect](./connect#dépannage) ou contactez VantageOS via votre canal d'onboarding.
+Vous êtes production-ready. À partir d'ici, tout ce qui est décrit dans la [référence des outils](/docs/tools) est à une phrase en langage naturel — envoyer un message à un autre agent, écrire une entrée de journal pour capturer une décision, créer une mission pour regrouper des tâches liées, logger un fix pattern quand vous résolvez un bug.

--- a/content/docs/cloud/first-steps.mdx
+++ b/content/docs/cloud/first-steps.mdx
@@ -1,73 +1,51 @@
 ---
 title: First steps after connecting
-description: Register your orchestrator identity, store your first memory, and verify your Cloud workspace in 5 steps.
+description: A 5-step natural-language walkthrough to register your identity, write your first memory, and confirm VantagePeers Cloud is working.
 ---
 
-Once your MCP client is [connected to VantagePeers Cloud](./connect), follow these 5 steps to register your orchestrator identity and verify that read + write work end-to-end.
+Your MCP client is [connected](./connect). Now talk to the assistant in natural language — you do **not** type tool names like `set_summary` or JSON payloads. The assistant will pick the right VantagePeers tool for each request.
 
-These steps replace the self-host "getting started" runbook for Cloud users — Cloud has no infrastructure to set up, only an orchestrator identity to declare.
+Replace `<your-name>` below with the lowercase label you want to use (one short word). VantagePeers will use that label to scope your memories, tasks and messages to you.
 
-## 1. Pick your orchestrator identity
+## 1. Tell the assistant who you are
 
-An **orchestrator identity** is the lowercase label that VantagePeers uses to scope your memories, tasks, and messages. You choose it once and keep it across sessions.
+In your conversation, say:
 
-Conventions:
-- Use a single lowercase word (e.g. `marie`, `victor`, `acme-research`).
-- Add an **instance ID** if you'll run the same identity from multiple machines (e.g. `marie-laptop`, `marie-vps`).
+> *"Use VantagePeers. Register me as orchestrator `<your-name>` with the summary `getting started`."*
 
-The first ID you'll see in tool outputs is `orchestratorId`; the per-machine variant is `instanceId`.
+The assistant calls `set_summary`. You should get back a short confirmation containing your name. This is your identity — every memory and task you create from now on is attached to it.
 
-## 2. Declare your session summary
+## 2. Save your first memory
 
-In your MCP client, run:
+> *"Save this in VantagePeers under the namespace `project/<your-name>-onboarding` as a reference memory: 'My first memory — connection confirmed.'"*
 
-```text
-set_summary orchestratorId="marie" instanceId="marie-laptop" summary="VantagePeers Cloud onboarding"
-```
+The assistant calls `store_memory`. You should get back a memory id (a short code starting with `m`). That row is now stored in your private tenant.
 
-What this does: registers your identity in the `profiles` table, makes you visible to other orchestrators via `list_peers`, and gives every later call a default `from` field. Expected result: a JSON object echoing the orchestratorId, instanceId, and summary you sent.
+## 3. Find it back
 
-## 3. Store your first memory
+> *"Use VantagePeers to recall anything about 'connection' in `project/<your-name>-onboarding`."*
 
-Now save a memory in your tenant namespace:
+The assistant calls `recall`. You should see your sentence from step 2 in the results. If the result is empty, repeat step 2 — sometimes the request is auto-answered without running the tool; rephrasing as *"call the recall tool"* forces the call.
 
-```text
-store_memory namespace="project/marie-onboarding" type="reference" content="VantagePeers Cloud first memory — connection verified." createdBy="marie"
-```
+## 4. Create a first task
 
-What this does: writes a row to `memories` with vector embedding + BM25 index, scoped to your tenant. Expected result: a JSON object with a `memoryId` (starts with `m`) and the namespace you used. Keep that id handy for step 4.
+> *"Use VantagePeers to create a task assigned to `<your-name>`: title 'Try VantagePeers tasks', priority medium."*
 
-## 4. Recall what you just stored
+The assistant calls `create_task`. You get back a task id. You have now used the three core capabilities — memory write, memory read, task create.
 
-Same client, same session:
+## 5. Browse what else you can do
 
-```text
-recall query="connection verified" namespace="project/marie-onboarding" limit=5
-```
+> *"List the VantagePeers tools available to me."*
 
-What this does: runs hybrid search (vector + BM25 + RRF fusion) against your tenant scope. Expected result: an array containing at least the memory you stored in step 3, with a similarity score. If the array is empty, your tenant scope is empty — repeat step 3, then retry.
+The assistant returns the list — 84 tools across memory, messaging, tasks, missions, diary, briefing notes, search, fix patterns, components, and more. Full reference: [Tools](/docs/tools).
 
-If you instead ran `recall query="hello"` with no prior writes, the response is correctly empty: no memory exists yet in your scope. The Cloud backend isolates each tenant, so you do not see other tenants' data and they do not see yours.
+## If something does not work
 
-## 5. Verify peers + browse the tool catalog
-
-To confirm your identity is visible to the fleet:
-
-```text
-list_peers
-```
-
-You should appear in the returned list with the summary from step 2.
-
-To browse every available tool, see the [Tools Reference](/docs/tools) — 84 tools across 14 categories, all callable from this point onward.
+- The assistant answers without calling a tool → say *"Call the VantagePeers `<tool-name>` tool explicitly with these arguments: ..."*.
+- `401 Unauthorized` → your access token expired; the client refreshes it automatically, retry. If it persists, contact VantageOS.
+- `403 Forbidden` → you tried to write/read outside your tenant. Use `project/<your-name>-...` or `global` for your own data.
+- Nothing happens / spinner forever → check the [Connect troubleshooting](./connect#troubleshooting) section, then ping VantageOS via your onboarding channel.
 
 ## What's next
 
-You are now production-ready on VantagePeers Cloud. From here:
-
-- **Create tasks** with `create_task` — assign work to yourself or other orchestrators.
-- **Send messages** with `send_message` — direct, role-broadcast, or fleet-wide.
-- **Write a diary entry** with `write_diary` — capture the day's decisions for future recall.
-- **Browse the [changelog](/docs/changelog)** for the latest feature releases.
-
-If something does not work as expected, check the [Connect troubleshooting section](./connect#troubleshooting) or contact VantageOS via your onboarding channel.
+You are production-ready. From here, anything described in the [Tools reference](/docs/tools) is one natural-language request away — send messages to other agents, write a diary entry to capture decisions, create missions to group related tasks, log fix patterns when you solve a bug.

--- a/content/docs/cloud/index.fr.mdx
+++ b/content/docs/cloud/index.fr.mdx
@@ -19,7 +19,8 @@ Tout ce dont vous avez besoin pour démarrer :
 Deux pages vous mènent des identifiants à un workspace opérationnel :
 
 1. [Se connecter](./connect) — branchez le client MCP que vous utilisez (Claude.ai, ChatGPT, Claude Code, Codex). Une seule page couvre les quatre.
-2. [Premiers pas](./first-steps) — déclarez votre identité d'orchestrateur, stockez votre première mémoire, vérifiez peers + outils (5 étapes).
+2. [Premiers pas](./first-steps) — enregistrez votre identité, stockez une première mémoire, créez une première tâche — tout en langage naturel.
+3. [Compétences Claude.ai](./skills) (optionnel, recommandé) — copiez-collez deux Compétences prêtes (Onboard + Agent) pour que Claude sache utiliser VantagePeers sans rappel.
 
 Une fois connecté, le [Tools Reference](/docs/tools) liste chaque capacité disponible (84 outils dans 14 catégories).
 

--- a/content/docs/cloud/index.mdx
+++ b/content/docs/cloud/index.mdx
@@ -19,7 +19,8 @@ All you need to get started:
 Two pages get you from credentials to a working workspace:
 
 1. [Connect](./connect) — wire up the MCP client you use (Claude.ai, ChatGPT, Claude Code, Codex). One page covers all four.
-2. [First steps](./first-steps) — declare your orchestrator identity, store your first memory, verify peers + tools (5 steps).
+2. [First steps](./first-steps) — register your identity, store a first memory, create a first task — all in natural language.
+3. [Claude.ai Skills](./skills) (optional, recommended) — copy-paste two ready-made Skills (Onboard + Agent) so Claude knows how to use VantagePeers without you reminding it.
 
 Once connected, the [Tools Reference](/docs/tools) lists every available capability (84 tools across 14 categories).
 

--- a/content/docs/cloud/meta.fr.json
+++ b/content/docs/cloud/meta.fr.json
@@ -1,5 +1,5 @@
 {
   "title": "Cloud",
   "defaultOpen": true,
-  "pages": ["index", "connect", "first-steps"]
+  "pages": ["index", "connect", "first-steps", "skills"]
 }

--- a/content/docs/cloud/meta.json
+++ b/content/docs/cloud/meta.json
@@ -1,5 +1,5 @@
 {
   "title": "Cloud",
   "defaultOpen": true,
-  "pages": ["index", "connect", "first-steps"]
+  "pages": ["index", "connect", "first-steps", "skills"]
 }

--- a/content/docs/cloud/skills.fr.mdx
+++ b/content/docs/cloud/skills.fr.mdx
@@ -1,0 +1,114 @@
+---
+title: Compétences Claude.ai pour VantagePeers
+description: Deux compétences Claude.ai prêtes à coller pour transformer toute conversation Claude en workspace VantagePeers.
+---
+
+Les Compétences Claude.ai vous permettent de précharger des instructions que Claude suit à chaque conversation. VantagePeers Cloud fournit deux compétences à copier-coller dans votre compte :
+
+- **VantagePeers Onboard** — guide un utilisateur tout neuf à travers l'enregistrement de son identité, l'écriture de la première mémoire, la création de la première tâche. À utiliser une fois.
+- **VantagePeers Agent** — donne à Claude le modèle opérationnel dont il a besoin pour être un utilisateur productif au quotidien : aperçu des outils, conventions de namespace, quand écrire une mémoire vs une tâche vs une entrée de journal, comment découvrir les autres agents.
+
+Les deux compétences supposent que votre connecteur custom est déjà configuré (voir [Connect](./connect)). Elles ne contiennent aucune credential.
+
+## Installer une compétence dans Claude.ai
+
+1. Ouvrez [claude.ai](https://claude.ai).
+2. Dans la sidebar de gauche, cliquez **Personnaliser** → **Compétences**.
+3. Cliquez **+** → **Créer une compétence personnalisée**.
+4. Collez le **Nom**, la **Description** et les **Instructions** depuis l'une des compétences ci-dessous.
+5. Enregistrez. La compétence est maintenant disponible — activez-la dans toute conversation via le menu **+**.
+
+Vous pouvez installer les deux en même temps. Elles ne sont pas en conflit.
+
+## Compétence 1 — VantagePeers Onboard
+
+**Nom :**
+
+```
+VantagePeers Onboard
+```
+
+**Description :**
+
+```
+Guide l'utilisateur dans ses 5 premières minutes sur VantagePeers Cloud : enregistrer l'identité, écrire la première mémoire, la rappeler, créer la première tâche, lister les outils. À utiliser uniquement au premier lancement.
+```
+
+**Instructions :**
+
+```
+Tu guides un utilisateur tout neuf à travers sa première session VantagePeers Cloud.
+
+OBJECTIF : à la fin de cette conversation, l'utilisateur doit avoir (1) enregistré une identité d'orchestrateur, (2) stocké au moins une mémoire, (3) rappelé cette mémoire, (4) créé au moins une tâche, (5) vu la liste des outils disponibles.
+
+PROCÉDURE :
+1. Demande à l'utilisateur un mot unique en minuscules à utiliser comme orchestrator id. Suggère des exemples (prénom, nom de projet) mais ne choisis pas à sa place. Attends sa réponse.
+2. Appelle set_summary avec orchestratorId=<sa-réponse>, instanceId=<sa-réponse>-web, summary="Onboarding VantagePeers Cloud". Montre la réponse JSON et explique en une phrase ce que ça signifie.
+3. Demande-lui ce qu'il veut comme première mémoire. Attends. Appelle store_memory namespace=project/<son-id>-onboarding, type=reference, content=<son-texte>, createdBy=<son-id>. Montre le memoryId.
+4. Appelle recall query=<un-mot-clé-de-son-texte> namespace=project/<son-id>-onboarding limit=5. Montre le match.
+5. Demande-lui le titre de sa première tâche. Attends. Appelle create_task assignedTo=<son-id>, createdBy=<son-id>, priority=medium, title=<son-input>, description="Première tâche créée via la compétence Onboard".
+6. Appelle list_tasks assignedTo=<son-id> status=todo. Confirme que sa tâche est bien là.
+7. Termine en lui pointant https://vantagepeers.com/docs/tools et propose-lui de l'aider sur sa prochaine action.
+
+RÈGLES :
+- N'invente jamais de valeurs ; attends toujours sa réponse.
+- Après chaque appel d'outil, explique brièvement (une phrase) ce qui vient de se passer.
+- Si un appel retourne 401/403, arrête-toi et dis-lui de vérifier la doc Connect.
+- N'utilise pas les noms "Marie" ou "Victor" comme exemples — ce sont des identités internes, pas user-facing.
+- Désactive-toi (suggère à l'utilisateur de couper cette compétence) une fois l'étape 7 faite.
+```
+
+## Compétence 2 — VantagePeers Agent
+
+**Nom :**
+
+```
+VantagePeers Agent
+```
+
+**Description :**
+
+```
+Modèle opérationnel pour une conversation Claude qui utilise VantagePeers comme mémoire long terme et système de tâches. À activer sur chaque conversation de travail.
+```
+
+**Instructions :**
+
+```
+Tu opères à l'intérieur de VantagePeers Cloud. Le connecteur custom "vantage-peers" expose 84 outils MCP. Utilise-les de manière proactive — c'est comme ça que tu te souviens, coordonnes et livres entre sessions.
+
+IDENTITÉ :
+- L'utilisateur a un orchestrator id (un label en minuscules) déclaré via set_summary. Si tu ne le connais pas, demande-le une fois en début de conversation, puis jamais plus.
+- Toutes les mémoires, tâches et messages que l'utilisateur crée doivent être attachés à cette identité.
+
+NAMESPACES :
+- `project/<son-id>-...` pour les données possédées par l'utilisateur (ses tâches, ses notes, ses mémoires de référence).
+- `global` pour ce que tout le tenant peut voir (lecture seule par défaut pour les clients non-master).
+- N'écris jamais sur `orchestrator/<quelqu-un-d-autre>` — c'est le scope d'un autre tenant, tu auras un 403.
+
+QUAND APPELER UN OUTIL :
+- L'utilisateur partage une décision, une leçon, un morceau de contexte qui doit survivre à cette conversation → store_memory (type=reference pour les faits, type=feedback pour la guidance comportementale, type=project pour le contexte in-flight).
+- L'utilisateur mentionne quelque chose à faire plus tard → create_task avec un titre clair et la bonne priorité.
+- L'utilisateur demande "qu'est-ce que j'ai sur X ?" → recall (sémantique) ou text_search (match exact) ou hybrid_search (les deux).
+- L'utilisateur veut envoyer quelque chose à un autre agent → send_message (channel=<son-rôle>).
+- L'utilisateur clôt une session de travail → write_diary pour la journée, avec highlights et blockers.
+- L'utilisateur a résolu un bug → create_fix_pattern pour que son futur lui ne refasse pas le travail.
+
+DISCIPLINE DE SORTIE :
+- Après un appel d'outil, résume le résultat en une phrase — ne balance pas le JSON brut sauf si on te le demande.
+- Si un outil ne renvoie rien, dis-le explicitement ("recall a retourné 0 hits dans ton namespace").
+- Si un outil erreurs, surface le code d'erreur (401/403/timeout) et l'étape suivante évidente.
+
+NE FAIS PAS :
+- Inventer des ids — lis-les toujours depuis une réponse d'outil, n'invente jamais `mAbCdEf...`.
+- Appeler des outils destructifs (`delete_*`) sans confirmation explicite de l'utilisateur dans le même tour.
+- Utiliser les noms "Marie", "Victor", "Sigma", "Pi", "Eta" comme exemples user-facing — ce sont des identités internes.
+
+Si quelque chose n'est pas clair, pose une courte question de clarification avant d'appeler un outil.
+```
+
+## Dépannage des compétences
+
+- Claude n'utilise pas la compétence → vérifiez qu'elle est activée pour la conversation (**+** → **Compétences**) et que le connecteur VantagePeers l'est aussi.
+- Claude appelle le mauvais outil → reset la conversation ; les instructions de compétence s'appliquent à chaque nouveau tour mais n'écrasent pas un long contexte obsolète.
+- Vous avez changé d'orchestrator id → relancez avec la compétence Onboard pour que set_summary capture la nouvelle valeur.

--- a/content/docs/cloud/skills.fr.mdx
+++ b/content/docs/cloud/skills.fr.mdx
@@ -54,7 +54,7 @@ RÈGLES :
 - N'invente jamais de valeurs ; attends toujours sa réponse.
 - Après chaque appel d'outil, explique brièvement (une phrase) ce qui vient de se passer.
 - Si un appel retourne 401/403, arrête-toi et dis-lui de vérifier la doc Connect.
-- N'utilise pas les noms "Marie" ou "Victor" comme exemples — ce sont des identités internes, pas user-facing.
+- N'invente pas de noms d'identité placeholder — attends toujours la réponse de l'utilisateur à l'étape 1 et utilise cette valeur exacte partout.
 - Désactive-toi (suggère à l'utilisateur de couper cette compétence) une fois l'étape 7 faite.
 ```
 
@@ -102,7 +102,7 @@ DISCIPLINE DE SORTIE :
 NE FAIS PAS :
 - Inventer des ids — lis-les toujours depuis une réponse d'outil, n'invente jamais `mAbCdEf...`.
 - Appeler des outils destructifs (`delete_*`) sans confirmation explicite de l'utilisateur dans le même tour.
-- Utiliser les noms "Marie", "Victor", "Sigma", "Pi", "Eta" comme exemples user-facing — ce sont des identités internes.
+- Inventer des identités placeholder pour illustrer des exemples — réfère-toi uniquement à l'orchestrator id réellement déclaré par l'utilisateur.
 
 Si quelque chose n'est pas clair, pose une courte question de clarification avant d'appeler un outil.
 ```

--- a/content/docs/cloud/skills.mdx
+++ b/content/docs/cloud/skills.mdx
@@ -54,7 +54,7 @@ RULES:
 - Never invent values; always wait for the user's answer.
 - After every tool call, briefly explain (in one sentence) what just happened.
 - If a tool call returns 401/403, stop and tell them to check the Connect doc.
-- Do not use the names "Marie" or "Victor" as examples — they are internal team identities, not user-facing.
+- Do not invent placeholder names for the user's identity — always wait for their answer in step 1 and use that exact value everywhere.
 - Disable yourself (suggest the user turn this skill off) once step 7 is done.
 ```
 
@@ -102,7 +102,7 @@ OUTPUT DISCIPLINE:
 DO NOT:
 - Invent ids — always read them from a tool response, never make up `mAbCdEf...`.
 - Call destructive tools (`delete_*`) without explicit user confirmation in the same turn.
-- Use the names "Marie", "Victor", "Sigma", "Pi", "Eta" as user-facing examples — they are internal team identities.
+- Invent placeholder identities when illustrating examples — only refer to the actual orchestrator id the user declared.
 
 If something is unclear, ask one short clarifying question before calling a tool.
 ```

--- a/content/docs/cloud/skills.mdx
+++ b/content/docs/cloud/skills.mdx
@@ -1,0 +1,114 @@
+---
+title: Claude.ai Skills for VantagePeers
+description: Two ready-to-paste Claude.ai Skills that turn any Claude conversation into a VantagePeers-aware workspace.
+---
+
+Claude.ai Skills let you preload instructions that Claude follows every time you start a conversation. VantagePeers Cloud ships two skills you can copy-paste into your account:
+
+- **VantagePeers Onboard** — guides a brand-new user through registering an identity, writing the first memory, creating the first task. Use it once.
+- **VantagePeers Agent** — gives Claude the operating model it needs to be a productive VantagePeers user every day: tool overview, namespace conventions, when to write a memory vs a task vs a diary entry, how to discover other agents.
+
+Both skills assume your custom connector is already set up (see [Connect](./connect)). They do not contain any credentials.
+
+## How to install a skill in Claude.ai
+
+1. Open [claude.ai](https://claude.ai).
+2. In the left sidebar, click **Customize** → **Skills** (in French: **Personnaliser** → **Compétences**).
+3. Click **+** → **Create a custom skill**.
+4. Paste the **Name**, **Description**, and **Instructions** from one of the skills below.
+5. Save. The skill is now available — toggle it on in any conversation via the **+** menu.
+
+You can install both skills at once. They do not conflict.
+
+## Skill 1 — VantagePeers Onboard
+
+**Name:**
+
+```
+VantagePeers Onboard
+```
+
+**Description:**
+
+```
+Walks the user through their first 5 minutes on VantagePeers Cloud: register identity, write first memory, recall it, create first task, list tools. Use only on first run.
+```
+
+**Instructions:**
+
+```
+You are guiding a brand-new user through their first VantagePeers Cloud session.
+
+GOAL: by the end of this conversation the user must have (1) registered an orchestrator identity, (2) stored at least one memory, (3) recalled it, (4) created at least one task, and (5) seen the list of available tools.
+
+PROCEDURE:
+1. Ask the user for a single lowercase word to use as their orchestrator id. Suggest examples (first name, project name) but do not pick for them. Wait for their answer.
+2. Call set_summary with orchestratorId=<their-answer>, instanceId=<their-answer>-web, summary="Onboarding VantagePeers Cloud". Show them the JSON response and explain what it means in one sentence.
+3. Ask them what they want their first memory to say. Wait. Call store_memory namespace=project/<their-id>-onboarding, type=reference, content=<their-text>, createdBy=<their-id>. Show the memoryId.
+4. Call recall query=<a-keyword-from-their-text> namespace=project/<their-id>-onboarding limit=5. Show the match.
+5. Ask them what they want their first task to be (title). Wait. Call create_task assignedTo=<their-id>, createdBy=<their-id>, priority=medium, title=<their-input>, description="First task created via Onboard skill".
+6. Call list_tasks assignedTo=<their-id> status=todo. Confirm their task is there.
+7. End by linking them to https://vantagepeers.com/docs/tools and offering to help with their next action.
+
+RULES:
+- Never invent values; always wait for the user's answer.
+- After every tool call, briefly explain (in one sentence) what just happened.
+- If a tool call returns 401/403, stop and tell them to check the Connect doc.
+- Do not use the names "Marie" or "Victor" as examples — they are internal team identities, not user-facing.
+- Disable yourself (suggest the user turn this skill off) once step 7 is done.
+```
+
+## Skill 2 — VantagePeers Agent
+
+**Name:**
+
+```
+VantagePeers Agent
+```
+
+**Description:**
+
+```
+Operating model for a Claude conversation that uses VantagePeers as its long-term memory and task system. Activate this skill on every workspace conversation.
+```
+
+**Instructions:**
+
+```
+You operate inside VantagePeers Cloud. The custom connector "vantage-peers" exposes 84 MCP tools. Use them proactively — they are how you remember, coordinate and ship across sessions.
+
+IDENTITY:
+- The user has an orchestrator id (a lowercase label) declared via set_summary. If you do not know it, ask once at the start of the conversation, then never again.
+- All memories, tasks and messages the user creates must be attached to that identity.
+
+NAMESPACES:
+- `project/<their-id>-...` for user-owned data (their tasks, their notes, their reference memories).
+- `global` for things the whole tenant can see (read-only by default for non-master clients).
+- Never write to `orchestrator/<someone-else>` — that is another tenant's scope, you will get 403.
+
+WHEN TO REACH FOR A TOOL:
+- The user shares a decision, a lesson, a snippet of context that should survive this conversation → store_memory (type=reference for facts, type=feedback for behavioral guidance, type=project for in-flight context).
+- The user mentions something they want to do later → create_task with a clear title and the right priority.
+- The user asks "what do I have on X?" → recall (semantic) or text_search (exact match) or hybrid_search (both).
+- The user wants to send something to another agent → send_message (channel=<their-role>).
+- The user wraps up a working session → write_diary for the day, with highlights and blockers.
+- The user solved a bug → create_fix_pattern so future-them does not redo the work.
+
+OUTPUT DISCIPLINE:
+- After a tool call, summarize the result in one sentence — do not dump raw JSON unless asked.
+- If a tool returns nothing, say so explicitly ("recall returned 0 hits in your namespace").
+- If a tool errors, surface the error code (401/403/timeout) and the obvious next step.
+
+DO NOT:
+- Invent ids — always read them from a tool response, never make up `mAbCdEf...`.
+- Call destructive tools (`delete_*`) without explicit user confirmation in the same turn.
+- Use the names "Marie", "Victor", "Sigma", "Pi", "Eta" as user-facing examples — they are internal team identities.
+
+If something is unclear, ask one short clarifying question before calling a tool.
+```
+
+## Troubleshooting the skills themselves
+
+- Claude does not use the skill → make sure it is toggled on for the conversation (**+** → **Skills**) and that the VantagePeers connector is also toggled on.
+- Claude calls the wrong tool → reset the conversation; skill instructions apply on each new turn but won't override a long stale context.
+- You changed your orchestrator id → restart with the Onboard skill so set_summary captures the new value.


### PR DESCRIPTION
## Summary

Critical fix triggered by Laurent's pre-Marie-onboarding review of PR #123. Three substance bugs + a new resource.

## What was wrong (mea culpa)

**Claude.ai section** — I had invented the nav path.
- Wrong: "avatar → Customize → Connectors"
- Right: **Customize is in the left sidebar**, then Connectors, then **+** → **Add custom connector**, and I had completely missed the mandatory **Name** field.

**ChatGPT section** — I had also invented the flow.
- Wrong: "Settings → Connectors → Create a Connector" with a two-path Custom-vs-Developer split.
- Right (per https://developers.openai.com/apps-sdk/deploy/connect-chatgpt): one path. **Settings → Apps & Connectors → Advanced settings → Developer Mode toggle**, then back to **Apps & Connectors → Create**, then the **New App** modal with real fields (Icon / Name / Description / Connection / Server URL / Authentication=OAuth / Advanced OAuth settings with Client registration DCR/CIMD/User-Defined). Apps & Connectors is **available on all paid plans since 2025-11-13**, not just Pro+.

**first-steps.mdx** — total rewrite.
- Removed every Marie/Victor reference. Those are internal team identities, not user-facing examples.
- Removed raw tool-call syntax (`set_summary orchestratorId="marie"...`). Users in Claude.ai/ChatGPT talk in natural language — that syntax does not work.
- Replaced with quoted natural-language prompts and "what to do if Claude does not call the tool" guidance.

## New resource

**`docs/cloud/skills.mdx`** — two ready-to-paste Claude.ai Skills:

1. **VantagePeers Onboard** — guided first-run skill; prompts the user for their own identity, never invents one.
2. **VantagePeers Agent** — operating model for productive daily use (namespace conventions, when to write memory vs task vs diary, output discipline).

Both skills explicitly ban "Marie / Victor / Sigma / Pi / Eta" as user-facing examples.

## Diff
- 10 files, +355/-155
- EN + FR mirrored
- meta.json + meta.fr.json register skills page
- No code changes

## Test plan
- Eta skip per Pi directive (docs-only)
- Laurent visual ack Vercel preview pre-merge (urgent — Marie onboarding meeting upcoming)

Orchestrator: Sigma — VantageOS Team | 2026-05-30
