### PR TITLE
[Day 88] docs cloud FR refonte — plugin Claude Code + skills exhaustifs

### DIFF
--- a/content/docs/cloud/connect.fr.mdx
+++ b/content/docs/cloud/connect.fr.mdx
@@ -1,80 +1,95 @@
 ---
 title: Se connecter à VantagePeers Cloud
-description: Connecter VantagePeers Cloud (hébergé, multi-tenant) à Claude Code, Claude.ai, ChatGPT ou Codex via MCP.
+description: Connecter VantagePeers Cloud (hébergé, multi-tenant) à Claude Code (plugin marketplace ou manuel), Claude.ai, ChatGPT ou Codex via MCP.
 ---
 
-VantagePeers Cloud est la version hébergée multi-tenant. Un seul backend, 84 outils MCP, partagés par tous les clients supportant MCP : **Claude Code**, **Claude.ai**, **ChatGPT**, **Codex**, et tout autre IDE parlant le protocole MCP. Aucun serveur à déployer chez vous.
+import { Callout } from 'fumadocs-ui/components/callout'
+
+VantagePeers Cloud est la version hébergée multi-tenant. Un seul backend, 84 outils MCP, partagés par tous les clients supportant MCP : **Claude Code**, **Claude.ai**, **ChatGPT**, **Codex**, et tout autre IDE parlant le protocole MCP. Aucun serveur à déployer chez toi.
 
 ## Avant de commencer
 
-Vous avez besoin de :
+Tu as besoin de :
 
-- Un `client_id` et un `client_secret` émis par VantageOS (envoyés hors bande — gardez le secret confidentiel, il n'est affiché qu'une fois).
+- Un `client_id` et un `client_secret` émis par VantageOS (envoyés hors bande — garde le secret confidentiel, il n'est affiché qu'une fois).
 - L'URL du serveur MCP : `https://vantage-peers-production.up.railway.app/mcp`.
 - L'un des clients supportés installé.
 
-VantagePeers Cloud tourne sur **`vantage-peers-mcp@2.4.1`** (publié le 30/05/2026). Les 84 outils embarquent les annotations ChatGPT Apps SDK (`readOnlyHint`, `openWorldHint`, `destructiveHint`) — les opérations d'écriture/destructives déclenchent nativement des prompts de confirmation dans les connecteurs custom ChatGPT.
+VantagePeers Cloud tourne sur **`vantage-peers-mcp@2.4.6`**. Les 84 outils embarquent les annotations ChatGPT Apps SDK (`readOnlyHint`, `openWorldHint`, `destructiveHint`) — les opérations d'écriture/destructives déclenchent nativement des prompts de confirmation dans les connecteurs custom ChatGPT.
 
 ## Comment fonctionne l'authentification
 
 VantagePeers Cloud implémente **OAuth 2.1 avec Dynamic Client Registration (DCR, RFC 7591) + PKCE (RFC 7636) + Protected Resource Metadata Discovery (RFC 9728)**. Concrètement :
 
 - Les clients qui supportent l'auto-discovery (Claude.ai, ChatGPT) récupèrent les métadonnées depuis `/.well-known/oauth-protected-resource` et `/.well-known/oauth-authorization-server`, exécutent le flux PKCE et obtiennent un access token scopé — aucune configuration manuelle au-delà de l'URL n'est nécessaire.
-- Les clients qui supportent la configuration OAuth manuelle (Claude.ai Advanced, ChatGPT Developer Mode) acceptent vos `client_id` + `client_secret` pour bootstrap le même flux avec une identité client stable.
+- Les clients qui supportent la configuration OAuth manuelle (Claude.ai Advanced, ChatGPT Developer Mode) acceptent tes `client_id` + `client_secret` pour bootstrap le même flux avec une identité client stable.
 - Le header `WWW-Authenticate` sur les réponses `401` suit le format MCP spec `Bearer resource_metadata="<URL-PRM>"`, qui permet au client de bootstrap la discovery depuis n'importe quelle requête non authentifiée.
 
-Le `client_secret` n'est **pas** un bearer token. Il est présenté au endpoint `/token` pour échanger un code d'autorisation validé par PKCE contre un access token. L'access token (courte durée, avec refresh) est ce qui est envoyé en `Authorization: Bearer <access_token>` sur les appels d'outils suivants. Votre client gère ça automatiquement.
+Le `client_secret` n'est **pas** un bearer token. Il est présenté au endpoint `/token` pour échanger un code d'autorisation validé par PKCE contre un access token. L'access token (courte durée, avec refresh) est ce qui est envoyé en `Authorization: Bearer <access_token>` sur les appels d'outils suivants. Ton client gère ça automatiquement.
 
-## Claude.ai (web)
+## Claude Code via le plugin marketplace
 
-Le plan Free autorise 1 connecteur custom. Pro, Max, Team et Enterprise en autorisent plusieurs.
+<Callout type="info">
+C'est le chemin **recommandé** pour Claude Code. En une commande, tu obtiens non seulement la connexion MCP au backend Cloud mais aussi 37+ skills, 7 hooks de qualité et 9 commandes slash. Tu sautes la configuration manuelle de `.mcp.json`.
+</Callout>
 
-1. Ouvrez [claude.ai](https://claude.ai).
-2. Dans la sidebar de gauche, cliquez **Personnaliser**.
-3. Cliquez **Connecteurs**.
-4. Cliquez le bouton **+** en haut à droite de la liste des connecteurs, puis sélectionnez **Ajouter un connecteur personnalisé**.
-5. Dans la modale **Ajouter un connecteur personnalisé**, renseignez :
-   - **Nom** : `VantagePeers` (ou tout label de votre choix — c'est ce qui apparaîtra dans vos conversations).
-   - **URL du serveur MCP distant** : `https://vantage-peers-production.up.railway.app/mcp`
-6. Déployez **Paramètres avancés** et collez :
-   - **ID client OAuth** : votre `client_id`
-   - **Secret client OAuth** : votre `client_secret`
-7. Cliquez **Ajouter**. Un onglet navigateur s'ouvre pour le consentement OAuth — acceptez.
-8. Dans une conversation, cliquez **+** dans la zone de saisie → activez **VantagePeers** (ou le nom donné à l'étape 5).
-9. Test en langage naturel : *« Utilise vantage-peers pour récupérer ce que tu trouves sur VantagePeers dans le namespace global. »* Claude route vers l'outil `recall`. Un tenant tout neuf ne renvoie rien — c'est normal (voir [Premiers pas](./first-steps) pour peupler votre workspace).
+Le plugin `vantage-peers` est distribué publiquement via le marketplace Claude Code (`vantageos-agency/vantage-peers-plugin`). Il embarque la connexion MCP au backend Cloud + l'agent expert `vantage-peers-expert` + tous les skills (check-messages, daily-start, close-day, write-diary, pre-compact, recall, standup, et plus).
 
-Utilisez les Paramètres avancés avec Client ID + Secret. Le chemin URL-only auto-discovery fonctionne aussi mais vous attache à un client transitoire et au scope par défaut `client-generic`.
+### Installer
 
-## ChatGPT
+```bash
+claude plugin marketplace add vantageos-agency/vantage-peers-plugin
+claude plugin install vantage-peers@vantage-peers-plugin
+```
 
-Le support MCP end-to-end ChatGPT est documenté par OpenAI dans [Apps SDK — Connect from ChatGPT](https://developers.openai.com/apps-sdk/deploy/connect-chatgpt). Depuis le 13/11/2025, **Apps & Connectors sont disponibles sur tous les plans payants (Plus, Pro, Business, Enterprise, Education)**.
+### Configurer le serveur MCP Cloud
 
-### Activer Developer Mode (une fois)
+Le plugin ajoute la définition du serveur `vantage-peers` dans ton workspace. Renseigne tes identifiants Cloud dans `.mcp.json` à la racine du workspace :
 
-1. Ouvrez [chatgpt.com](https://chatgpt.com).
-2. **Settings** → **Apps & Connectors** → **Advanced settings**.
-3. Activez **Developer mode**. Si votre politique organisationnelle le bloque, contactez votre admin.
+```json
+{
+  "mcpServers": {
+    "vantage-peers": {
+      "type": "http",
+      "url": "https://vantage-peers-production.up.railway.app/mcp",
+      "oauth": {
+        "client_id": "YOUR_CLIENT_ID",
+        "client_secret": "YOUR_CLIENT_SECRET"
+      }
+    }
+  }
+}
+```
 
-### Ajouter VantagePeers Cloud
+Redémarre Claude Code (`exit` puis relance depuis ton workspace). Au premier appel, le client exécute le flux PKCE contre `/authorize` et `/token`, met en cache l'access token et le rafraîchit automatiquement.
 
-1. De retour dans **Settings → Apps & Connectors**, cliquez **Create**. La modale **New App** s'ouvre.
-2. Renseignez :
-   - **Icon** (optionnel) : uploadez une icône VantagePeers si vous en avez une.
-   - **Name** : `VantagePeers`
-   - **Description** (optionnel) : `Mémoire partagée, tâches et messagerie pour équipes d'agents IA.`
-   - **Connection** → laissez **Server URL** sélectionné.
-   - **Server URL** : `https://vantage-peers-production.up.railway.app/mcp`
-   - **Authentication** : sélectionnez **OAuth**.
-3. Déployez **Advanced OAuth settings**. Sous **Client registration**, choisissez **Dynamic Client Registration (DCR)** — le serveur l'annonce ; CIMD n'est pas supporté, User-Defined OAuth Client est une alternative si vous voulez réutiliser un `client_id`+`client_secret` fixe.
-4. Cochez **I understand and want to continue** (warning OpenAI sur les serveurs MCP custom) et cliquez **Create**. Le flux de consentement navigateur s'exécute ; acceptez.
-5. Dans une nouvelle conversation, cliquez **+** dans la zone de saisie → **More** → sélectionnez **VantagePeers**.
-6. Test en langage naturel : *« Utilise VantagePeers pour lister mes tâches ouvertes. »* ChatGPT appelle `list_tasks`. Un tenant tout neuf renvoie une liste vide — peuplez-le via [Premiers pas](./first-steps).
+### Vérifier
 
-Les outils d'écriture et destructifs (`create_*`, `update_*`, `delete_*`) déclenchent des prompts de confirmation avant exécution. C'est piloté par les annotations `readOnlyHint` et `destructiveHint` portées par chaque outil — comportement attendu, pas un bug.
+```
+/vantage-peers-init
+```
 
-## Claude Code
+La commande exécute 3 vérifications (enregistrement MCP, connectivité `/health`, auth Bearer via `recall`). Les 3 doivent afficher `PASS`.
 
-Ajoutez `vantage-peers` à votre `.mcp.json` projet (ou global `~/.claude.json`) :
+Puis enchaîne avec :
+
+```
+/daily-start
+/check-messages
+/check-tasks
+```
+
+Tutoriel pas-à-pas + liste des hooks et skills : [VantagePeers Toolkit — Installation](/docs/toolkit/install) et [Toolkit — Skills](/docs/toolkit/skills). La page [Compétences & Skills Cloud](./skills) recense aussi les skills plugin.
+
+### Désactiver un hook ou skill
+
+Le plugin est opinioné. Si un hook bloque un appel et que tu veux le désactiver temporairement, voir [Toolkit — Hooks](/docs/toolkit/hooks).
+
+## Claude Code via `.mcp.json` manuel (fallback)
+
+Si tu ne veux pas du plugin (workspace sans Claude Code, version de Claude Code sans support plugins, environnement contraint), tu peux configurer le serveur MCP à la main.
+
+Ajoute `vantage-peers` à ton `.mcp.json` projet (ou global `~/.claude.json`) :
 
 ```json
 {
@@ -93,12 +108,12 @@ Ajoutez `vantage-peers` à votre `.mcp.json` projet (ou global `~/.claude.json`)
 
 Puis :
 
-1. Redémarrez Claude Code (`exit` puis relancez dans votre workspace).
-2. Au premier appel, Claude Code exécute le flux PKCE contre `/authorize` et `/token`, cache l'access token et le rafraîchit automatiquement.
-3. Lancez `/mcp` pour confirmer que `vantage-peers` est connecté.
+1. Redémarre Claude Code (`exit` puis relance dans ton workspace).
+2. Au premier appel, Claude Code exécute le flux PKCE contre `/authorize` et `/token`, met en cache l'access token et le rafraîchit automatiquement.
+3. Lance `/mcp` pour confirmer que `vantage-peers` est connecté.
 4. Test : `recall query="hello"` — doit retourner une réponse JSON.
 
-Si votre build Claude Code ne supporte pas encore le champ `oauth`, pré-émettez un access token via PKCE (voir [Émettre un access token manuellement](#émettre-un-access-token-manuellement) ci-dessous) et utilisez-le ainsi :
+Si ton build Claude Code ne supporte pas encore le champ `oauth`, pré-émets un access token via PKCE (voir [Émettre un access token manuellement](#émettre-un-access-token-manuellement) ci-dessous) et utilise-le ainsi :
 
 ```json
 {
@@ -116,6 +131,55 @@ Si votre build Claude Code ne supporte pas encore le champ `oauth`, pré-émette
 
 Les access tokens sont de courte durée. Refresh via le endpoint `/token` avec `grant_type=refresh_token` quand ils expirent.
 
+## Claude.ai (web)
+
+Le plan Free autorise 1 connecteur custom. Pro, Max, Team et Enterprise en autorisent plusieurs.
+
+1. Ouvre [claude.ai](https://claude.ai).
+2. Dans la sidebar de gauche, clique **Personnaliser**.
+3. Clique **Connecteurs**.
+4. Clique le bouton **+** en haut à droite de la liste des connecteurs, puis sélectionne **Ajouter un connecteur personnalisé**.
+5. Dans la modale **Ajouter un connecteur personnalisé**, renseigne :
+   - **Nom** : `VantagePeers` (ou tout label de ton choix — c'est ce qui apparaîtra dans tes conversations).
+   - **URL du serveur MCP distant** : `https://vantage-peers-production.up.railway.app/mcp`
+6. Déploie **Paramètres avancés** et colle :
+   - **ID client OAuth** : ton `client_id`
+   - **Secret client OAuth** : ton `client_secret`
+7. Clique **Ajouter**. Un onglet navigateur s'ouvre pour le consentement OAuth — accepte.
+8. Dans une conversation, clique **+** dans la zone de saisie → active **VantagePeers** (ou le nom donné à l'étape 5).
+9. Test en langage naturel : *« Utilise vantage-peers pour récupérer ce que tu trouves sur VantagePeers dans le namespace global. »* Claude route vers l'outil `recall`. Un tenant tout neuf ne renvoie rien — c'est normal (voir [Premiers pas](./first-steps) pour peupler ton workspace).
+
+Utilise les Paramètres avancés avec Client ID + Secret. Le chemin URL-only auto-discovery fonctionne aussi mais t'attache à un client transitoire et au scope par défaut `client-generic`.
+
+Pour aller plus loin, installe les deux Compétences Claude.ai (Onboard + Agent) — voir [Compétences & Skills](./skills).
+
+## ChatGPT
+
+Le support MCP end-to-end ChatGPT est documenté par OpenAI dans [Apps SDK — Connect from ChatGPT](https://developers.openai.com/apps-sdk/deploy/connect-chatgpt). Depuis le 13/11/2025, **Apps & Connectors sont disponibles sur tous les plans payants (Plus, Pro, Business, Enterprise, Education)**.
+
+### Activer Developer Mode (une fois)
+
+1. Ouvre [chatgpt.com](https://chatgpt.com).
+2. **Settings** → **Apps & Connectors** → **Advanced settings**.
+3. Active **Developer mode**. Si ta politique organisationnelle le bloque, contacte ton admin.
+
+### Ajouter VantagePeers Cloud
+
+1. De retour dans **Settings → Apps & Connectors**, clique **Create**. La modale **New App** s'ouvre.
+2. Renseigne :
+   - **Icon** (optionnel) : uploade une icône VantagePeers si tu en as une.
+   - **Name** : `VantagePeers`
+   - **Description** (optionnel) : `Mémoire partagée, tâches et messagerie pour équipes d'agents IA.`
+   - **Connection** → laisse **Server URL** sélectionné.
+   - **Server URL** : `https://vantage-peers-production.up.railway.app/mcp`
+   - **Authentication** : sélectionne **OAuth**.
+3. Déploie **Advanced OAuth settings**. Sous **Client registration**, choisis **Dynamic Client Registration (DCR)** — le serveur l'annonce ; CIMD n'est pas supporté, User-Defined OAuth Client est une alternative si tu veux réutiliser un `client_id`+`client_secret` fixe.
+4. Coche **I understand and want to continue** (warning OpenAI sur les serveurs MCP custom) et clique **Create**. Le flux de consentement navigateur s'exécute ; accepte.
+5. Dans une nouvelle conversation, clique **+** dans la zone de saisie → **More** → sélectionne **VantagePeers**.
+6. Test en langage naturel : *« Utilise VantagePeers pour lister mes tâches ouvertes. »* ChatGPT appelle `list_tasks`. Un tenant tout neuf renvoie une liste vide — peuple-le via [Premiers pas](./first-steps).
+
+Les outils d'écriture et destructifs (`create_*`, `update_*`, `delete_*`) déclenchent des prompts de confirmation avant exécution. C'est piloté par les annotations `readOnlyHint` et `destructiveHint` portées par chaque outil — comportement attendu, pas un bug.
+
 ## Codex (CLI OpenAI)
 
 Codex supporte MCP via son `~/.codex/config.toml` (ou équivalent au niveau projet) :
@@ -131,16 +195,16 @@ client_id = "YOUR_CLIENT_ID"
 client_secret = "YOUR_CLIENT_SECRET"
 ```
 
-Si votre build Codex ne supporte pas encore le bloc `oauth`, fallback sur un access token pré-émis dans les headers (même pattern que Claude Code ci-dessus).
+Si ton build Codex ne supporte pas encore le bloc `oauth`, fallback sur un access token pré-émis dans les headers (même pattern que Claude Code manuel ci-dessus).
 
-1. Enregistrez la config.
-2. Redémarrez `codex` pour qu'il prenne le nouveau serveur.
+1. Enregistre la config.
+2. Redémarre `codex` pour qu'il prenne le nouveau serveur.
 3. Lister les outils : `codex mcp list` doit inclure `vantage-peers`.
-4. Test : demandez à Codex *« appelle recall avec query=hello »*.
+4. Test : demande à Codex *« appelle recall avec query=hello »*.
 
 ## Émettre un access token manuellement
 
-Si votre client ne peut pas exécuter OAuth automatiquement, vous pouvez exécuter le flux PKCE vous-même et coller l'access token résultant dans un header `Bearer`. Bash :
+Si ton client ne peut pas exécuter OAuth automatiquement, tu peux exécuter le flux PKCE toi-même et coller l'access token résultant dans un header `Bearer`. Bash :
 
 ```bash
 BASE="https://vantage-peers-production.up.railway.app"
@@ -152,11 +216,11 @@ REDIRECT="http://localhost:3000/callback"
 VERIFIER=$(openssl rand -base64 64 | tr -d "=+/" | head -c 64)
 CHALLENGE=$(printf "%s" "$VERIFIER" | openssl dgst -sha256 -binary | openssl base64 | tr -d "=" | tr "+/" "-_")
 
-# 2. Affichez l'URL d'authorize — ouvrez dans un navigateur, acceptez, copiez le `code` depuis l'URL de callback
+# 2. Affiche l'URL d'authorize — ouvre dans un navigateur, accepte, copie le `code` depuis l'URL de callback
 echo "$BASE/oauth/authorize?response_type=code&client_id=$CLIENT_ID&redirect_uri=$REDIRECT&code_challenge=$CHALLENGE&code_challenge_method=S256&scope=mcp:full"
 
-# 3. Après consentement, échangez le code contre un access_token
-read -p "Collez le code depuis l'URL de callback : " CODE
+# 3. Après consentement, échange le code contre un access_token
+read -p "Colle le code depuis l'URL de callback : " CODE
 curl -s -X POST "$BASE/oauth/token" \
   -H "Content-Type: application/x-www-form-urlencoded" \
   -d "grant_type=authorization_code" \
@@ -167,25 +231,33 @@ curl -s -X POST "$BASE/oauth/token" \
   -d "code_verifier=$VERIFIER" | jq .
 ```
 
-La réponse contient `access_token` (courte durée) et `refresh_token`. Envoyez `Authorization: Bearer <access_token>` sur chaque appel d'outil.
+La réponse contient `access_token` (courte durée) et `refresh_token`. Envoie `Authorization: Bearer <access_token>` sur chaque appel d'outil.
 
-## Vérifier votre installation
+## Vérifier ton installation
 
 Quel que soit le client, ces trois appels doivent réussir :
 
-- `recall query="VantagePeers"` — recherche sémantique dans votre scope.
-- `list_tasks` — vos tâches assignées.
+- `recall query="VantagePeers"` — recherche sémantique dans ton scope.
+- `list_tasks` — tes tâches assignées.
 - `list_memories namespace="global"` — mémoires globales (scope public read-only).
 
 ## Dépannage
 
-- **`401 Unauthorized`** — access token expiré ou `client_secret` invalide. Refresh du token (les clients le font automatiquement) ou contactez VantageOS pour ré-émettre les credentials.
-- **`403 Forbidden`** — votre scope ne couvre pas cette ressource. Les tokens DCR-émis ont par défaut le scope `client-generic` (écriture sur votre tenant uniquement). Les tentatives de lecture sur `orchestrator/*` hors de votre tenant retournent `403`.
-- **`401` avec `WWW-Authenticate: Bearer resource_metadata="..."`** — votre client devrait auto-découvrir le serveur d'auth et exécuter le flux. S'il ne le fait pas, passez en config manuelle ou tokens pré-émis.
+- **`401 Unauthorized`** — access token expiré ou `client_secret` invalide. Refresh du token (les clients le font automatiquement) ou contacte VantageOS pour ré-émettre les credentials.
+- **`403 Forbidden`** — ton scope ne couvre pas cette ressource. Les tokens DCR-émis ont par défaut le scope `client-generic` (écriture sur ton tenant uniquement). Les tentatives de lecture sur `orchestrator/*` hors de ton tenant retournent `403`.
+- **`401` avec `WWW-Authenticate: Bearer resource_metadata="..."`** — ton client devrait auto-découvrir le serveur d'auth et exécuter le flux. S'il ne le fait pas, passe en config manuelle ou tokens pré-émis.
 - **Prompts de confirmation supplémentaires dans ChatGPT** — attendu. Pilotés par les annotations `destructiveHint` et `readOnlyHint` par outil.
+
+## Pages liées
+
+- [VantagePeers Cloud — aperçu](./index)
+- [Premiers pas](./first-steps) — première identité, première mémoire, première tâche
+- [Compétences & Skills](./skills) — Compétences Claude.ai (Onboard + Agent) + skills plugin Claude Code
+- [Toolkit — Installation](/docs/toolkit/install) — démarrage rapide plugin en 5 étapes
+- [Toolkit — Skills](/docs/toolkit/skills) — référence complète des skills plugin
 
 ## Aide
 
 - [Documentation](https://vantagepeers.com/docs)
 - [Journal des modifications](/docs/changelog)
-- Support : via le canal convenu avec VantageOS lors de votre onboarding.
+- Support : via le canal convenu avec VantageOS lors de ton onboarding.

--- a/content/docs/cloud/index.fr.mdx
+++ b/content/docs/cloud/index.fr.mdx
@@ -1,33 +1,60 @@
 ---
 title: VantagePeers Cloud
-description: Utilisez VantagePeers sans installation ni hébergement — connectez Claude Code, Claude.ai ou ChatGPT en quelques minutes avec les identifiants que nous vous fournissons.
+description: Utilise VantagePeers sans installation ni hébergement — connecte Claude Code, Claude.ai ou ChatGPT en quelques minutes avec les identifiants que nous te fournissons.
 ---
 
-VantagePeers Cloud est la version hébergée de VantagePeers. Vous recevez des identifiants de VantageOS et vous connectez en quelques minutes — sans configuration de serveur, sans infrastructure à maintenir.
+import { Callout } from 'fumadocs-ui/components/callout'
+
+VantagePeers Cloud est la version hébergée multi-tenant de VantagePeers. Tu reçois des identifiants de VantageOS et tu te connectes en quelques minutes — sans configuration de serveur, sans infrastructure à maintenir.
+
+<Callout type="info">
+**Tu utilises Claude Code ?** Le chemin le plus court est le **plugin Claude Code `vantage-peers`** distribué via le marketplace Claude Code — installation en une commande, skills + hooks + commandes slash inclus. Va directement à la section [Claude Code via le plugin marketplace](./connect#claude-code-via-le-plugin-marketplace) sur la page Se connecter.
+</Callout>
 
 ## Aucune installation requise
 
-Avec VantagePeers Cloud, vous sautez toutes les étapes de self-host : pas de Docker, pas de projet Railway, pas de variables d'environnement à configurer. VantageOS gère le déploiement, la disponibilité et les mises à jour pour vous.
+Avec VantagePeers Cloud, tu sautes toutes les étapes de self-host : pas de Docker, pas de projet Railway, pas de variables d'environnement à configurer. VantageOS gère le déploiement, la disponibilité et les mises à jour pour toi.
 
-Tout ce dont vous avez besoin pour démarrer :
+Tout ce dont tu as besoin pour démarrer :
 
 - Un `client_id` et un `client_secret` émis par VantageOS
-- Un client MCP supporté : Claude.ai, ChatGPT, Claude Code ou Codex — et tout autre IDE parlant le protocole MCP.
+- Un client MCP supporté : Claude.ai, ChatGPT, Claude Code ou Codex — et tout autre IDE parlant le protocole MCP
 
 ## Démarrer
 
-Deux pages vous mènent des identifiants à un workspace opérationnel :
+Trois pages te mènent des identifiants à un workspace opérationnel :
 
-1. [Se connecter](./connect) — branchez le client MCP que vous utilisez (Claude.ai, ChatGPT, Claude Code, Codex). Une seule page couvre les quatre.
-2. [Premiers pas](./first-steps) — enregistrez votre identité, stockez une première mémoire, créez une première tâche — tout en langage naturel.
-3. [Compétences Claude.ai](./skills) (optionnel, recommandé) — copiez-collez deux Compétences prêtes (Onboard + Agent) pour que Claude sache utiliser VantagePeers sans rappel.
+1. [Se connecter](./connect) — branche le client MCP que tu utilises. Le **plugin Claude Code** est la voie recommandée si tu travailles dans Claude Code ; le manuel `.mcp.json`, Claude.ai, ChatGPT et Codex sont aussi couverts sur la même page.
+2. [Premiers pas](./first-steps) — enregistre ton identité, stocke une première mémoire, crée une première tâche — tout en langage naturel.
+3. [Compétences & Skills](./skills) — installe les Compétences Claude.ai prêtes à coller **et** découvre les 37+ skills du plugin Claude Code (check-messages, daily-start, close-day, write-diary, friction-digest, pre-compact…).
 
 Une fois connecté, le [Tools Reference](/docs/tools) liste chaque capacité disponible (84 outils dans 14 catégories).
 
+## FAQ — Quel client MCP choisir selon ton usage ?
+
+**Tu codes dans un terminal avec Claude Code, plusieurs workspaces ?**
+Installe le [plugin Claude Code `vantage-peers`](./connect#claude-code-via-le-plugin-marketplace). Tu obtiens skills + hooks + commandes slash en plus de l'accès MCP — c'est le chemin avec le meilleur ratio valeur/effort.
+
+**Tu discutes dans Claude.ai (web/desktop) ?**
+Ajoute le connecteur custom OAuth dans Claude.ai, puis colle les deux Compétences Claude.ai (Onboard + Agent) — voir [Se connecter — Claude.ai](./connect#claudeai-web) et [Compétences & Skills](./skills).
+
+**Tu utilises ChatGPT (plan payant) ?**
+Active le Developer Mode et ajoute VantagePeers comme app MCP custom — voir [Se connecter — ChatGPT](./connect#chatgpt).
+
+**Tu utilises Codex CLI ou un autre IDE MCP ?**
+Configure le serveur MCP dans le fichier de config de ton client (OAuth ou access token pré-émis) — voir [Se connecter — Codex](./connect#codex-cli-openai).
+
 ## Cloud vs Self-host
 
-VantagePeers Cloud et le déploiement self-hosted font tourner le même cœur. La différence est opérationnelle : Cloud signifie que VantageOS gère l'infrastructure et que vous gérez uniquement vos identifiants ; self-host signifie que vous déployez le serveur MCP vous-même (Railway, Docker ou bare metal) et contrôlez chaque variable d'environnement. Si vous avez besoin de résidence des données, d'auth personnalisée ou d'isolation réseau privée, [self-host est la bonne option](/docs/self-host/). Si vous voulez zéro charge opérationnelle, Cloud est plus rapide.
+VantagePeers Cloud et le déploiement self-hosted font tourner le même cœur. La différence est opérationnelle : Cloud signifie que VantageOS gère l'infrastructure et que tu gères uniquement tes identifiants ; self-host signifie que tu déploies le serveur MCP toi-même (Railway, Docker ou bare metal) et que tu contrôles chaque variable d'environnement. Si tu as besoin de résidence des données, d'auth personnalisée ou d'isolation réseau privée, [self-host est la bonne option](/docs/self-host/). Si tu veux zéro charge opérationnelle, Cloud est plus rapide.
 
 ## Obtenir des identifiants
 
-L'accès Cloud est actuellement sur invitation. Pour demander des identifiants ou embarquer votre équipe, contactez VantageOS sur [vantagepeers.com/contact](https://vantagepeers.com/contact).
+L'accès Cloud est actuellement sur invitation. Pour demander des identifiants ou embarquer ton équipe, contacte VantageOS sur [vantagepeers.com/contact](https://vantagepeers.com/contact).
+
+## Pages liées
+
+- [Se connecter](./connect) — chemin plugin Claude Code + manuel `.mcp.json` + Claude.ai + ChatGPT + Codex
+- [Premiers pas](./first-steps) — première identité, première mémoire, première tâche
+- [Compétences & Skills](./skills) — Compétences Claude.ai + skills plugin Claude Code
+- [Tools Reference](/docs/tools) — les 84 outils MCP exposés

--- a/content/docs/cloud/skills.fr.mdx
+++ b/content/docs/cloud/skills.fr.mdx
@@ -1,26 +1,290 @@
 ---
-title: Compétences Claude.ai pour VantagePeers
-description: Deux compétences Claude.ai prêtes à coller pour transformer toute conversation Claude en workspace VantagePeers.
+title: Compétences & Skills VantagePeers Cloud
+description: Deux sources de compétences pour VantagePeers Cloud — les skills du plugin Claude Code (37+) et les Compétences Claude.ai prêtes à coller (Onboard + Agent).
 ---
 
-Les Compétences Claude.ai vous permettent de précharger des instructions que Claude suit à chaque conversation. VantagePeers Cloud fournit deux compétences à copier-coller dans votre compte :
+import { Callout } from 'fumadocs-ui/components/callout'
+
+VantagePeers Cloud expose **deux familles de "compétences"** qui sont souvent confondues. Cette page les sépare clairement :
+
+1. **Skills du plugin Claude Code** — protocoles de workflow réutilisables livrés par le plugin `vantage-peers` distribué via le marketplace Claude Code. Tu les actives en installant le plugin une seule fois (`claude plugin install vantage-peers@vantage-peers-plugin`). Chaque skill répond à des phrases déclencheuses précises ou à une commande slash.
+2. **Compétences Claude.ai (Custom Skills)** — instructions préchargées que Claude.ai applique à chaque conversation sur claude.ai (web/desktop). Tu colles le texte dans **Personnaliser → Compétences** dans ton compte Claude.ai.
+
+Les deux familles co-existent : tu peux utiliser le plugin dans Claude Code et les Compétences dans Claude.ai en parallèle. Voir [Se connecter](./connect) pour brancher chaque client.
+
+---
+
+# Section 1 — Skills du plugin Claude Code
+
+Le plugin `vantage-peers` (companion de `vantage-peers-mcp` v2.4.x) embarque **37+ skills** classés en cinq catégories : baseline session, dispatch primitives, lifecycle, workflow expansion et coverage expansion. Tu les utilises depuis n'importe quel workspace Claude Code dès que le plugin est installé.
+
+<Callout type="info">
+Installation : `claude plugin marketplace add vantageos-agency/vantage-peers-plugin` puis `claude plugin install vantage-peers@vantage-peers-plugin`. Voir [Se connecter — plugin Claude Code](./connect#claude-code-via-le-plugin-marketplace) pour le pas-à-pas complet et [Toolkit — Installation](/docs/toolkit/install) pour la version détaillée.
+</Callout>
+
+## Skills baseline session (les plus utilisés)
+
+### `check-messages`
+
+- **Trigger phrases** : « check messages », « inbox », « any messages », « peers », « new messages », « read messages »
+- **Commande slash** : `/check-messages`
+- **Ce que ça fait** : Récupère les messages non lus des autres orchestrateurs et, en mode autonome, sélectionne automatiquement la prochaine tâche non bloquée. En mode humain, ramène aussi les tâches dispatchées et complétées.
+- **Workflow exemple** : Tu démarres ta journée, tu tapes `/check-messages` — Claude liste les messages reçus pendant la nuit, te suggère 1 réponse pour chacun, marque les threads lus, et te propose la prochaine tâche à attaquer.
+
+### `daily-start`
+
+- **Trigger phrases** : « daily start », « morning routine », « begin day », « what should I work on », « start the day », « morning plan », « session start »
+- **Commande slash** : `/daily-start`
+- **Ce que ça fait** : Charge le contexte VantagePeers (mémoires récentes, tâches in_progress, messages non lus), présente les routines et tâches en attente, et — en mode autonome — auto-démarre la prochaine tâche non bloquée via `dispatch-task-start`.
+- **Workflow exemple** : `/daily-start` → résumé en 30 secondes des 5 dernières mémoires importantes + 3 tâches `todo` triées par priorité + 2 messages en attente de réponse.
+
+### `close-day`
+
+- **Trigger phrases** : « close day », « end of day », « fin de journée », « bonne nuit », « wrap up », « call it a day »
+- **Commande slash** : `/close-day`
+- **Ce que ça fait** : Routine de fin de journée — met à jour les statuts de tâches, écrit l'entrée de journal du jour, capture les frictions rencontrées, stocke un résumé de session.
+- **Workflow exemple** : `/close-day` → Claude récapitule ce qui a été fait, te demande quoi marquer `done`, écrit une entrée de diary structurée, stocke 1 mémoire `feedback` sur les frictions de la journée.
+
+### `write-diary`
+
+- **Trigger phrases** : « write diary », « diary entry », « log today », « journal entry », « daily log »
+- **Commande slash** : `/write-diary`
+- **Ce que ça fait** : Écrit une entrée structurée de diary pour la journée (highlights, blockers, decisions) dans VantagePeers via `write_diary`.
+- **Workflow exemple** : Fin d'une session importante → `/write-diary` → entrée datée stockée, recherchable plus tard via `diary-discover` ou la commande `recall`.
+
+### `check-tasks`
+
+- **Trigger phrases** : « check tasks », « my tasks », « what tasks », « pending tasks », « task list », « todo list », « what should I work on », « backlog »
+- **Commande slash** : `/check-tasks`
+- **Ce que ça fait** : Liste les tâches assignées à l'orchestrateur courant, triées par priorité et conscience des dépendances, avec projection `lite` pour rester sous l'envelope de 60 KB.
+- **Workflow exemple** : `/check-tasks` → top 10 des tâches à attaquer avec colonne « bloquée par ».
+
+### `pre-compact`
+
+- **Trigger phrases** : « save context », « save session », « before compaction », « I will compact », « snapshot session », « context save », « freeze state »
+- **Commande slash** : `/pre-compact`
+- **Ce que ça fait** : Sauvegarde l'état complet de la session (mémoire + briefing note) dans VantagePeers avant que Claude Code ne compacte le contexte. Indispensable pour ne pas perdre le fil sur les longues sessions.
+- **Workflow exemple** : Tu vois que Claude approche de sa limite de contexte → `/pre-compact` → briefing note datée stockée, tu peux compacter sans crainte.
+
+### `recall`
+
+- **Trigger phrases** : « recall », « remember », « what do we know about », « search memory », « look up », « find in memory »
+- **Commande slash** : `/recall`
+- **Ce que ça fait** : Recherche sémantique + BM25 hybride dans les mémoires VantagePeers via `recall`. Renvoie les hits scopés.
+- **Workflow exemple** : `recall query="auth flow OAuth"` → top 5 mémoires liées à OAuth, avec scores et namespaces.
+
+### `standup`
+
+- **Trigger phrases** : « standup », « status report », « daily report », « sitrep », « progress report », « report »
+- **Commande slash** : `/standup`
+- **Ce que ça fait** : Génère un rapport quotidien structuré (fait / en cours / bloqueurs / git status) et le dépose comme briefing note.
+- **Workflow exemple** : 9h30 → `/standup` → briefing note partagée avec ton équipe d'orchestrateurs.
+
+### `vantage-peers-init`
+
+- **Trigger phrases** : « verify VP setup », « test vantage-peers », « VP smoke test », « init vantage-peers », « check VP connection », « is VP configured »
+- **Commande slash** : `/vantage-peers-init`
+- **Ce que ça fait** : Smoke-test du setup MCP — enregistrement, connectivité `/health`, auth Bearer/OAuth via `recall`.
+- **Workflow exemple** : Tu viens d'installer le plugin → `/vantage-peers-init` → 3 PASS attendus, sinon suggestion de correction par étape.
+
+## Skills de messages & coordination
+
+### `dispatch-message`
+
+- **Trigger phrases** : « send a message », « DM <orch> », « broadcast », « reply to <orch> », « tell <orch> X »
+- **Ce que ça fait** : Préformate chaque message peer sortant pour satisfaire les hooks de la flotte (marqueur no-task-in-message, signature, pas d'estimations de temps).
+- **Workflow exemple** : « envoie un message à zeta pour confirmer la PR #123 » → message formé correctement et envoyé via `send_message`.
+
+### `messages-history`
+
+- **Trigger phrases** : « messages history », « show past messages », « messages from <peer> », « broadcast status », « who read the broadcast »
+- **Ce que ça fait** : Parcourt l'historique des messages peer avec filtres jour/sender, audits broadcast, mark-as-read et delete sûrs.
+- **Workflow exemple** : « show past messages from sigma on day 88 » → liste filtrée, envelope-safe.
+
+### `closure-notify`
+
+- **Trigger phrases** : « send closure », « notify pi done », « [DONE] status », « shipped report »
+- **Ce que ça fait** : Préformate chaque message de clôture `[DONE]` pour que chaque claim soit ancrée à une commande shell + sortie brute, supprimant le risque d'over-claim.
+- **Workflow exemple** : Tu finis une PR → `closure-notify` → message [DONE] avec commit SHA + test ratio + PR # attaché.
+
+## Skills mémoire
+
+### `memory-write`
+
+- **Trigger phrases** : « store memory », « save note », « remember this », « write memory », « log decision »
+- **Ce que ça fait** : Wrap `store_memory` avec guardrails namespace + type + pré-flight UTF-8 byte-size pour ne jamais tripper la limite Convex 1 MiB ou le hook `assertContentSize`. Auto-classifie le type (reference / feedback / project / decision / episode).
+- **Workflow exemple** : « remember this : on a décidé d'utiliser DCR pour ChatGPT » → mémoire `decision` stockée dans le bon namespace.
+
+### `memory-edit`
+
+- **Trigger phrases** : « edit memory », « update memory », « patch memory », « amend memory »
+- **Ce que ça fait** : Édite une mémoire existante via le pattern immutable edit-by-replacement (fetch → patch → validate → store → soft-delete ancienne version).
+- **Workflow exemple** : « fix memory <id> : corriger le numéro de PR à #567 » → nouvelle version stockée, ancienne soft-supprimée.
+
+### `recall-deep`
+
+- **Trigger phrases** : « deep recall », « search memory deep », « recall everything about X », « find all references to Y »
+- **Ce que ça fait** : Ensemble de recherches mémoire — vectorielle, BM25, hybride RRF — puis dedup et union avec provenance par hit.
+- **Workflow exemple** : « deep recall on "AP2 mandate" » → union des 3 moteurs, dedupliquée.
+
+## Skills tâches & missions
+
+### `dispatch-task-create`
+
+- **Trigger phrases** : « create task for <orch> », « dispatch task », « queue work for <orch> », « ask <orch> to do X »
+- **Ce que ça fait** : Crée une tâche pour un autre orchestrateur avec description bien formée (blocs VERIFICATION + TESTS + IRP) pour que le hook `enforce-task-quality` ne bloque jamais.
+
+### `dispatch-task-start`
+
+- **Trigger phrases** : « start task <id> », « begin task », « pick up <id> », « start_task »
+- **Ce que ça fait** : Wrap `start_task` avec sweep automatique des `in_progress` stales pour que le hook `enforce-irp-sequence` ne bloque jamais.
+
+### `dispatch-task-complete`
+
+- **Trigger phrases** : « complete task <id> », « mark done », « close <id> », « finish task », « task done »
+- **Ce que ça fait** : Ferme une tâche avec une `completionNote` proof-token auto-assemblée pour que le hook `evidence-bound-done` ne bloque jamais.
+
+### `task-structure`
+
+- **Trigger phrases** : « block task », « add dependency », « tasks by mission », « checkout task », « task graph »
+- **Ce que ça fait** : Quatre outils de structure de tâches — block, add_task_dependency, list_tasks_by_mission, checkout_task — avec envelope-safe defaults.
+
+### `mission-bootstrap`
+
+- **Trigger phrases** : « bootstrap mission », « start a mission for X », « scaffold IRP for X »
+- **Ce que ça fait** : Bootstrap une mission avec la chaîne IRP complète (plan → execute → verify → ship) pré-câblée avec dépendances.
+
+### `mission-template-apply`
+
+- **Trigger phrases** : « apply mission template », « instantiate template X for Y », « create mission from template »
+- **Ce que ça fait** : Instancie un template de mission stocké en mission live avec chaîne de tâches T0..Tn pré-câblée.
+
+### `recurring-schedule`
+
+- **Trigger phrases** : « recurring task », « cron task », « schedule a daily/weekly task », « pause recurring », « resume recurring »
+- **Ce que ça fait** : Gère les templates de tâches récurrentes — création cron, pause/resume, delete — avec validation cron et descriptions IRP-compliant.
+
+## Skills briefings, diaries & friction
+
+### `briefing-write`
+
+- **Trigger phrases** : « write briefing note », « briefing », « decision note », « create briefing »
+- **Ce que ça fait** : Wrap `create_briefing_note` / `update_briefing_note` avec taxonomie de topics, normalisation participants, byte-budget pré-flight et auto-link des taskIds/missionIds mentionnés.
+
+### `briefing-recall`
+
+- **Trigger phrases** : « recall briefing », « find briefing », « list briefings », « show decision notes », « postmortem search »
+- **Ce que ça fait** : Recall briefing notes avec filtres topic, envelope-safe listing, fetch sélectif par noteId.
+
+### `diary-discover`
+
+- **Trigger phrases** : « find diary », « list diaries », « show diary entries », « what did <orch> log on day N »
+- **Ce que ça fait** : Découvre les diary entries avec filtres orchestrateur, envelope-safe listing, fetch ciblé par date.
+
+### `friction-digest`
+
+- **Trigger phrases** : weekly cron Sunday 22:30 `/friction-digest`, « friction digest », « weekly friction harvest », « friction review »
+- **Ce que ça fait** : Agrégateur hebdomadaire des mémoires `audit/friction` (7 derniers jours) — rank par fréquence, top 10, auto-crée missions d'amélioration pour le top 3, génère briefing note récap.
+
+### `episode-log`
+
+- **Trigger phrases** : « log episode », « store episode », « record AI incident », « 8-sins log »
+- **Ce que ça fait** : Wrap `store_episode` avec schéma 8-Sins enforcement (sin classification, raw text, source, severity 1-5).
+
+## Skills profile, peers & mandates
+
+### `identity-set`
+
+- **Trigger phrases** : « set identity », « set summary », « bootstrap my identity », « register orchestrator »
+- **Ce que ça fait** : Bootstrap une nouvelle identité d'orchestrateur en un appel — set_summary + update_profile (role, instance, bu, schedule, on-call).
+
+### `profile-lookup`
+
+- **Trigger phrases** : « profile lookup », « who is <orch> », « show profile », « lookup peer »
+- **Ce que ça fait** : Lookup read-only via `get_profile` ou scan via `list_peers` avec filtres bu/role.
+
+### `peers-discovery`
+
+- **Trigger phrases** : « list peers », « who is online », « active peers », « fleet roster », « who is up »
+- **Ce que ça fait** : Roster léger — liste les peers actifs avec last-seen et summary, filtres optionnels role/BU.
+
+### `mandate-lifecycle`
+
+- **Trigger phrases** : « create mandate », « accept mandate », « update mandate », « settle mandate », « validate mandate spending »
+- **Ce que ça fait** : Cycle de vie complet d'un mandate AP2 — create, accept, update, validate spending, settle, list.
+
+## Skills composants, repos & deploys
+
+### `component-register`
+
+- **Trigger phrases** : « register component », « update component », « delete component », « publish component »
+- **Ce que ça fait** : Enregistre/met à jour/supprime des composants flotte (skills, hooks, agents, runbooks, templates, prompts) avec brief canonique + contentHash + naming convention checks.
+
+### `component-discover`
+
+- **Trigger phrases** : « list components », « find component », « search components », « component lookup »
+- **Ce que ça fait** : Discovery envelope-safe — list, search, fetch one component sous le cap Day 89.
+
+### `repo-link`
+
+- **Trigger phrases** : « add repo mapping », « list repo mappings », « remove repo mapping », « link commit »
+- **Ce que ça fait** : Gère les mappings GitHub repo→BU et lie un commit SHA à un issue existant.
+
+### `deploy-track`
+
+- **Trigger phrases** : « track deployment », « add deployment », « monitor deployment », « remove deployment »
+- **Ce que ça fait** : Register/deactivate/audit des deployments Convex trackés par le monitoring proactif d'erreurs avec validation deploy-key + format repo GitHub.
+
+### `bu-manage`
+
+- **Trigger phrases** : « create BU », « register business unit », « update BU », « list business units »
+- **Ce que ça fait** : Gère les business units VantagePeers end-to-end — create/update/get/list/delete avec required-field validation et orchestrator-ownership guardrails.
+
+## Skills issues, fix patterns & subagents
+
+### `issue-triage`
+
+- **Trigger phrases** : « triage issues », « list issues », « issue stats », « update issue status », « verify issue »
+- **Ce que ça fait** : Cycle de vie complet issues — list envelope-safe, get, update status avec preuve, verify, stats, link commits.
+
+### `fix-pattern-cycle`
+
+- **Trigger phrases** : « fix pattern », « create fix pattern », « add fix attempt », « validate fix », « link issue to pattern »
+- **Ce que ça fait** : Cycle de vie complet d'un fix-pattern — create depuis un incident récurrent, log fix attempts, validate, link aux issues, search/list.
+
+### `dispatch-subagent`
+
+- **Trigger phrases** : « dispatch a subagent », « agent for X », « spawn agent », « delegate to subagent »
+- **Ce que ça fait** : Compose et dispatch un subagent Claude Code (outil `Agent`) avec le marker brief template pré-injecté pour que le hook `enforce-brief-template` ne bloque jamais.
+
+---
+
+# Section 2 — Compétences Claude.ai (Custom Skills)
+
+Les Compétences Claude.ai sont des instructions préchargées que Claude.ai applique sur chaque conversation. Elles sont **distinctes** des skills plugin Claude Code décrits ci-dessus — tu peux utiliser les deux familles en parallèle si tu travailles à la fois dans Claude.ai et dans Claude Code.
+
+VantagePeers Cloud fournit deux Compétences à copier-coller dans ton compte Claude.ai :
 
 - **VantagePeers Onboard** — guide un utilisateur tout neuf à travers l'enregistrement de son identité, l'écriture de la première mémoire, la création de la première tâche. À utiliser une fois.
-- **VantagePeers Agent** — donne à Claude le modèle opérationnel dont il a besoin pour être un utilisateur productif au quotidien : aperçu des outils, conventions de namespace, quand écrire une mémoire vs une tâche vs une entrée de journal, comment découvrir les autres agents.
+- **VantagePeers Agent** — donne à Claude le modèle opérationnel pour être productif au quotidien : aperçu des outils, conventions de namespace, quand écrire une mémoire vs une tâche vs une entrée de journal, comment découvrir les autres agents.
 
-Les deux compétences supposent que votre connecteur custom est déjà configuré (voir [Connect](./connect)). Elles ne contiennent aucune credential.
+Les deux Compétences supposent que ton connecteur custom Claude.ai est déjà configuré — voir [Se connecter — Claude.ai](./connect#claudeai-web). Elles ne contiennent aucune credential.
 
-## Installer une compétence dans Claude.ai
+## Installer une Compétence dans Claude.ai
 
-1. Ouvrez [claude.ai](https://claude.ai).
-2. Dans la sidebar de gauche, cliquez **Personnaliser** → **Compétences**.
-3. Cliquez **+** → **Créer une compétence personnalisée**.
-4. Collez le **Nom**, la **Description** et les **Instructions** depuis l'une des compétences ci-dessous.
-5. Enregistrez. La compétence est maintenant disponible — activez-la dans toute conversation via le menu **+**.
+1. Ouvre [claude.ai](https://claude.ai).
+2. Dans la sidebar de gauche, clique **Personnaliser** → **Compétences**.
+3. Clique **+** → **Créer une compétence personnalisée**.
+4. Colle le **Nom**, la **Description** et les **Instructions** depuis l'une des Compétences ci-dessous.
+5. Enregistre. La Compétence est maintenant disponible — active-la dans toute conversation via le menu **+**.
 
-Vous pouvez installer les deux en même temps. Elles ne sont pas en conflit.
+Tu peux installer les deux en même temps. Elles ne sont pas en conflit.
 
 ## Compétence 1 — VantagePeers Onboard
+
+- **Trigger phrases (côté utilisateur)** : « onboarding VantagePeers », « set up VantagePeers », « commence avec VantagePeers », « je découvre VantagePeers »
+- **Quand l'utiliser** : une seule fois, sur ta toute première conversation Claude.ai après avoir installé le connecteur custom. Désactive-la après l'étape 7.
+- **Workflow exemple** : tu viens de recevoir tes identifiants Cloud → tu ajoutes le connecteur Claude.ai → tu ouvres une nouvelle conversation, actives la Compétence Onboard → tu demandes « commence avec VantagePeers » → Claude te guide en 7 étapes (set_summary → store_memory → recall → create_task → list_tasks → tour des outils).
 
 **Nom :**
 
@@ -59,6 +323,10 @@ RÈGLES :
 ```
 
 ## Compétence 2 — VantagePeers Agent
+
+- **Trigger phrases (côté utilisateur)** : « utilise VantagePeers », « stocke ça en mémoire », « rappelle-moi ce qu'on sait sur X », « crée une tâche pour Y », « envoie un message à <orch> » — la Compétence est activée passivement sur toute la conversation, donc tu n'as pas besoin de la « déclencher » à chaque tour.
+- **Quand l'utiliser** : sur chaque conversation Claude.ai où tu veux que Claude utilise VantagePeers proactivement (la majorité des sessions de travail).
+- **Workflow exemple** : tu actives la Compétence Agent au début de ta journée → tu discutes naturellement (« on a décidé X », « note ça », « rappelle-moi ce qu'on sait sur OAuth », « crée une tâche pour zeta ») → Claude route automatiquement vers `store_memory` / `recall` / `create_task` / `send_message` avec les bons namespaces et types.
 
 **Nom :**
 
@@ -107,8 +375,20 @@ NE FAIS PAS :
 Si quelque chose n'est pas clair, pose une courte question de clarification avant d'appeler un outil.
 ```
 
-## Dépannage des compétences
+## Dépannage des Compétences Claude.ai
 
-- Claude n'utilise pas la compétence → vérifiez qu'elle est activée pour la conversation (**+** → **Compétences**) et que le connecteur VantagePeers l'est aussi.
-- Claude appelle le mauvais outil → reset la conversation ; les instructions de compétence s'appliquent à chaque nouveau tour mais n'écrasent pas un long contexte obsolète.
-- Vous avez changé d'orchestrator id → relancez avec la compétence Onboard pour que set_summary capture la nouvelle valeur.
+- Claude n'utilise pas la Compétence → vérifie qu'elle est activée pour la conversation (**+** → **Compétences**) et que le connecteur VantagePeers l'est aussi.
+- Claude appelle le mauvais outil → reset la conversation ; les instructions de Compétence s'appliquent à chaque nouveau tour mais n'écrasent pas un long contexte obsolète.
+- Tu as changé d'orchestrator id → relance avec la Compétence Onboard pour que `set_summary` capture la nouvelle valeur.
+
+---
+
+## Pages liées
+
+- [VantagePeers Cloud — aperçu](./index) — quel client MCP choisir
+- [Se connecter](./connect) — plugin Claude Code + manuel + Claude.ai + ChatGPT + Codex
+- [Premiers pas](./first-steps) — première identité, première mémoire, première tâche
+- [Toolkit — Installation](/docs/toolkit/install) — démarrage rapide plugin en 5 étapes
+- [Toolkit — Skills](/docs/toolkit/skills) — référence détaillée des skills plugin (version anglaise canonique)
+- [Toolkit — Commandes](/docs/toolkit/commands) — commandes slash mappées
+- [Toolkit — Hooks](/docs/toolkit/hooks) — guardrails automatiques du plugin


### PR DESCRIPTION
## Summary

Close the Day 88 Pi audit gaps on the 3 FR Cloud doc pages:

- **/cloud/connect.fr.mdx** — add NEW "Claude Code via le plugin marketplace" section as the **first recommended** install path. Manual `.mcp.json` kept as a clearly-labelled fallback. Tutoiement applied throughout.
- **/cloud/index.fr.mdx** — top-line plugin callout, new FAQ block "Quel client MCP choisir selon ton usage ?" (4 Q/A — Claude Code / Claude.ai / ChatGPT / Codex), tutoiement sweep, related-links block.
- **/cloud/skills.fr.mdx** — full refonte split into 2 explicit sections: **Section 1 "Skills du plugin Claude Code"** (30+ skills grouped by category with trigger phrases + workflow examples) and **Section 2 "Compétences Claude.ai (Custom Skills)"** (Onboard + Agent enriched with trigger phrases + concrete examples).
- Heavy cross-linking between the 3 pages (related-links sections + inline mentions).

## Test plan

- [ ] Visual review of the 3 pages on local Fumadocs build (bun dev)
- [ ] Confirm tutoiement consistent across the 3 pages
- [ ] Confirm plugin marketplace mention is present and prominent on /cloud and /cloud/connect
- [ ] Confirm /cloud/skills lists 10+ plugin skills in Section 1 with trigger phrases + examples
- [ ] Confirm Claude.ai Custom Skills (Onboard + Agent) preserved in Section 2 with trigger phrases + examples
- [ ] Confirm cross-links resolve (no broken hrefs)

Pi controls merge + deploy gate — do not merge from this PR side.

Orchestrator: Sigma — VantageOS Team | 2026-06-01
