### PR TITLE
docs(cloud/index): add Grok host, correct 84->105 tools, rescope skills link (T1)

### DIFF
--- a/content/docs/cloud/index.fr.mdx
+++ b/content/docs/cloud/index.fr.mdx
@@ -1,6 +1,6 @@
 ---
 title: VantagePeers Cloud
-description: Utilise VantagePeers sans installation ni hébergement — connecte Claude Code, Claude.ai ou ChatGPT en quelques minutes avec les identifiants que nous te fournissons.
+description: Utilise VantagePeers sans installation ni hébergement — connecte Claude Code, Claude.ai, ChatGPT ou Grok en quelques minutes avec les identifiants que nous te fournissons.
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout'
@@ -18,7 +18,7 @@ Avec VantagePeers Cloud, tu sautes toutes les étapes de self-host : pas de Dock
 Tout ce dont tu as besoin pour démarrer :
 
 - Un `client_id` et un `client_secret` émis par VantageOS
-- Un client MCP supporté : Claude.ai, ChatGPT, Claude Code ou Codex — et tout autre IDE parlant le protocole MCP
+- Un client MCP supporté : Claude.ai, ChatGPT, Claude Code, Codex ou Grok — et tout autre IDE parlant le protocole MCP
 
 ## Démarrer
 
@@ -28,7 +28,7 @@ Trois pages te mènent des identifiants à un workspace opérationnel :
 2. [Premiers pas](./first-steps) — enregistre ton identité, stocke une première mémoire, crée une première tâche — tout en langage naturel.
 3. [Compétences & Skills](./skills) — installe les Compétences Claude.ai prêtes à coller **et** découvre les 37+ skills du plugin Claude Code (check-messages, daily-start, close-day, write-diary, friction-digest, pre-compact…).
 
-Une fois connecté, le [Tools Reference](/docs/tools) liste chaque capacité disponible (84 outils dans 14 catégories).
+Une fois connecté, le [Tools Reference](/docs/tools) liste chaque capacité disponible (105 outils).
 
 ## FAQ — Quel client MCP choisir selon ton usage ?
 
@@ -57,4 +57,4 @@ L'accès Cloud est actuellement sur invitation. Pour demander des identifiants o
 - [Se connecter](./connect) — chemin plugin Claude Code + manuel `.mcp.json` + Claude.ai + ChatGPT + Codex
 - [Premiers pas](./first-steps) — première identité, première mémoire, première tâche
 - [Compétences & Skills](./skills) — Compétences Claude.ai + skills plugin Claude Code
-- [Tools Reference](/docs/tools) — les 84 outils MCP exposés
+- [Tools Reference](/docs/tools) — les 105 outils MCP exposés

--- a/content/docs/cloud/index.mdx
+++ b/content/docs/cloud/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: VantagePeers Cloud
-description: Use VantagePeers without installing or hosting — connect your Claude Code, Claude.ai, or ChatGPT in minutes with credentials we provide.
+description: Use VantagePeers without installing or hosting — connect your Claude Code, Claude.ai, ChatGPT, or Grok in minutes with credentials we provide.
 ---
 
 VantagePeers Cloud is the hosted version of VantagePeers. You receive credentials from VantageOS and connect in minutes — no server setup, no infrastructure to maintain.
@@ -12,17 +12,17 @@ With VantagePeers Cloud you skip every self-host step: no Docker, no Railway pro
 All you need to get started:
 
 - A `client_id` and `client_secret` issued by VantageOS
-- One supported MCP client: Claude.ai, ChatGPT, Claude Code, or Codex — and any other IDE that speaks the MCP protocol.
+- One supported MCP client: Claude.ai, ChatGPT, Claude Code, Codex, or Grok — and any other IDE that speaks the MCP protocol.
 
 ## Get started
 
 Two pages get you from credentials to a working workspace:
 
-1. [Connect](./connect) — wire up the MCP client you use (Claude.ai, ChatGPT, Claude Code, Codex). One page covers all four.
+1. [Connect](./connect) — wire up the MCP client you use (Claude.ai, ChatGPT, Claude Code, Codex, Grok). One page covers them all.
 2. [First steps](./first-steps) — register your identity, store a first memory, create a first task — all in natural language.
-3. [Claude.ai Skills](./skills) (optional, recommended) — copy-paste two ready-made Skills (Onboard + Agent) so Claude knows how to use VantagePeers without you reminding it.
+3. [Skills](./skills) (optional, recommended) — copy-paste ready-made skills (Onboard + Agent) so your assistant knows how to use VantagePeers without you reminding it. The same skills run on Claude.ai, Grok, and Claude Code — each host installs them differently.
 
-Once connected, the [Tools Reference](/docs/tools) lists every available capability (84 tools across 14 categories).
+Once connected, the [Tools Reference](/docs/tools) lists every available capability (105 tools).
 
 ## Cloud vs Self-host
 


### PR DESCRIPTION
## What

**T1** of the docs-sync mission — brings `/docs/cloud` (index) in line with deployed reality, against the T0 audit (memory `j574p86sy94xj021pmj3zzb1s98cqmvw`).

## Changes (EN `index.mdx` + FR `index.fr.mdx`, in lockstep)

1. **Grok added to the supported hosts.** Grok is a live MCP host (the `prometheus` orchestrator runs on it) but was absent from the host enumeration — added to the page description, the requirements list, and the "Connect" line. No dead link to a Grok page: the dedicated Grok connect path is **T6**, so this PR only lists Grok as a supported client.
2. **`84 tools` → `105`.** The cloud pages hard-coded 84 while the **enforced** `content/docs/tools-catalogue.mdx` Summary Total is **105** (the site's own `check-tool-counts.mjs` CI gate asserts that integer). The cloud copy had drifted three months. Dropped the unverified "14 categories" rider.
3. **"Claude.ai Skills" → "Skills".** The same Onboard/Agent skills run on Claude.ai, Grok, and Claude Code — each host just installs them differently. The per-host invocation model is **T2**'s page (the skills page); this PR only fixes the mis-scoped label/link on the index.

## VERIFICATION

```
grep -c 84  index.mdx index.fr.mdx  -> 0, 0  (no stale count left)
grep -ci grok index.mdx index.fr.mdx -> 4, 2 (Grok now present)
diff: 2 files, 9+/9-  (index.mdx + index.fr.mdx only)
```

## SELF-GATE:

- refs: repo vantageos-agency/vantage-peers-site, branch sigma/docs-t1-cloud-index-grok @ b4aa5d8, base main. Task k17bbm4tx5jc8d0919tgwrjx858cnykp (mission k5732x8twg8ga952f30p0nyb3n8cmpez).
- counts: 2 files, 9+/9−; 0 "84" remaining; Grok present in both.
- standard: the tool count is taken from the ONE enforced source (tools-catalogue.mdx Summary, asserted by the repo's own check-tool-counts CI), not typed — so the cloud copy and the catalogue can no longer drift apart on this number. EN and FR edited together (the mission requires both siblings).
- scope: the /docs/cloud index ONLY (T1). The other surfaces are their own tasks: skills page + the Skill-2-breaks-on-Grok defect (T2), first-steps (T3), the plugin page (T4), the runbook (T5), the dedicated Grok page (T6), the Claude Code page (T7). I do not merge — Eta gates, Pi authorizes. Note: the EN index is thinner than the FR (which already carries the plugin FAQ + "37+ skills"); a full EN/FR re-sync is larger than T1's enumerated scope and is flagged for the mission owner.
- bite proof on real material: the count fix is anchored to the repo's OWN enforced integer (105 in tools-catalogue.mdx, gated by check-tool-counts.mjs) — a reader who trusts the cloud page now gets the same number the catalogue is CI-checked against, closing the exact drift class that check exists to prevent; and Grok is added because it is a real running host (prometheus), not a roadmap item.

Orchestrator: Sigma — VantagePeers | 2026-08-18
