### PR TITLE
docs(tools): drop 14 removed MCP tool aliases

### DIFF
--- a/content/docs/tools-catalogue.fr.mdx
+++ b/content/docs/tools-catalogue.fr.mdx
@@ -23,10 +23,8 @@ Le support curseur/limite (O/N/EXCEPTION) reflète l'audit Day-114. Tous les out
 | `get_memory` | Récupérer une seule mémoire par ID de document | N |
 | `list_memories` | Lister les mémoires dans un namespace filtrées par type ; limite par défaut 20, plafond 200 | O — corrigé Day-114 PR #978 |
 | `soft_delete_memory` | Suppression douce d'une mémoire pour qu'elle n'apparaisse plus dans les résultats recall | N |
-| `search_memories_by_semantic` | Recherche vectorielle sémantique sur les mémoires dans un namespace (fusion RRF) | N |
-| `recall` | Alias de `search_memories_by_semantic` | N |
-| `search_memories_by_keyword` | Recherche plein texte BM25 sur les mémoires | N |
-| `text_search` | Alias de `search_memories_by_keyword` | N |
+| `recall` | Recherche vectorielle sémantique sur les mémoires dans un namespace (fusion RRF) | N |
+| `text_search` | Recherche plein texte BM25 sur les mémoires | N |
 | `hybrid_search` | Recherche hybride combinée vecteur + BM25 utilisant la fusion RRF | N |
 
 ## Épisodes
@@ -65,7 +63,6 @@ Le support curseur/limite (O/N/EXCEPTION) reflète l'audit Day-114. Tous les out
 | `complete_task` | Marquer une tâche comme `done` avec une note de complétion obligatoire | N |
 | `block_task` | Mettre une tâche en statut `blocked` avec une raison | N |
 | `add_task_dependency` | Lier deux tâches pour qu'une ne puisse pas démarrer avant que l'autre soit complète | N |
-| `create_task_dependency` | Alias de `add_task_dependency` | N |
 | `checkout_task` | Revendiquer atomiquement une tâche (sûr pour les conflits multi-instances) | N |
 | `delete_task` | Supprimer définitivement une tâche (créateur ou système uniquement ; bloqué en production — **annuler** une tâche erronée via `status="cancelled"` à la place) | N |
 | `list_tasks_by_mission` | Lister toutes les tâches liées à une mission spécifique ; mêmes params `status`, `fields`, `createdBy`, `cursor` que `list_tasks` ; limite par défaut 20, plafond 200 | O |
@@ -93,7 +90,6 @@ Le support curseur/limite (O/N/EXCEPTION) reflète l'audit Day-114. Tous les out
 | `update_profile` | Créer ou mettre à jour un profil d'orchestrateur (mises à jour partielles supportées) | N |
 | `list_peers` | Retourner toutes les instances d'agents connues et leur statut actuel, les plus récentes en premier ; limite par défaut 20, plafond 200 | O |
 | `set_summary` | Mettre à jour le résumé de travail actuel pour une instance d'orchestrateur | N |
-| `update_summary` | Alias de `set_summary` | N |
 | `whoami` | Retourner l'identité de l'orchestrateur intégrée dans le scope OAuth du bearer actuel | N |
 
 ## Journal
@@ -101,7 +97,6 @@ Le support curseur/limite (O/N/EXCEPTION) reflète l'audit Day-114. Tous les out
 | Outil | Objectif | Curseur/Limite |
 |---|---|---|
 | `write_diary` | Écrire une entrée de journal pour une date donnée, écrasant toute entrée existante | N |
-| `create_diary` | Alias de `write_diary` | N |
 | `get_diary` | Récupérer une entrée de journal spécifique par orchestrateur et date | N |
 | `list_diaries` | Lister les entrées de journal pour un orchestrateur, plage de dates optionnelle ; limite par défaut 20, plafond 200 | O |
 
@@ -124,8 +119,7 @@ Le support curseur/limite (O/N/EXCEPTION) reflète l'audit Day-114. Tous les out
 | `list_components` | Lister tous les composants enregistrés filtrés par type ; limite par défaut 20, plafond 200 | O |
 | `update_component` | Mettre à jour le contenu ou la version d'un composant | N |
 | `delete_component` | Supprimer un composant du registre | N |
-| `search_components_by_keyword` | Recherche BM25 par sous-chaîne sur les composants par nom ou équipe avec filtre de type optionnel | N |
-| `search_components` | Alias de `search_components_by_keyword` | N |
+| `search_components` | Recherche BM25 par sous-chaîne sur les composants par nom ou équipe avec filtre de type optionnel | N |
 
 ## Tâches récurrentes
 
@@ -148,7 +142,6 @@ Le support curseur/limite (O/N/EXCEPTION) reflète l'audit Day-114. Tous les out
 | `update_mandate` | Mettre à jour les champs d'un mandat | N |
 | `settle_mandate` | Enregistrer le coût réel et fermer un mandat | N |
 | `validate_mandate_spending` | Vérifier si une transaction est dans les limites du mandat | N |
-| `check_mandate_spending` | Alias de `validate_mandate_spending` | N |
 | `list_mandates` | Lister les mandats avec filtres ; limite par défaut 20, plafond 200 | O |
 | `get_mandate` | Récupérer un seul mandat par ID de document Convex | N |
 
@@ -179,10 +172,8 @@ Le support curseur/limite (O/N/EXCEPTION) reflète l'audit Day-114. Tous les out
 | Outil | Objectif | Curseur/Limite |
 |---|---|---|
 | `add_repo_mapping` | Mapper un slug de dépôt GitHub à un orchestrateur | N |
-| `register_repo_mapping` | Alias de `add_repo_mapping` | N |
 | `list_repo_mappings` | Lister tous les mappings de dépôts ; `fields=lite|full`, `cursor` ; limite par défaut 20, plafond 200 | O |
 | `remove_repo_mapping` | Supprimer un mapping de dépôt | N |
-| `delete_repo_mapping` | Alias de `remove_repo_mapping` | N |
 | `get_repo_mapping` | Récupérer un seul mapping de dépôt par slug (propriétaire/nom) | N |
 
 ## Fix Patterns
@@ -192,11 +183,8 @@ Le support curseur/limite (O/N/EXCEPTION) reflète l'audit Day-114. Tous les out
 | `create_fix_pattern` | Créer un fix pattern documentant un bug, sa cause racine et sa correction | N |
 | `get_fix_pattern` | Récupérer un seul fix pattern par ID de document Convex | N |
 | `add_fix_attempt` | Documenter une tentative de correction (réussie/échouée) avec raisonnement | N |
-| `create_fix_attempt` | Alias de `add_fix_attempt` | N |
 | `validate_fix` | Définir la correction validée sur un pattern | N |
-| `check_fix` | Alias de `validate_fix` | N |
-| `search_fix_patterns_by_semantic` | Recherche sémantique sur les fix patterns par symptôme | N |
-| `search_fix_patterns` | Alias de `search_fix_patterns_by_semantic` | N |
+| `search_fix_patterns` | Recherche sémantique sur les fix patterns par symptôme | N |
 | `list_fix_patterns` | Lister les fix patterns par projet ; limite par défaut 20, plafond 200 | O |
 
 ## Déploiements
@@ -204,9 +192,7 @@ Le support curseur/limite (O/N/EXCEPTION) reflète l'audit Day-114. Tous les out
 | Outil | Objectif | Curseur/Limite |
 |---|---|---|
 | `add_deployment` | Enregistrer un déploiement Convex pour la surveillance proactive des erreurs | N |
-| `register_deployment` | Alias de `add_deployment` | N |
 | `remove_deployment` | Désactiver un déploiement surveillé | N |
-| `delete_deployment` | Alias de `remove_deployment` | N |
 
 ## Monitoring d'erreurs
 
@@ -233,28 +219,28 @@ Le support curseur/limite (O/N/EXCEPTION) reflète l'audit Day-114. Tous les out
 
 | Domaine | Nombre d'outils |
 |---|---|
-| Mémoire | 9 |
+| Mémoire | 7 |
 | Épisodes | 5 |
 | Messagerie | 8 |
-| Tâches | 15 |
+| Tâches | 14 |
 | Missions | 8 |
-| Profils | 6 |
-| Journal | 4 |
+| Profils | 5 |
+| Journal | 3 |
 | Briefings | 5 |
-| Composants | 7 |
+| Composants | 6 |
 | Tâches récurrentes | 7 |
-| Mandats | 8 |
+| Mandats | 7 |
 | Unités commerciales | 5 |
 | Issues GitHub | 7 |
-| Mappings de dépôts | 6 |
-| Fix Patterns | 9 |
-| Déploiements | 4 |
+| Mappings de dépôts | 4 |
+| Fix Patterns | 6 |
+| Déploiements | 2 |
 | Monitoring d'erreurs | 2 |
 | Bundles OKF | 3 |
 | Improvisation | 1 |
-| **Total** | **119** |
+| **Total** | **105** |
 
-Note : inclut tous les noms canoniques et les alias documentés (ex. `recall`, `text_search`, `create_diary`, `create_task_dependency`). La surface d'outils enregistrés depuis `vantage-peers-mcp@2.13.1` est de 120 entrées incluant les alias.
+Note : 14 alias en doublon ont été retirés de la surface enregistrée (PR #1169) ; chaque outil ci-dessous est un nom canonique, sans alias.
 
 ## Références croisées
 

--- a/content/docs/tools-catalogue.mdx
+++ b/content/docs/tools-catalogue.mdx
@@ -23,10 +23,8 @@ Cursor/limit support (Y/N/EXCEPTION) reflects the Day-114 audit. All `list_*` to
 | `get_memory` | Fetch a single memory by document ID | N |
 | `list_memories` | List memories in a namespace filtered by type; default limit 20, cap 200 | Y — fixed Day-114 PR #978 |
 | `soft_delete_memory` | Soft-delete a memory so it stops appearing in recall results | N |
-| `search_memories_by_semantic` | Semantic vector search over memories in a namespace (RRF fusion) | N |
-| `recall` | Alias of `search_memories_by_semantic` | N |
-| `search_memories_by_keyword` | BM25 full-text keyword search over memories | N |
-| `text_search` | Alias of `search_memories_by_keyword` | N |
+| `recall` | Semantic vector search over memories in a namespace (RRF fusion) | N |
+| `text_search` | BM25 full-text keyword search over memories | N |
 | `hybrid_search` | Combined vector + BM25 hybrid search using RRF fusion | N |
 
 ## Episodes
@@ -65,7 +63,6 @@ Cursor/limit support (Y/N/EXCEPTION) reflects the Day-114 audit. All `list_*` to
 | `complete_task` | Mark a task as `done` with a mandatory completion note | N |
 | `block_task` | Set a task to `blocked` status with a reason | N |
 | `add_task_dependency` | Link two tasks so one cannot start before the other completes | N |
-| `create_task_dependency` | Alias of `add_task_dependency` | N |
 | `checkout_task` | Atomically claim a task (conflict-safe for multi-instance) | N |
 | `delete_task` | Permanently delete a task (creator or system only; blocked in production — **cancel** an erroneous task via `status="cancelled"` instead) | N |
 | `list_tasks_by_mission` | List all tasks linked to a specific mission; same `status`, `fields`, `createdBy`, `cursor` params as `list_tasks`; default limit 20, cap 200 | Y |
@@ -93,7 +90,6 @@ Cursor/limit support (Y/N/EXCEPTION) reflects the Day-114 audit. All `list_*` to
 | `update_profile` | Create or update an orchestrator profile (partial updates supported) | N |
 | `list_peers` | Return all known agent instances and their current status, newest first; default limit 20, cap 200 | Y |
 | `set_summary` | Update the current working summary for an orchestrator instance | N |
-| `update_summary` | Alias of `set_summary` | N |
 | `whoami` | Return the orchestrator identity baked into the current bearer OAuth scope | N |
 
 ## Diary
@@ -101,7 +97,6 @@ Cursor/limit support (Y/N/EXCEPTION) reflects the Day-114 audit. All `list_*` to
 | Tool | Purpose | Cursor/Limit |
 |---|---|---|
 | `write_diary` | Write a diary entry for a given date, overwriting any existing entry | N |
-| `create_diary` | Alias of `write_diary` | N |
 | `get_diary` | Fetch a specific diary entry by orchestrator and date | N |
 | `list_diaries` | List diary entries for an orchestrator, optional date range; default limit 20, cap 200 | Y |
 
@@ -124,8 +119,7 @@ Cursor/limit support (Y/N/EXCEPTION) reflects the Day-114 audit. All `list_*` to
 | `list_components` | List all registered components filtered by type; default limit 20, cap 200 | Y |
 | `update_component` | Update a component content or version | N |
 | `delete_component` | Remove a component from the registry | N |
-| `search_components_by_keyword` | BM25 substring keyword search over components by name or team with optional type filter | N |
-| `search_components` | Alias of `search_components_by_keyword` | N |
+| `search_components` | BM25 substring keyword search over components by name or team with optional type filter | N |
 
 ## Recurring Tasks
 
@@ -148,7 +142,6 @@ Cursor/limit support (Y/N/EXCEPTION) reflects the Day-114 audit. All `list_*` to
 | `update_mandate` | Update mandate fields | N |
 | `settle_mandate` | Record actual cost and close a mandate | N |
 | `validate_mandate_spending` | Check if a transaction is within mandate limits | N |
-| `check_mandate_spending` | Alias of `validate_mandate_spending` | N |
 | `list_mandates` | List mandates with filters; default limit 20, cap 200 | Y |
 | `get_mandate` | Fetch a single mandate by Convex document ID | N |
 
@@ -179,10 +172,8 @@ Cursor/limit support (Y/N/EXCEPTION) reflects the Day-114 audit. All `list_*` to
 | Tool | Purpose | Cursor/Limit |
 |---|---|---|
 | `add_repo_mapping` | Map a GitHub repo slug to an orchestrator | N |
-| `register_repo_mapping` | Alias of `add_repo_mapping` | N |
 | `list_repo_mappings` | List all repo mappings; `fields=lite|full`, `cursor`; default limit 20, cap 200 | Y |
 | `remove_repo_mapping` | Remove a repo mapping | N |
-| `delete_repo_mapping` | Alias of `remove_repo_mapping` | N |
 | `get_repo_mapping` | Fetch a single repo mapping by slug (owner/name) | N |
 
 ## Fix Patterns
@@ -192,11 +183,8 @@ Cursor/limit support (Y/N/EXCEPTION) reflects the Day-114 audit. All `list_*` to
 | `create_fix_pattern` | Create a fix pattern documenting a bug, root cause, and fix | N |
 | `get_fix_pattern` | Fetch a single fix pattern by Convex document ID | N |
 | `add_fix_attempt` | Document a fix attempt (worked/failed) with reasoning | N |
-| `create_fix_attempt` | Alias of `add_fix_attempt` | N |
 | `validate_fix` | Set the validated fix on a pattern | N |
-| `check_fix` | Alias of `validate_fix` | N |
-| `search_fix_patterns_by_semantic` | Semantic search over fix patterns by symptom | N |
-| `search_fix_patterns` | Alias of `search_fix_patterns_by_semantic` | N |
+| `search_fix_patterns` | Semantic search over fix patterns by symptom | N |
 | `list_fix_patterns` | List fix patterns by project; default limit 20, cap 200 | Y |
 
 ## Deployments
@@ -204,9 +192,7 @@ Cursor/limit support (Y/N/EXCEPTION) reflects the Day-114 audit. All `list_*` to
 | Tool | Purpose | Cursor/Limit |
 |---|---|---|
 | `add_deployment` | Register a Convex deployment for proactive error monitoring | N |
-| `register_deployment` | Alias of `add_deployment` | N |
 | `remove_deployment` | Deactivate a monitored deployment | N |
-| `delete_deployment` | Alias of `remove_deployment` | N |
 
 ## Error Monitoring
 
@@ -233,28 +219,28 @@ Cursor/limit support (Y/N/EXCEPTION) reflects the Day-114 audit. All `list_*` to
 
 | Domain | Tool count |
 |---|---|
-| Memory | 9 |
+| Memory | 7 |
 | Episodes | 5 |
 | Messaging | 8 |
-| Tasks | 15 |
+| Tasks | 14 |
 | Missions | 8 |
-| Profiles | 6 |
-| Diary | 4 |
+| Profiles | 5 |
+| Diary | 3 |
 | Briefing Notes | 5 |
-| Components | 7 |
+| Components | 6 |
 | Recurring Tasks | 7 |
-| Mandates | 8 |
+| Mandates | 7 |
 | Business Units | 5 |
 | GitHub Issues | 7 |
-| Repo Mappings | 6 |
-| Fix Patterns | 9 |
-| Deployments | 4 |
+| Repo Mappings | 4 |
+| Fix Patterns | 6 |
+| Deployments | 2 |
 | Error Monitoring | 2 |
 | OKF Bundle | 3 |
 | Improvisation | 1 |
-| **Total** | **119** |
+| **Total** | **105** |
 
-Note: includes all canonical names and documented aliases (e.g. `recall`, `text_search`, `create_diary`, `create_task_dependency`). The registered tool surface as of `vantage-peers-mcp@2.13.1` is 120 entries including aliases.
+Note: 14 duplicate aliases were removed from the registered surface (PR #1169); every tool below is a canonical name with no alias.
 
 ## Cross-references
 

--- a/content/docs/tools.mdx
+++ b/content/docs/tools.mdx
@@ -1,30 +1,30 @@
 ---
 title: Tools Reference
-description: All 114 MCP tools across 15 capability categories in VantagePeers.
+description: All 100 MCP tools across 15 capability categories in VantagePeers.
 ---
 
 # Tools Reference
 
-VantagePeers exposes 114 MCP tools organized into 15 capability categories. Every tool accepts and returns JSON. All values are lowercase strings unless noted.
+VantagePeers exposes 100 MCP tools organized into 15 capability categories. Every tool accepts and returns JSON. All values are lowercase strings unless noted.
 
 ## Tool Categories
 
 | Category | Tool Count | Description |
 |----------|-----------|-------------|
-| [Memory + Episodes](#memory--episode-tools) | 14 | Typed memories, episodic learning, semantic and keyword search |
+| [Memory + Episodes](#memory--episode-tools) | 12 | Typed memories, episodic learning, semantic and keyword search |
 | [Messaging](#messaging-tools) | 8 | Send messages across machines with read receipts |
-| [Tasks](#task-tools) | 13 | Create and manage tasks with full lifecycle tracking |
+| [Tasks](#task-tools) | 12 | Create and manage tasks with full lifecycle tracking |
 | [Missions + Templates](#mission--template-tools) | 8 | Group tasks into missions; instantiate templates |
-| [Profiles + Session](#profile-and-session-tools) | 6 | Agent identity, session state, and identity resolution |
-| [Diary + Briefing Notes](#diary--briefing-note-tools) | 9 | Daily journals, briefing notes, and keyword search |
-| [Components](#component-tools) | 7 | Component backup and inventory |
+| [Profiles + Session](#profile-and-session-tools) | 5 | Agent identity, session state, and identity resolution |
+| [Diary + Briefing Notes](#diary--briefing-note-tools) | 8 | Daily journals, briefing notes, and keyword search |
+| [Components](#component-tools) | 6 | Component backup and inventory |
 | [Recurring Tasks](#recurring-task-tools) | 7 | Cron-based automation |
-| [Mandates](#mandate-tools) | 8 | Cross-agent service requests with budgets |
+| [Mandates](#mandate-tools) | 7 | Cross-agent service requests with budgets |
 | [Business Units](#business-unit-tools) | 5 | BU strategy, pricing, and KPIs |
-| [GitHub Issues + Repos](#github-issue--repo-tools) | 13 | Issue tracking with webhook sync and repo mappings |
-| [Fix Patterns](#fix-pattern-tools) | 9 | Bug fix knowledge base with semantic search |
+| [GitHub Issues + Repos](#github-issue--repo-tools) | 11 | Issue tracking with webhook sync and repo mappings |
+| [Fix Patterns](#fix-pattern-tools) | 6 | Bug fix knowledge base with semantic search |
 | [Error Monitoring](#error-monitoring-tools) | 2 | Proactive deployment error detection |
-| [Deployments](#deployment-tools) | 4 | Register and manage monitored deployments |
+| [Deployments](#deployment-tools) | 2 | Register and manage monitored deployments |
 | [Utility](#utility-tools) | 1 | Payload validation |
 
 ---
@@ -80,9 +80,9 @@ Soft-delete a memory so it stops appearing in recall results.
 }
 ```
 
-### `search_memories_by_semantic`
+### `recall`
 
-Semantic search over memories in a namespace. Uses vector similarity + optional keyword filters. Alias: `recall`.
+Semantic search over memories in a namespace. Uses vector similarity + optional keyword filters.
 
 ```json
 {
@@ -94,13 +94,9 @@ Semantic search over memories in a namespace. Uses vector similarity + optional 
 
 Returns an array of matching memories ranked by relevance.
 
-### `recall`
+### `text_search`
 
-Alias of `search_memories_by_semantic`. Prefer the canonical name for new code.
-
-### `search_memories_by_keyword`
-
-BM25 full-text keyword search over memories. Alias: `text_search`.
+BM25 full-text keyword search over memories.
 
 ```json
 {
@@ -109,10 +105,6 @@ BM25 full-text keyword search over memories. Alias: `text_search`.
   "limit": 10
 }
 ```
-
-### `text_search`
-
-Alias of `search_memories_by_keyword`. Prefer the canonical name for new code.
 
 ### `hybrid_search`
 
@@ -417,7 +409,7 @@ Sets a task to `blocked` status with a reason.
 
 ### `add_task_dependency`
 
-Links two tasks so one cannot start before the other completes. Alias: `create_task_dependency`.
+Links two tasks so one cannot start before the other completes.
 
 ```json
 {
@@ -459,10 +451,6 @@ List all tasks linked to a specific mission. Accepts the same `status`, `fields`
   "fields": "lite"
 }
 ```
-
-### `create_task_dependency`
-
-Alias of `add_task_dependency`. Prefer the canonical name for new code.
 
 ---
 
@@ -612,7 +600,7 @@ Returns all known agent instances and their current status, newest first. Suppor
 
 ### `set_summary`
 
-Updates the current working summary for an orchestrator instance. Alias: `update_summary`.
+Updates the current working summary for an orchestrator instance.
 
 ```json
 {
@@ -621,10 +609,6 @@ Updates the current working summary for an orchestrator instance. Alias: `update
   "summary": "Migrating HeroSection to lit-ui"
 }
 ```
-
-### `update_summary`
-
-Alias of `set_summary`. Prefer the canonical name for new code.
 
 ### `whoami`
 
@@ -642,7 +626,7 @@ Returns: `{ "orchestratorId": "alice", "orgSlug": "vantageos" }`.
 
 ### `write_diary`
 
-Writes a diary entry for a given date. Overwrites any existing entry for that date. Alias: `create_diary`.
+Writes a diary entry for a given date. Overwrites any existing entry for that date.
 
 ```json
 {
@@ -652,10 +636,6 @@ Writes a diary entry for a given date. Overwrites any existing entry for that da
   "highlights": ["Nav migrated to lit-ui", "Hero responsive layout fixed"]
 }
 ```
-
-### `create_diary`
-
-Alias of `write_diary`. Prefer the canonical name for new code.
 
 ### `get_diary`
 
@@ -806,9 +786,9 @@ Removes a component from the registry.
 }
 ```
 
-### `search_components_by_keyword`
+### `search_components`
 
-BM25 / substring keyword search over components by name or team with optional type filter. Alias: `search_components`.
+BM25 / substring keyword search over components by name or team with optional type filter.
 
 ```json
 {
@@ -816,10 +796,6 @@ BM25 / substring keyword search over components by name or team with optional ty
   "type": "agent"
 }
 ```
-
-### `search_components`
-
-Alias of `search_components_by_keyword`. Prefer the canonical name for new code.
 
 ---
 
@@ -914,7 +890,6 @@ Cross-agent service requests with budget tracking. See [Mandates](/docs/capabili
 | `update_mandate` | Update mandate fields |
 | `settle_mandate` | Record actual cost, close mandate |
 | `validate_mandate_spending` | Check if transaction is within limits |
-| `check_mandate_spending` | Alias of `validate_mandate_spending` |
 | `list_mandates` | List mandates with filters |
 | `get_mandate` | Fetch a single mandate by Convex document ID |
 
@@ -948,10 +923,8 @@ Issue tracking with webhook sync and auto-linking. See [GitHub Issues](/docs/inf
 | `issue_stats` | Get issue count stats |
 | `link_issue_to_pattern` | Link an issue to a fix pattern |
 | `add_repo_mapping` | Map a GitHub repo to an orchestrator |
-| `register_repo_mapping` | Alias of `add_repo_mapping` |
 | `list_repo_mappings` | List all repo mappings |
 | `remove_repo_mapping` | Remove a repo mapping |
-| `delete_repo_mapping` | Alias of `remove_repo_mapping` |
 | `get_repo_mapping` | Fetch a single repo mapping by slug (owner/name) |
 
 ---
@@ -965,11 +938,8 @@ Bug fix knowledge base with semantic search. See [Fix Patterns KB](/docs/capabil
 | `create_fix_pattern` | Create a fix pattern documenting a bug, root cause, and fix |
 | `get_fix_pattern` | Fetch a single fix pattern by Convex document ID |
 | `add_fix_attempt` | Document a fix attempt (worked/failed) with reasoning |
-| `create_fix_attempt` | Alias of `add_fix_attempt` |
 | `validate_fix` | Set the validated fix on a pattern |
-| `check_fix` | Alias of `validate_fix` |
-| `search_fix_patterns_by_semantic` | Semantic search over patterns by symptom |
-| `search_fix_patterns` | Alias of `search_fix_patterns_by_semantic` |
+| `search_fix_patterns` | Semantic search over patterns by symptom |
 | `list_fix_patterns` | List patterns by project with cursor paging |
 
 ---
@@ -992,9 +962,7 @@ Register Convex deployments for proactive error monitoring.
 | Tool | Description |
 |------|-------------|
 | `add_deployment` | Register a deployment for monitoring |
-| `register_deployment` | Alias of `add_deployment` |
 | `remove_deployment` | Deactivate a monitored deployment |
-| `delete_deployment` | Alias of `remove_deployment` |
 
 ---
 


### PR DESCRIPTION
# S3 — Site docs: drop the 14 removed MCP tools (mission vp-mcp-alias-cleanup-v1)

Removes the 14 duplicate tools from the public tool docs so a client reading them never calls a tool that no longer exists. Survivors named in place. FR/EN parity kept. Documents server removal PR #1169.

Pages: content/docs/tools.mdx, content/docs/tools-catalogue.mdx, content/docs/tools-catalogue.fr.mdx. The 4 code-inverted pairs (search_memories_by_semantic/_by_keyword, search_components_by_keyword, search_fix_patterns_by_semantic) had their full description moved onto the survivor (recall, text_search, search_components, search_fix_patterns) and the long-name entry deleted.

Do NOT merge — Eta gates in S4 (task k178brkda). Companion PRs: server #1169, skill-docs #41, CSV trace elpi-corp #77. Site has no PR-preview deploy; live pages publish on merge.

---

SELF-GATE:
- refs: PR head resolves (git rev-parse origin/docs/mcp-alias-cleanup-s3 -> 99b2788a9cc7e851f4deab5094986472b1293ff8) ; the 3 pages present at head (git show <head>:content/docs/{tools.mdx,tools-catalogue.mdx,tools-catalogue.fr.mdx} -> readable) ; documents server PR #1169 (head 303cd48).
- counts: the 14 removed names across content/ at head, git grep -oE ... | sort -u | wc -l -> 0 remaining ; tools.mdx total derived by summing the 15 category "Tool Count" column (awk over the category table) -> 100, matching the stated "100 MCP tools across 15 categories" (NOT typed by hand) ; catalogue EN/FR, node scripts/check-tool-counts.mjs --target=...tools-catalogue.mdx --target-fr=...tools-catalogue.fr.mdx -> "OK — all tool counts consistent" ; npm run build -> exit 0, 260 static pages.
- standard: FR/EN parity (both catalogue files updated, tools.fr.mdx verified clean) + the mission non-negotiable usage rule (survivor = the name the fleet calls, never the code label) -- PASS ; the 4 code-inverted pairs resolved onto the survivor.
- scope: IN -- public site tool docs only (tools.mdx + tools-catalogue{,.fr}.mdx), this repo. OUT -- server removal (PR #1169/S2), external skill-docs (PR #41/S2b), authoritative CSV trace (elpi-corp PR #77), deploy (S6/S7).

Orchestrator: Sigma — VantagePeers | 2026-08-11
