### PR TITLE
docs(mcp-tools): add improvisation-digest (PR-I)

### DIFF
--- a/content/docs/cloud/mcp-tools/improvisation-digest.mdx
+++ b/content/docs/cloud/mcp-tools/improvisation-digest.mdx
@@ -107,10 +107,10 @@ The A5 exclusions prevent false positives from automated infrastructure records 
 ## V1 scope and V2 roadmap
 
 <Callout type="warn">
-V1 (current) scans VP records only — tasks, messages, and memories stored in VantagePeers (Option C). V2 evolution to transcript-replay (Option A — reading raw agent output from conversation logs) is reserved if V1 proves to miss too many improvisations due to agents not storing all fleet-state claims as VP records.
+V1 (current) scans VP records only — tasks, messages, and memories stored in VantagePeers (Option C). Per Pi Day-113 arbitration (msg `k97a0pp6kq1axkj6cmc4pecpy989ce1w`), the fallback if V1 misses too many improvisations is **Option B** — a new dedicated `sessions` Convex table — **not** Option A (transcript-replay from JSONL conversation logs).
 </Callout>
 
-V1 was selected because VP records are already structured, queryable, and authorship-attributed. Option A would require a separate transcript ingestion pipeline and is significantly more complex. Monitor `countsByOrch` trends over 2–4 weeks to determine whether V1 coverage is sufficient before investing in V2.
+V1 was selected because VP records are already structured, queryable, and authorship-attributed. Monitor `countsByOrch` trends over 2–4 weeks; if V1 coverage proves insufficient (because agents do not store all fleet-state claims as VP records), the next iteration introduces a dedicated `sessions` table (Option B) where the digest can pull richer per-session context without the transcript ingestion pipeline complexity of Option A.
 
 ## Cross-reference
 

--- a/content/docs/cloud/mcp-tools/improvisation-digest.mdx
+++ b/content/docs/cloud/mcp-tools/improvisation-digest.mdx
@@ -1,0 +1,120 @@
+---
+title: improvisation_digest
+description: Weekly advisory digest scanning VP records for fleet/state claims missing the VP-Sources footer.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout'
+
+# improvisation_digest
+
+Scan a rolling time window of VP tasks, messages, and memories for records that carry durable-artifact fleet/state tokens (commit SHA, PR number, VP document ID, or decisive verb such as `merged`, `deployed`, `approved`) but have **no VP-Sources footer**. This is the Eta heuristic proxy for an orchestrator having made a fleet-state claim without a prior `recall` upstream.
+
+<Callout type="info">
+ADVISORY-only — pure read query. `improvisation_digest` never blocks any action. Results are informational: a high improvisation rate indicates a team should increase VP-Sources citation hygiene, but the tool itself takes no automated action and has no side effects.
+</Callout>
+
+## Args
+
+| Arg | Type | Default | Description |
+|---|---|---|---|
+| `windowDays` | number | `7` | Number of days to look back. |
+| `orchestrators` | string[] | — | Scope to these orchestrator roles only (e.g. `["sigma","pi"]`). Omit to scan all orchestrators. |
+
+## Returns
+
+```ts
+{
+  countsByOrch: Record<string, number>,      // hit count per orchestrator
+  countsByCategory: Record<string, number>,  // hit count per record type: "task" | "message" | "memory"
+  samples: Array<{                           // up to 50 representative snippets
+    id: string,
+    category: string,
+    orchestrator: string,
+    snippet: string
+  }>
+}
+```
+
+`countsByOrch` and `countsByCategory` are both zero-initialized for all observed orchestrators/categories — entries with zero hits are omitted from the returned map. `samples` is sorted newest-first and capped at 50 entries.
+
+## Examples
+
+### Default 7-day window across all orchestrators
+
+```jsonc
+// call
+{ "windowDays": 7 }
+
+// response (illustrative)
+{
+  "countsByOrch": { "sigma": 3, "pi": 1 },
+  "countsByCategory": { "task": 2, "message": 2 },
+  "samples": [
+    {
+      "id": "k17abc...",
+      "category": "task",
+      "orchestrator": "sigma",
+      "snippet": "completionNote: merged PR #954 into main — VP-MCP top level..."
+    },
+    {
+      "id": "k97def...",
+      "category": "message",
+      "orchestrator": "pi",
+      "snippet": "deployed vantage-peers-mcp@2.13.0 to Railway at commit ef91f6f"
+    }
+  ]
+}
+```
+
+### Scoped to a single orchestrator
+
+```jsonc
+// call — audit sigma's last 14 days
+{ "windowDays": 14, "orchestrators": ["sigma"] }
+
+// response — only sigma records are evaluated
+{
+  "countsByOrch": { "sigma": 5 },
+  "countsByCategory": { "task": 3, "memory": 2 },
+  "samples": [
+    {
+      "id": "k17xxx...",
+      "category": "memory",
+      "orchestrator": "sigma",
+      "snippet": "approved PR-C — list_repo_mappings envelope safety shipped at 4ddca2b"
+    }
+  ]
+}
+```
+
+## Detection heuristic (Eta A5 scope filter)
+
+A record is flagged when **both** conditions hold simultaneously:
+
+| Condition | Check |
+|---|---|
+| **Durable-artifact token present** | Body contains at least one of: 7–40 hex commit SHA; `#NNN` PR/issue ref; Convex document ID (`k1…` or `j…` prefix); decisive verb (`merged`, `deployed`, `approved`, `shipped`, `released`, `fixed`). |
+| **VP-Sources footer absent** | Body does NOT contain the `VP-Sources:` substring. |
+
+**A5 scope exclusions** — the following are never flagged regardless of content:
+
+- Records authored by `system`
+- Records where `createdBy` matches `/^cron-/i` (dash mandatory)
+- Records originating from webhook ingestion paths
+
+The A5 exclusions prevent false positives from automated infrastructure records that legitimately reference SHAs or PR numbers without a VP-Sources footer obligation.
+
+## V1 scope and V2 roadmap
+
+<Callout type="warn">
+V1 (current) scans VP records only — tasks, messages, and memories stored in VantagePeers (Option C). V2 evolution to transcript-replay (Option A — reading raw agent output from conversation logs) is reserved if V1 proves to miss too many improvisations due to agents not storing all fleet-state claims as VP records.
+</Callout>
+
+V1 was selected because VP records are already structured, queryable, and authorship-attributed. Option A would require a separate transcript ingestion pipeline and is significantly more complex. Monitor `countsByOrch` trends over 2–4 weeks to determine whether V1 coverage is sufficient before investing in V2.
+
+## Cross-reference
+
+- [VP-Sources answer-footer doctrine](/docs/cloud/doctrine/vp-sources-footer) — full reference including worked examples, `none-needed` acceptable cases, and advisory-only rationale.
+- Convex query: `improvisationDigest:scanWindow`
+- Mission: `k571gcctka8mq5jbkgpj0a0b2n892ctg` (VP-MCP top level Bloc A, PR-I)
+- T-RED `cd6cda3` · T-GREEN `b9414dc`

--- a/content/docs/cloud/mcp-tools/meta.json
+++ b/content/docs/cloud/mcp-tools/meta.json
@@ -6,6 +6,7 @@
     "list-components",
     "list-repo-mappings",
     "list-tasks",
-    "bulk-complete-tasks"
+    "bulk-complete-tasks",
+    "improvisation-digest"
   ]
 }


### PR DESCRIPTION
## Summary

PR-I companion site PR — new Fumadocs page `cloud/mcp-tools/improvisation-digest.mdx` documenting the new `improvisation_digest` ADVISORY weekly digest MCP tool shipped in companion vantage-peers PR #TBD (`feat/vpmcp-i-improvisation-digest-weekly`, commit `ef91f6f`).

## What this PR does

- **NEW** `content/docs/cloud/mcp-tools/improvisation-digest.mdx` (122 LOC) — frontmatter, args table (2 args: `windowDays` default 7, `orchestrators?: string[]`), returns envelope (`countsByOrch`, `countsByCategory: {complete_task, send_message, store_memory}`, `samples[≤50]`), 2 examples (default 7-day window all orchestrators / scoped to single orchestrator), detection heuristic section (Eta verbatim summary), `<Callout type="info">` ADVISORY-only pure read query, `<Callout type="warn">` V1=Option C, V2 evolution to Option A reserved, cross-link to VP-Sources doctrine page (PR-H precedent).
- **UPDATE** `content/docs/cloud/mcp-tools/meta.json` — register `improvisation-digest` in pages array.

## Test plan

- [x] `pnpm build` — clean, zero MDX/TS errors.
- [x] 245/245 pages prerendered (EN + FR).

## Commits (1)

- `91a2e6e` — `docs(mcp-tools): add improvisation-digest — PR-I advisory weekly digest`

## References

- Companion PR (vantage-peers): `feat/vpmcp-i-improvisation-digest-weekly`
- Mission `k571gcctka8mq5jbkgpj0a0b2n892ctg` (VP-MCP Bloc A 8/10)

Orchestrator: Sigma — VantagePeers | 2026-06-26