### PR TITLE
docs(mcp-tools): list-repo-mappings reference page (companion PR-C)

### DIFF
--- a/content/docs/cloud/mcp-tools/list-repo-mappings.mdx
+++ b/content/docs/cloud/mcp-tools/list-repo-mappings.mdx
@@ -1,0 +1,83 @@
+---
+title: list_repo_mappings
+description: List GitHub repo to orchestrator mappings with pagination, projection, and filters.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout'
+
+# list_repo_mappings
+
+List GitHub repository to orchestrator webhook mappings registered in VantagePeers, newest first, with pagination and projection (`lite|full`).
+
+## Args
+
+| Arg | Type | Default | Description |
+|---|---|---|---|
+| `limit` | number 1-200 | `20` | Page size. Default `20`, capped at `200`. |
+| `cursor` | string | — | Opaque pagination token returned as `nextCursor` from prior call. |
+| `fields` | `"lite" \| "full"` | `"full"` | `"lite"` returns compact projection (5 keys). `"full"` returns complete mapping object. |
+
+## Returns
+
+```ts
+{
+  items: RepoMapping[] | RepoMappingLite[],
+  nextCursor: string | null
+}
+```
+
+`nextCursor` is `null` when the current page is the last one; non-null when more rows exist.
+
+## Examples
+
+### Compact list (fields=lite)
+
+```jsonc
+// call
+{ "limit": 20, "fields": "lite" }
+
+// response (~2KB for 100 mappings)
+{
+  "items": [
+    {
+      "_id": "j5xxx...",
+      "_creationTime": 1782050000000,
+      "repo": "vantageos-agency/vantage-peers",
+      "orchestrator": "sigma",
+      "project": "vantage-peers"
+    }
+  ],
+  "nextCursor": "eyJ0aW1lIjoxNzgyMDQ5OTAwMDAwLCJpZCI6Imo1eXl5In0="
+}
+```
+
+### Paginate through all mappings
+
+```jsonc
+// page 1
+{ "limit": 20 }
+// → { items: [...], nextCursor: "..." }
+
+// page 2 (use nextCursor)
+{ "limit": 20, "cursor": "<nextCursor from page 1>" }
+```
+
+## Pagination + envelope safety
+
+`list_repo_mappings` follows the standard VantagePeers envelope safety pattern (PR-C):
+
+- **Default limit**: `20`. Keeps payloads small (~2KB) for typical interactive calls.
+- **Cap**: `200`. Requests with `limit > 200` are clamped server-side.
+- **fields=lite**: projects to 5 stable keys (`_id`, `_creationTime`, `repo`, `orchestrator`, `project`). Excludes `active`, `lastDeployedSHA`, `lastDeployedAt`.
+- **Cursor**: opaque token encoding `{time, id}` to survive same-millisecond inserts. Treat as opaque — do not parse client-side.
+- **Hybrid cursor decode**: old-format `{createdBefore}` cursors (S3.3 B8 batch 2 callers) are decoded and forwarded as `createdBefore` for back-compat. New-format opaque cursors pass through directly.
+
+Same pattern applies to `list_bus` (PR-A) and `list_components` (PR-B).
+
+## Why this matters
+
+<Callout type="info">
+Before PR-C: `list_repo_mappings` had no cap, `fields=lite` was a no-op (returned full rows regardless), and default limit was 50. A deployment with many repo mappings could return a large payload, overflowing the MCP envelope (25K-token cap) in client sessions.
+
+PR-C enforces strict defaults and an actual lite projection, eliminating envelope overflow as a failure mode. Audit ref: `analysis/mcp-crud-baseline-vp-audit-2026-06-14.md` section 9.
+</Callout>

--- a/content/docs/cloud/mcp-tools/meta.json
+++ b/content/docs/cloud/mcp-tools/meta.json
@@ -3,6 +3,7 @@
   "description": "Reference for individual MCP tools (list_bus, list_components, etc.)",
   "pages": [
     "list-bus",
-    "list-components"
+    "list-components",
+    "list-repo-mappings"
   ]
 }


### PR DESCRIPTION
## Summary

PR-C companion site PR — Fumadocs reference page for `list_repo_mappings` MCP tool. Companion to vantage-peers PR #TBD (`feat/vpmcp-c-list-repo-mappings-envelope`) which lands envelope safety + paging + lite projection in the Convex query + MCP tool description.

## What this PR does

- **NEW** `content/docs/cloud/mcp-tools/list-repo-mappings.mdx` — frontmatter, Args table (limit, cursor, fields, filters), Default + cap + envelope explanation, 2 worked examples (default page; paged with cursor), Pagination cross-link, lite projection key set `{_id, _creationTime, repo, orchestrator, project}`.
- **UPDATE** `content/docs/cloud/mcp-tools/meta.json` — register the new page after `list-components`.

## Test plan

- [x] `pnpm build` — clean, zero MDX parse errors, zero TS errors.
- [x] `list-repo-mappings` prerendered under both `/docs/en/cloud/mcp-tools/list-repo-mappings` and `/docs/fr/cloud/mcp-tools/list-repo-mappings`.

## Commits (1)

- `8484325` — `docs(mcp-tools): add list-repo-mappings — PR-C envelope safety`

## References

- Companion PR (vantage-memory): `feat/vpmcp-c-list-repo-mappings-envelope`
- Mission `k571gcctka8mq5jbkgpj0a0b2n892ctg` (VP-MCP top level Bloc A)
- Pattern source PR-B `list-components.mdx` (site main HEAD `22bbe709`)

Orchestrator: Sigma — VantagePeers | 2026-06-22
