### PR TITLE
fix(docs/cloud/fr): escape MDX angle-bracket placeholders — unblock Vercel build

### DIFF
--- a/content/docs/cloud/skills.fr.mdx
+++ b/content/docs/cloud/skills.fr.mdx
@@ -91,13 +91,13 @@ Installation : `claude plugin marketplace add vantageos-agency/vantage-peers-plu
 
 ### `dispatch-message`
 
-- **Trigger phrases** : « send a message », « DM <orch> », « broadcast », « reply to <orch> », « tell <orch> X »
+- **Trigger phrases** : « send a message », « DM `<orch>` », « broadcast », « reply to `<orch>` », « tell `<orch>` X »
 - **Ce que ça fait** : Préformate chaque message peer sortant pour satisfaire les hooks de la flotte (marqueur no-task-in-message, signature, pas d'estimations de temps).
 - **Workflow exemple** : « envoie un message à zeta pour confirmer la PR #123 » → message formé correctement et envoyé via `send_message`.
 
 ### `messages-history`
 
-- **Trigger phrases** : « messages history », « show past messages », « messages from <peer> », « broadcast status », « who read the broadcast »
+- **Trigger phrases** : « messages history », « show past messages », « messages from `<peer>` », « broadcast status », « who read the broadcast »
 - **Ce que ça fait** : Parcourt l'historique des messages peer avec filtres jour/sender, audits broadcast, mark-as-read et delete sûrs.
 - **Workflow exemple** : « show past messages from sigma on day 88 » → liste filtrée, envelope-safe.
 
@@ -119,7 +119,7 @@ Installation : `claude plugin marketplace add vantageos-agency/vantage-peers-plu
 
 - **Trigger phrases** : « edit memory », « update memory », « patch memory », « amend memory »
 - **Ce que ça fait** : Édite une mémoire existante via le pattern immutable edit-by-replacement (fetch → patch → validate → store → soft-delete ancienne version).
-- **Workflow exemple** : « fix memory <id> : corriger le numéro de PR à #567 » → nouvelle version stockée, ancienne soft-supprimée.
+- **Workflow exemple** : « fix memory `<id>` : corriger le numéro de PR à #567 » → nouvelle version stockée, ancienne soft-supprimée.
 
 ### `recall-deep`
 
@@ -131,17 +131,17 @@ Installation : `claude plugin marketplace add vantageos-agency/vantage-peers-plu
 
 ### `dispatch-task-create`
 
-- **Trigger phrases** : « create task for <orch> », « dispatch task », « queue work for <orch> », « ask <orch> to do X »
+- **Trigger phrases** : « create task for `<orch>` », « dispatch task », « queue work for `<orch>` », « ask `<orch>` to do X »
 - **Ce que ça fait** : Crée une tâche pour un autre orchestrateur avec description bien formée (blocs VERIFICATION + TESTS + IRP) pour que le hook `enforce-task-quality` ne bloque jamais.
 
 ### `dispatch-task-start`
 
-- **Trigger phrases** : « start task <id> », « begin task », « pick up <id> », « start_task »
+- **Trigger phrases** : « start task `<id>` », « begin task », « pick up `<id>` », « start_task »
 - **Ce que ça fait** : Wrap `start_task` avec sweep automatique des `in_progress` stales pour que le hook `enforce-irp-sequence` ne bloque jamais.
 
 ### `dispatch-task-complete`
 
-- **Trigger phrases** : « complete task <id> », « mark done », « close <id> », « finish task », « task done »
+- **Trigger phrases** : « complete task `<id>` », « mark done », « close `<id>` », « finish task », « task done »
 - **Ce que ça fait** : Ferme une tâche avec une `completionNote` proof-token auto-assemblée pour que le hook `evidence-bound-done` ne bloque jamais.
 
 ### `task-structure`
@@ -178,7 +178,7 @@ Installation : `claude plugin marketplace add vantageos-agency/vantage-peers-plu
 
 ### `diary-discover`
 
-- **Trigger phrases** : « find diary », « list diaries », « show diary entries », « what did <orch> log on day N »
+- **Trigger phrases** : « find diary », « list diaries », « show diary entries », « what did `<orch>` log on day N »
 - **Ce que ça fait** : Découvre les diary entries avec filtres orchestrateur, envelope-safe listing, fetch ciblé par date.
 
 ### `friction-digest`
@@ -200,7 +200,7 @@ Installation : `claude plugin marketplace add vantageos-agency/vantage-peers-plu
 
 ### `profile-lookup`
 
-- **Trigger phrases** : « profile lookup », « who is <orch> », « show profile », « lookup peer »
+- **Trigger phrases** : « profile lookup », « who is `<orch>` », « show profile », « lookup peer »
 - **Ce que ça fait** : Lookup read-only via `get_profile` ou scan via `list_peers` avec filtres bu/role.
 
 ### `peers-discovery`
@@ -324,7 +324,7 @@ RÈGLES :
 
 ## Compétence 2 — VantagePeers Agent
 
-- **Trigger phrases (côté utilisateur)** : « utilise VantagePeers », « stocke ça en mémoire », « rappelle-moi ce qu'on sait sur X », « crée une tâche pour Y », « envoie un message à <orch> » — la Compétence est activée passivement sur toute la conversation, donc tu n'as pas besoin de la « déclencher » à chaque tour.
+- **Trigger phrases (côté utilisateur)** : « utilise VantagePeers », « stocke ça en mémoire », « rappelle-moi ce qu'on sait sur X », « crée une tâche pour Y », « envoie un message à `<orch>` » — la Compétence est activée passivement sur toute la conversation, donc tu n'as pas besoin de la « déclencher » à chaque tour.
 - **Quand l'utiliser** : sur chaque conversation Claude.ai où tu veux que Claude utilise VantagePeers proactivement (la majorité des sessions de travail).
 - **Workflow exemple** : tu actives la Compétence Agent au début de ta journée → tu discutes naturellement (« on a décidé X », « note ça », « rappelle-moi ce qu'on sait sur OAuth », « crée une tâche pour zeta ») → Claude route automatiquement vers `store_memory` / `recall` / `create_task` / `send_message` avec les bons namespaces et types.
 


### PR DESCRIPTION
## Summary

URGENT fix — Vercel deploy `42d62d7` (PR #125 squash merge) failed build, leaving `/docs/fr/cloud/skills` serving the stale prior-build content. Marie onboarding gate blocked.

Task: `k17bcftzrjnvjxn1qhyws1wm5587v3zf` (Pi dispatch — VP message `jn77h1ypvk68b4n93n87re3fc987vqzm`).

## Root cause

Turbopack MDX error at `content/docs/cloud/skills.fr.mdx:94`:

```
Error: Expected a closing tag for `<orch>` (94:103-94:109) before the end of `paragraph`
```

The PR #125 docs refonte added trigger-phrase lines like:

```
- **Trigger phrases** : « DM <orch> », « reply to <orch> », « tell <orch> X »
```

MDX parsed bare `<orch>` / `<peer>` / `<id>` as JSX/HTML opening tags and aborted before reaching the closing French quote.

## Fix

Wrap every placeholder of shape `<word>` (outside code blocks) in backticks via a one-shot Python pass:

```
« DM `<orch>` », « reply to `<orch>` », « tell `<orch>` X »
```

Backticked placeholders render as inline-code spans — also more honest about what they are (template variables for the reader to fill in).

Applied across `content/docs/cloud/skills.fr.mdx` only (the other two FR pages and the EN locale parity are clean).

## Verification

- [x] `bun run build` → Compiled successfully. sitemap.xml + llms.txt + llms-full.txt generated. No Turbopack MDX errors.
- [x] `git diff --stat` → 1 file changed, 9 insertions(+), 9 deletions(-) — minimal surface.
- [ ] Vercel deploy of this branch → state=SUCCESS for HEAD `015dc61768ce5eccb7fce21f5d8223fd6911ca39`
- [ ] Post-merge: `curl https://www.vantagepeers.com/docs/fr/cloud/skills` contains `Skills du plugin Claude Code` + `vantage-peers-mcp v2.4.x`
- [ ] Post-merge: `curl https://www.vantagepeers.com/docs/fr/cloud/connect` contains `Claude Code via le plugin marketplace`
- [ ] Post-merge: `curl https://www.vantagepeers.com/docs/fr/cloud` contains `Quel client MCP choisir`

## Refs

- Pi urgent dispatch: VP message `jn77h1ypvk68b4n93n87re3fc987vqzm`
- Task: `k17bcftzrjnvjxn1qhyws1wm5587v3zf`
- Failed deploy reference: `42d62d7` (PR #125 squash)

`friction_observed`: Pi annonce DEPLOY SUCCESS au merge sans verifier Vercel deployment status — capitalize fix_pattern `vercel-deploy-verify-status`. Build agent docs refonte n'a pas non plus testé `bun run build` localement avant ship — capitalize `pre-ship-local-build-verify` au brief template general agent + UI agent.

Orchestrator: Sigma — VantageOS Team | 2026-06-01 Day 88

Orchestrator: sigma — VantageOS Team | 2026-06-01
