### PR TITLE
chore(site): tool-count CI gate + #137 integer drift correction (Day-101 root-fix)

### DIFF
--- a/.github/workflows/check-tool-counts.yml
+++ b/.github/workflows/check-tool-counts.yml
@@ -1,0 +1,29 @@
+name: Check tool counts
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  check-tool-counts:
+    name: scripts/check-tool-counts.mjs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Assert tools-catalogue.mdx + .fr.mdx Summary integers
+        # Day-101 root-fix for fix-pattern m974527p6jbbb5kzj3jt2z636n89fddv.
+        # Canonical script lives in vantageos-agency/vantage-peers
+        # (scripts/check-tool-counts.mjs, shipped in PR #986). This repo
+        # vendors a byte-equivalent copy under scripts/ — the two MUST stay
+        # in sync. Stdlib-only Node 20 — no npm install needed.
+        run: |
+          node scripts/check-tool-counts.mjs \
+            --target=content/docs/tools-catalogue.mdx \
+            --target-fr=content/docs/tools-catalogue.fr.mdx

--- a/content/docs/tools-catalogue.fr.mdx
+++ b/content/docs/tools-catalogue.fr.mdx
@@ -236,7 +236,7 @@ Le support curseur/limite (O/N/EXCEPTION) reflète l'audit Day-114. Tous les out
 | Mémoire | 9 |
 | Épisodes | 5 |
 | Messagerie | 8 |
-| Tâches | 16 |
+| Tâches | 15 |
 | Missions | 8 |
 | Profils | 6 |
 | Journal | 4 |
@@ -252,7 +252,7 @@ Le support curseur/limite (O/N/EXCEPTION) reflète l'audit Day-114. Tous les out
 | Monitoring d'erreurs | 2 |
 | Bundles OKF | 3 |
 | Improvisation | 1 |
-| **Total** | **120** |
+| **Total** | **119** |
 
 Note : inclut tous les noms canoniques et les alias documentés (ex. `recall`, `text_search`, `create_diary`, `create_task_dependency`). La surface d'outils enregistrés depuis `vantage-peers-mcp@2.13.1` est de 120 entrées incluant les alias.
 

--- a/content/docs/tools-catalogue.mdx
+++ b/content/docs/tools-catalogue.mdx
@@ -236,7 +236,7 @@ Cursor/limit support (Y/N/EXCEPTION) reflects the Day-114 audit. All `list_*` to
 | Memory | 9 |
 | Episodes | 5 |
 | Messaging | 8 |
-| Tasks | 16 |
+| Tasks | 15 |
 | Missions | 8 |
 | Profiles | 6 |
 | Diary | 4 |
@@ -252,7 +252,7 @@ Cursor/limit support (Y/N/EXCEPTION) reflects the Day-114 audit. All `list_*` to
 | Error Monitoring | 2 |
 | OKF Bundle | 3 |
 | Improvisation | 1 |
-| **Total** | **120** |
+| **Total** | **119** |
 
 Note: includes all canonical names and documented aliases (e.g. `recall`, `text_search`, `create_diary`, `create_task_dependency`). The registered tool surface as of `vantage-peers-mcp@2.13.1` is 120 entries including aliases.
 

--- a/content/docs/tools-catalogue.mdx
+++ b/content/docs/tools-catalogue.mdx
@@ -252,7 +252,7 @@ Cursor/limit support (Y/N/EXCEPTION) reflects the Day-114 audit. All `list_*` to
 | Error Monitoring | 2 |
 | OKF Bundle | 3 |
 | Improvisation | 1 |
-| **Total** | **120** |
+| **Total** | **119** |
 
 Note: includes all canonical names and documented aliases (e.g. `recall`, `text_search`, `create_diary`, `create_task_dependency`). The registered tool surface as of `vantage-peers-mcp@2.13.1` is 120 entries including aliases.
 

--- a/content/docs/tools-catalogue.mdx
+++ b/content/docs/tools-catalogue.mdx
@@ -252,7 +252,7 @@ Cursor/limit support (Y/N/EXCEPTION) reflects the Day-114 audit. All `list_*` to
 | Error Monitoring | 2 |
 | OKF Bundle | 3 |
 | Improvisation | 1 |
-| **Total** | **119** |
+| **Total** | **120** |
 
 Note: includes all canonical names and documented aliases (e.g. `recall`, `text_search`, `create_diary`, `create_task_dependency`). The registered tool surface as of `vantage-peers-mcp@2.13.1` is 120 entries including aliases.
 

--- a/scripts/check-tool-counts.mjs
+++ b/scripts/check-tool-counts.mjs
@@ -1,0 +1,258 @@
+#!/usr/bin/env node
+/**
+ * check-tool-counts.mjs — site-repo mirror.
+ *
+ * CANONICAL SOURCE: vantageos-agency/vantage-peers
+ *   path: scripts/check-tool-counts.mjs
+ *   shipped in PR #986 (Day-101 root-fix, fix-pattern m974527p6jbbb5kzj3jt2z636n89fddv).
+ *
+ * Why a mirror lives here: CI on vantage-peers-site needs to assert that the
+ * tools-catalogue.mdx (EN + FR) Summary integers + grand **Total** stay
+ * consistent with the per-domain table row counts in this repo. Both files
+ * (vantage-memory and vantage-peers-site copies) MUST stay byte-equivalent
+ * apart from this header comment block. Any change made here must be ported
+ * upstream and shipped via a PR against vantage-peers — and vice-versa.
+ *
+ * Usage:
+ *   node scripts/check-tool-counts.mjs \
+ *     --target=content/docs/tools-catalogue.mdx \
+ *     --target-fr=content/docs/tools-catalogue.fr.mdx
+ *
+ *   node scripts/check-tool-counts.mjs --update [...]
+ *
+ * The script will also try to count canonical surface from
+ * `mcp-server/src/tools.ts` if present (not the case in this repo) — falls
+ * back silently when absent. No network calls.
+ *
+ * Stdlib only (Node ≥ 20). Idempotent.
+ */
+
+import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const REPO_ROOT = resolve(__dirname, "..");
+
+const args = process.argv.slice(2);
+const UPDATE = args.includes("--update");
+const targetEn =
+	(args.find((a) => a.startsWith("--target=")) || "").slice(9) || null;
+const targetFr =
+	(args.find((a) => a.startsWith("--target-fr=")) || "").slice(12) || null;
+
+const ERRORS = [];
+const FIXED = [];
+
+function fail(msg) {
+	ERRORS.push(msg);
+}
+
+function info(msg) {
+	process.stdout.write(`${msg}\n`);
+}
+
+function countCanonicalSurface() {
+	const mainFile = join(REPO_ROOT, "mcp-server/src/tools.ts");
+	if (!existsSync(mainFile)) return null;
+	let total = 0;
+	const RE = /^[ \t]*server\.tool\(/gm;
+	const main = readFileSync(mainFile, "utf8");
+	total += (main.match(RE) || []).length;
+	const toolsDir = join(REPO_ROOT, "mcp-server/src/tools");
+	if (existsSync(toolsDir)) {
+		for (const entry of readdirSync(toolsDir)) {
+			if (!entry.endsWith(".ts")) continue;
+			if (entry.includes("__tests__")) continue;
+			const sub = readFileSync(join(toolsDir, entry), "utf8");
+			total += (sub.match(RE) || []).length;
+		}
+	}
+	return total;
+}
+
+function parseCatalogue(path) {
+	if (!existsSync(path)) {
+		fail(`Catalogue not found at ${path}`);
+		return null;
+	}
+	const src = readFileSync(path, "utf8");
+	const lines = src.split("\n");
+
+	let summaryStartLine = -1;
+	let summaryEndLine = lines.length;
+	for (let i = 0; i < lines.length; i++) {
+		if (!/^## /.test(lines[i])) continue;
+		let j = i + 1;
+		while (j < lines.length && !/^## /.test(lines[j])) j++;
+		for (let k = i + 1; k < j; k++) {
+			if (/^\|\s*\*\*[^|*]+\*\*\s*\|\s*\*\*\d+\*\*\s*\|/.test(lines[k])) {
+				summaryStartLine = i;
+				summaryEndLine = j;
+				break;
+			}
+		}
+		if (summaryStartLine !== -1) break;
+	}
+
+	const actual = {};
+	let currentDomain = null;
+	let skipDomain = false;
+	for (let i = 0; i < lines.length; i++) {
+		const ln = lines[i];
+		const h2 = ln.match(/^## (.+?)\s*$/);
+		if (h2) {
+			currentDomain = h2[1];
+			skipDomain = summaryStartLine !== -1 && i >= summaryStartLine;
+			if (!skipDomain && !(currentDomain in actual)) actual[currentDomain] = 0;
+			continue;
+		}
+		if (!currentDomain || skipDomain) continue;
+		if (/^\| `[^`]+` \|/.test(ln)) {
+			actual[currentDomain]++;
+		}
+	}
+
+	const declared = {};
+	let declaredTotal = null;
+	for (let i = summaryStartLine + 1; i < summaryEndLine; i++) {
+		const ln = lines[i];
+		const totalMatch = ln.match(
+			/^\|\s*\*\*[^|*]+\*\*\s*\|\s*\*\*(\d+)\*\*\s*\|/,
+		);
+		if (totalMatch) {
+			declaredTotal = Number.parseInt(totalMatch[1], 10);
+			continue;
+		}
+		const rowMatch = ln.match(/^\|\s*([^|*]+?)\s*\|\s*(\d+)\s*\|/);
+		if (rowMatch) {
+			declared[rowMatch[1].trim()] = Number.parseInt(rowMatch[2], 10);
+		}
+	}
+
+	return {
+		src,
+		lines,
+		actual,
+		declared,
+		declaredTotal,
+		summaryRange: [summaryStartLine, summaryEndLine],
+	};
+}
+
+function checkCatalogue(path, label) {
+	const parsed = parseCatalogue(path);
+	if (!parsed) return null;
+	const drifts = [];
+	const allDomains = new Set([
+		...Object.keys(parsed.actual),
+		...Object.keys(parsed.declared),
+	]);
+	for (const d of allDomains) {
+		const a = parsed.actual[d] ?? 0;
+		const dec = parsed.declared[d];
+		if (dec === undefined) {
+			drifts.push({ domain: d, declared: "missing-from-Summary", actual: a });
+			continue;
+		}
+		if (a !== dec) {
+			drifts.push({ domain: d, declared: dec, actual: a });
+		}
+	}
+	const actualTotal = Object.values(parsed.actual).reduce((s, n) => s + n, 0);
+	const totalDrift = parsed.declaredTotal !== actualTotal;
+	return { path, label, parsed, drifts, actualTotal, totalDrift };
+}
+
+function updateCatalogueInPlace(report) {
+	let src = report.parsed.src;
+	for (const d of report.drifts) {
+		if (typeof d.declared !== "number") continue;
+		const re = new RegExp(
+			`(\\|\\s*${escapeRegex(d.domain)}\\s*\\|\\s*)${d.declared}(\\s*\\|)`,
+			"m",
+		);
+		const before = src;
+		src = src.replace(re, `$1${d.actual}$2`);
+		if (src !== before)
+			FIXED.push(`${report.label}: ${d.domain} ${d.declared}→${d.actual}`);
+	}
+	if (report.totalDrift) {
+		const re = /(\|\s*\*\*Total\*\*\s*\|\s*\*\*)\d+(\*\*\s*\|)/m;
+		const before = src;
+		src = src.replace(re, `$1${report.actualTotal}$2`);
+		if (src !== before) {
+			FIXED.push(
+				`${report.label}: **Total** ${report.parsed.declaredTotal}→${report.actualTotal}`,
+			);
+		}
+	}
+	writeFileSync(report.path, src);
+}
+
+function escapeRegex(s) {
+	return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function reportCatalogue(report) {
+	info(`\n${report.label} (${report.path})`);
+	info(`  actual rows per domain: total=${report.actualTotal}`);
+	if (report.drifts.length === 0 && !report.totalDrift) {
+		info(`  Summary integers + Total — OK`);
+		return;
+	}
+	for (const d of report.drifts) {
+		info(`  ${d.domain}: Summary=${d.declared}, table-rows=${d.actual}`);
+	}
+	if (report.totalDrift) {
+		info(
+			`  **Total**: declared=${report.parsed.declaredTotal}, sum=${report.actualTotal}`,
+		);
+	}
+}
+
+function main() {
+	const canonical = countCanonicalSurface();
+	if (canonical !== null) {
+		info(`tools.ts canonical surface = ${canonical}`);
+	} else {
+		info(`tools.ts not in this repo — skipping canonical surface count.`);
+	}
+
+	if (targetEn) {
+		const enReport = checkCatalogue(targetEn, "tools-catalogue.mdx");
+		if (enReport) {
+			reportCatalogue(enReport);
+			if (enReport.drifts.length > 0 || enReport.totalDrift) {
+				if (UPDATE) updateCatalogueInPlace(enReport);
+				else fail(`${enReport.label} drift`);
+			}
+		}
+	}
+
+	if (targetFr) {
+		const frReport = checkCatalogue(targetFr, "tools-catalogue.fr.mdx");
+		if (frReport) {
+			reportCatalogue(frReport);
+			if (frReport.drifts.length > 0 || frReport.totalDrift) {
+				if (UPDATE) updateCatalogueInPlace(frReport);
+				else fail(`${frReport.label} drift`);
+			}
+		}
+	}
+
+	if (FIXED.length > 0) {
+		info(`\nApplied ${FIXED.length} fix(es) (--update):`);
+		for (const f of FIXED) info(`  ${f}`);
+	}
+	if (ERRORS.length > 0) {
+		info(`\nFAIL — ${ERRORS.length} drift class(es) detected:`);
+		for (const e of ERRORS) info(`  ${e}`);
+		info(`\nRe-run with --update to auto-fix integers.`);
+		process.exit(1);
+	}
+	info(`\nOK — all tool counts consistent.`);
+}
+
+main();


### PR DESCRIPTION
## Summary

Day-101 ROOT-FIX for fix-pattern m974527p6jbbb5kzj3jt2z636n89fddv — class hand-maintained tool-count tally drifts from the registry. Companion to vantage-peers PR #986 which ships the canonical script + CI gate in the monorepo.

## What this PR ships

1. scripts/check-tool-counts.mjs — byte-equivalent vendor of the canonical script in vantageos-agency/vantage-peers (path: scripts/check-tool-counts.mjs). Header comment cites the canonical source. Stdlib-only Node 20 — no deps added.

2. .github/workflows/check-tool-counts.yml — runs the script on every push (any branch) + every PR + workflow_dispatch. Asserts EN + FR catalogue Summary integers + grand Total match per-domain table row counts. The Summary section is located by content (the bolded Total row) so the parser is language-agnostic.

3. Live integer drift correction for #137 (per Eta APPROVED-with-tracked-drift comment): Tasks 16→15, Total 120→119 in BOTH content/docs/tools-catalogue.mdx and content/docs/tools-catalogue.fr.mdx. Applied via the script's --update mode (idempotent). EN and FR diff identical.

## Plant-error proof

Commits on this branch:

- 3b8e40f — initial script + workflow + integer correction (green expected)
- 2a66464 — plant: Total 119 → Total 120 in EN catalogue (red expected)
- 3416ca2 — revert plant (green expected, PR HEAD)

CI evidence:

| Commit | Conclusion | Run URL |
|---|---|---|
| 3b8e40f (initial) | SUCCESS | https://github.com/vantageos-agency/vantage-peers-site/actions/runs/28294974641 |
| 2a66464 (plant) | FAILURE | https://github.com/vantageos-agency/vantage-peers-site/actions/runs/28294977955 |
| 3416ca2 (revert, PR HEAD) | SUCCESS | https://github.com/vantageos-agency/vantage-peers-site/actions/runs/28294990106 |

## Related

- Fix-pattern: m974527p6jbbb5kzj3jt2z636n89fddv
- Canonical script: vantageos-agency/vantage-peers PR #986
- Prior drift PR (squashed): vantageos-agency/vantage-peers-site #137

## Out-of-scope

- No restructuring of catalogue content (scope: counts + CI only).
- PR intentionally left open — not merged here.