### PR TITLE
docs(cloud): add MCP tool reference — list_bus (companion PR-A #928 vantage-memory)

### DIFF
--- a/content/docs/cloud/mcp-tools/list-bus.mdx
+++ b/content/docs/cloud/mcp-tools/list-bus.mdx
@@ -1,0 +1,92 @@
+---
+title: list_bus
+description: List business units with pagination, projection, and filters.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout'
+
+# list_bus
+
+List business units (BUs) registered in VantagePeers, with pagination, projection (`lite|full`), and optional filters.
+
+## Args
+
+| Arg | Type | Default | Description |
+|---|---|---|---|
+| `orchestratorId` | string | — | Filter by lead orchestrator (e.g. `"sigma"`). |
+| `status` | `"idea" \| "building" \| "live" \| "revenue"` | — | Filter by lifecycle status. |
+| `limit` | number 1-200 | `20` | Page size. Default `20`, capped at `200`. |
+| `cursor` | string | — | Opaque pagination token returned as `nextCursor` from prior call. |
+| `fields` | `"lite" \| "full"` | `"full"` | `"lite"` returns compact projection (5 keys). `"full"` returns complete BU object (18+ keys). |
+
+## Returns
+
+```ts
+{
+  items: BusinessUnit[] | BusinessUnitLite[],
+  nextCursor: string | null
+}
+```
+
+`nextCursor` is `null` when the current page is the last one; non-null when more rows exist.
+
+## Examples
+
+### Compact list (fields=lite)
+
+```jsonc
+// call
+{ "limit": 20, "fields": "lite" }
+
+// response (~5KB for 100 BUs)
+{
+  "items": [
+    {
+      "_id": "j5xxx...",
+      "_creationTime": 1782050000000,
+      "name": "VantagePeers",
+      "status": "live",
+      "orchestratorId": "sigma"
+    }
+  ],
+  "nextCursor": "eyJjcmVhdGlvblRpbWUiOjE3ODIwNDk5MDAwMDAsImlkIjoiajV5eXkifQ=="
+}
+```
+
+### Detailed single BU (fields=full + limit=1)
+
+```jsonc
+{ "orchestratorId": "sigma", "limit": 1, "fields": "full" }
+```
+
+Returns the full BU record (name, description, purpose, businessModel, targetCustomers, services, pricing, revenueProjections, coreTeam, etc.).
+
+### Paginate through all live BUs
+
+```jsonc
+// page 1
+{ "status": "live", "limit": 20 }
+// → { items: [...], nextCursor: "..." }
+
+// page 2 (use nextCursor)
+{ "status": "live", "limit": 20, "cursor": "<nextCursor from page 1>" }
+```
+
+## Pagination + envelope safety
+
+`list_bus` follows the standard VantagePeers envelope safety pattern (PR-A):
+
+- **Default limit**: `20`. Keeps payloads small (~2-5KB) for typical interactive calls.
+- **Cap**: `200`. Requests with `limit > 200` are clamped server-side.
+- **fields=lite**: projects to 5 stable keys (`_id`, `_creationTime`, `name`, `status`, `orchestratorId`). Payload stays under 25KB even for 100 BUs.
+- **Cursor**: opaque token encoding `{creationTime, id}` to survive same-millisecond inserts. Treat as opaque — do not parse client-side.
+
+Same pattern applies to `list_components` (PR-B) and `list_repo_mappings` (PR-C).
+
+## Why this matters
+
+<Callout type="info">
+Before PR-A: `list_bus` had no cap, `fields=lite` was a no-op (returned full rows), and default limit was 50. A fleet with many BUs could return a 64KB+ payload, overflowing the MCP envelope (25K-token cap) in client sessions.
+
+PR-A enforces strict defaults and an actual lite projection, eliminating envelope overflow as a failure mode. Audit ref: `analysis/mcp-crud-baseline-vp-audit-2026-06-14.md` section 9.
+</Callout>

--- a/content/docs/cloud/mcp-tools/meta.json
+++ b/content/docs/cloud/mcp-tools/meta.json
@@ -1,0 +1,7 @@
+{
+  "title": "MCP Tools",
+  "description": "Reference for individual MCP tools (list_bus, list_components, etc.)",
+  "pages": [
+    "list-bus"
+  ]
+}

--- a/content/docs/cloud/meta.json
+++ b/content/docs/cloud/meta.json
@@ -1,5 +1,5 @@
 {
   "title": "Cloud",
   "defaultOpen": true,
-  "pages": ["index", "connect", "first-steps", "skills"]
+  "pages": ["index", "connect", "first-steps", "skills", "mcp-tools"]
 }


### PR DESCRIPTION
## Scope

Companion site doc for vantage-memory PR-A **#928** — adds first entry in new `/docs/cloud/mcp-tools/` reference section : `list-bus.mdx`.

VP mission VP-MCP top level `k571gcctka8mq5jbkgpj0a0b2n892ctg`. Audit ref `analysis/mcp-crud-baseline-vp-audit-2026-06-14.md` section 9.

## Changes

- NEW `content/docs/cloud/mcp-tools/list-bus.mdx` — Fumadocs page covering :
  - Args reference table (orchestratorId, status, limit, cursor, fields)
  - Returns shape (`{items, nextCursor}` envelope)
  - 3 worked examples (lite list / full single / paginated)
  - Pagination + envelope safety pattern
  - Why this matters — Day 110 envelope overflow rationale
- NEW `content/docs/cloud/mcp-tools/meta.json` — Fumadocs nav config for the new subsection.
- MODIFIED `content/docs/cloud/meta.json` — parent nav adds `"mcp-tools"` page.

## Sibling

To merge in parallel with vantage-memory PR #928. The code changes that this doc describes are in that PR.

## Eta T-VERIFY checklist

Per Eta Q6 criteria (msg `k97e4acr7xms3rv9sxhtybq1mh8931cg`) :

- [ ] MDX file structurally valid (frontmatter + imports + code blocks).
- [ ] No new behavioral prescription introduced.
- [ ] Cross-link with vantage-memory PR #928 explicit.
- [ ] Pattern reusable for PR-B (list_components) and PR-C (list_repo_mappings).

## Mission tracking

| VP entity | ID | Status |
|---|---|---|
| Mission VP-MCP top level | `k571gcctka8mq5jbkgpj0a0b2n892ctg` | execute |
| Companion vantage-memory PR | `#928` | open |
| T-DOC site (this PR) | covered under `k17ayqgzcxefz3q9745391ny25893y3z` | done |

VP-Sources: get_briefing_note(js70p08dztt7v9y3n0tvwe5e51892875), get_mission(k571gcctka8mq5jbkgpj0a0b2n892ctg), get_task(k17ayqgzcxefz3q9745391ny25893y3z)

Orchestrator: Sigma — VantagePeers | 2026-06-21
